### PR TITLE
feat(custom_providers_support): support custom OpenAI/Anthropic-compatible LLM endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ lat check                      # validate all links and code refs
 
 Run `lat --help` when in doubt about available commands or options.
 
-If `lat search` fails because no API key is configured, explain to the user that semantic search requires a key provided via `LAT_LLM_KEY` (direct value), `LAT_LLM_KEY_FILE` (path to key file), or `LAT_LLM_KEY_HELPER` (command that prints the key). Supported key prefixes: `sk-...` (OpenAI) or `vck_...` (Vercel). If the user doesn't want to set it up, use `lat locate` for direct lookups instead.
+If `lat search` fails because no API key is configured, explain to the user that semantic search requires a key provided via `LAT_LLM_KEY` (direct value), `LAT_LLM_KEY_FILE` (path to key file), or `LAT_LLM_KEY_HELPER` (command that prints the key). Supported key prefixes: `sk-...` (OpenAI) or `vck_...` (Vercel). For self-hosted or 3rd-party endpoints (Ollama, LM Studio, Azure OpenAI, an Anthropic-compatible proxy, etc.), set `LAT_LLM_BASE_URL` and `LAT_LLM_MODEL` (and optionally `LAT_LLM_PROVIDER=anthropic` for `x-api-key`-style auth) instead of relying on a key prefix. If the user doesn't want to set it up, use `lat locate` for direct lookups instead.
 
 # Syntax primer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ lat check                      # validate all links and code refs
 
 Run `lat --help` when in doubt about available commands or options.
 
-If `lat search` fails because no API key is configured, explain to the user that semantic search requires a key provided via `LAT_LLM_KEY` (direct value), `LAT_LLM_KEY_FILE` (path to key file), or `LAT_LLM_KEY_HELPER` (command that prints the key). Supported key prefixes: `sk-...` (OpenAI) or `vck_...` (Vercel). If the user doesn't want to set it up, use `lat locate` for direct lookups instead.
+If `lat search` fails because no API key is configured, explain to the user that semantic search requires a key provided via `LAT_LLM_KEY` (direct value), `LAT_LLM_KEY_FILE` (path to key file), or `LAT_LLM_KEY_HELPER` (command that prints the key). Supported key prefixes: `sk-...` (OpenAI) or `vck_...` (Vercel). For self-hosted or 3rd-party endpoints (Ollama, LM Studio, Azure OpenAI, an Anthropic-compatible proxy, etc.), set `LAT_LLM_BASE_URL` and `LAT_LLM_MODEL` (and optionally `LAT_LLM_PROVIDER=anthropic` for `x-api-key`-style auth) instead of relying on a key prefix. If the user doesn't want to set it up, use `lat locate` for direct lookups instead.
 
 # Syntax primer
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,33 @@ lat mcp                         # start MCP server for editor integration
 
 ## Configuration
 
-Semantic search (`lat search`) requires an OpenAI (`sk-...`) or Vercel AI Gateway (`vck_...`) API key. The key is resolved in order:
+Semantic search (`lat search`) requires an embedding API key. The key is resolved in order:
 
 1. `LAT_LLM_KEY` env var — direct value
 2. `LAT_LLM_KEY_FILE` env var — path to a file containing the key
 3. `LAT_LLM_KEY_HELPER` env var — shell command that prints the key (10s timeout)
-4. Config file — saved by `lat init`. Run `lat config` to see its location.
+4. Config file — saved by `lat init`. Run `lat config` to see its location and current settings.
+
+By default the key prefix picks the provider: OpenAI (`sk-...`) or Vercel AI Gateway (`vck_...`).
+
+### Custom endpoints
+
+To use a self-hosted or 3rd-party endpoint instead (Ollama, LM Studio, Azure OpenAI, Groq, Together AI, an Anthropic-compatible proxy, etc.), set:
+
+- `LAT_LLM_BASE_URL` — the API root, e.g. `http://localhost:11434/v1`
+- `LAT_LLM_PROVIDER` — `openai` (default) or `anthropic`. This only controls the auth header: `openai` sends `Authorization: Bearer <key>`, `anthropic` sends `x-api-key: <key>` plus an `anthropic-version` header (both still POST the same `{model, input}` embeddings request body, since Anthropic has no native embeddings API of its own — this targets Anthropic-compatible proxies that add one).
+- `LAT_LLM_MODEL` — the embedding model name, e.g. `nomic-embed-text`. Required when `LAT_LLM_PROVIDER=anthropic`.
+- `LAT_LLM_ANTHROPIC_VERSION` — overrides the `anthropic-version` header (default `2023-06-01`). Only used when `LAT_LLM_PROVIDER=anthropic`.
+
+```bash
+# Using a local Ollama instance running an embedding model
+export LAT_LLM_BASE_URL=http://localhost:11434/v1
+export LAT_LLM_KEY=ollama
+export LAT_LLM_MODEL=nomic-embed-text
+lat search "how do we handle auth?"
+```
+
+Each of these can also be set once via the config file (`llm_base_url`, `llm_provider`, `llm_model`, `llm_anthropic_version`) instead of exporting env vars every session.
 
 ## Development
 

--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -235,11 +235,17 @@ Implementation: [[src/cli/init.ts]], checklist menu in [[src/cli/checklist-menu.
 
 User-level configuration is stored in `~/.config/lat/config.json` (XDG Base Directory on Linux/macOS, `%APPDATA%\lat\config.json` on Windows). The `XDG_CONFIG_HOME` env var is respected if set.
 
-Currently supports one field:
+Supports these fields, each with a matching env var that takes priority over it:
 
-- `llm_key` — embedding API key for semantic search, used when `LAT_LLM_KEY` env var is not set
+- `llm_key` (`LAT_LLM_KEY`) — embedding API key for semantic search
+- `llm_base_url` (`LAT_LLM_BASE_URL`) — custom OpenAI/Anthropic-compatible embeddings API root, for self-hosted or 3rd-party endpoints (Ollama, LM Studio, Azure OpenAI, Groq, Together AI, an Anthropic-compatible proxy, etc.). Bypasses key-prefix provider detection entirely.
+- `llm_provider` (`LAT_LLM_PROVIDER`) — `openai` (default) or `anthropic`. Only controls the auth header sent alongside `llm_base_url`: `openai` sends `Authorization: Bearer <key>`; `anthropic` sends `x-api-key: <key>` plus an `anthropic-version` header. Both still POST the same `{model, input}` embeddings body — Anthropic itself has no embeddings API, so this targets Anthropic-compatible proxies that add one.
+- `llm_model` (`LAT_LLM_MODEL`) — embedding model name override, usable with or without `llm_base_url`. Required when `llm_provider` is `anthropic`.
+- `llm_anthropic_version` (`LAT_LLM_ANTHROPIC_VERSION`) — overrides the `anthropic-version` header (default `2023-06-01`). Only used when `llm_provider` is `anthropic`.
 
-Key resolution order: `LAT_LLM_KEY` > `LAT_LLM_KEY_FILE` > `LAT_LLM_KEY_HELPER` > config file `llm_key`. This applies everywhere: `lat search`, `lat check`, and the MCP `lat_search` tool.
+Key resolution order: `LAT_LLM_KEY` > `LAT_LLM_KEY_FILE` > `LAT_LLM_KEY_HELPER` > config file `llm_key`. This applies everywhere: `lat search`, `lat check`, and the MCP `lat_search` tool. The other four fields resolve as env var, then config file value, then a built-in default (see [[cli#Provider Detection]]).
+
+Run `lat config` to see the config file path and all resolved values.
 
 Implementation: [[src/config.ts]]
 
@@ -317,12 +323,17 @@ Requires an LLM key resolved by [[src/config.ts#getLlmKey]] in priority order:
 3. `LAT_LLM_KEY_HELPER` env var — shell command that prints the key to stdout (10 s timeout)
 4. `llm_key` from config file (see [[cli#Configuration File]])
 
-Provider is auto-detected from the resolved key prefix:
+[[src/search/provider.ts#detectProvider]] resolves the provider in this order:
 
-- `sk-...` — OpenAI (uses `text-embedding-3-small`, 1536 dims)
-- `vck_...` — Vercel AI Gateway (uses `openai/text-embedding-3-small`, 1536 dims)
-- `sk-ant-...` — Anthropic (not supported, errors with guidance)
-- `REPLAY_LAT_LLM_KEY::<url>` — test-only replay server for offline testing
+1. `LAT_LLM_PROVIDER=anthropic` (via [[src/config.ts#getLlmProviderOptions]]) — requires `LAT_LLM_BASE_URL` and `LAT_LLM_MODEL` (throws a precise error naming whichever is missing, since Anthropic has no default embeddings endpoint or model). Sends `x-api-key`/`anthropic-version` headers instead of `Authorization: Bearer`.
+2. `LAT_LLM_BASE_URL` set (provider unset or `openai`) — custom OpenAI-compatible endpoint. Model defaults to `text-embedding-3-small` if `LAT_LLM_MODEL` isn't set.
+3. Otherwise, auto-detected from the resolved key prefix:
+   - `sk-...` — OpenAI (uses `text-embedding-3-small`, 1536 dims by default)
+   - `vck_...` — Vercel AI Gateway (uses `openai/text-embedding-3-small`, 1536 dims by default)
+   - `sk-ant-...` — Anthropic (not supported without `LAT_LLM_BASE_URL`, errors with guidance)
+   - `REPLAY_LAT_LLM_KEY::<url>` — test-only replay server for offline testing
+
+`LAT_LLM_MODEL` overrides the model name in all of these cases (required for the `anthropic` case). Overriding the model, or using a custom base URL, clears the provider's statically known `dimensions` — see [[cli#Storage#Dimension Resolution]] below for how the actual dimension count is then resolved.
 
 Implementation: [[src/search/provider.ts]], [[src/config.ts]]
 
@@ -341,6 +352,12 @@ Single `sections` table holds metadata, content, content hash, and the embedding
 The database is stored at `lat.md/.cache/vectors.db` and should not be committed (included in `.gitignore` template).
 
 Implementation: [[src/search/db.ts]]
+
+#### Dimension Resolution
+
+The `sections.embedding` column is a fixed-size `F32_BLOB(dimensions)`, so the vector length must be known before the table is created. Built-in providers (OpenAI, Vercel) know their dimension count statically; custom base URLs and model overrides don't.
+
+[[src/search/schema.ts#resolveSchema]] resolves it: it caches a `name:apiBase:model` signature plus the resolved dimension count in the `meta` table (created but otherwise unused by [[src/search/db.ts#ensureSchema]]). If the signature is unchanged from the last run, the cached dimension is reused with no extra API call. If unknown (first run, or the signature changed) and the provider has no static `dimensions`, it issues one embedding call to a probe string to learn the vector length. If the signature changed since the last run, the caller ([[src/cli/search.ts#runSearch|withDb]]) drops and recreates the `sections` table before calling `ensureSchema()` with the new dimension — a fixed-size `F32_BLOB` can't hold vectors of a different size, so switching provider/model triggers an automatic full re-embed instead of a hard DB error.
 
 ### Indexing
 

--- a/lat.md/tests/search.md
+++ b/lat.md/tests/search.md
@@ -4,11 +4,59 @@ lat:
 ---
 # Search
 
-Tests in `tests/search.test.ts`.
+Tests in `tests/search.test.ts` and `tests/config.test.ts`.
+
+## Configuration Resolution
+
+Unit tests in `tests/config.test.ts` for the custom-endpoint resolvers in `src/config.ts`, each mirroring `getLlmKey`'s env-var-then-config-file resolution.
+
+### Resolve from env vars
+
+`getLlmBaseUrl`, `getLlmProvider`, `getLlmModel`, and `getLlmAnthropicVersion` each return their respective `LAT_LLM_*` env var value when set.
+
+### Undefined when unset
+
+Each resolver returns `undefined` when neither its env var nor a config file value is set, so callers can apply their own defaults.
+
+### Bundles into provider options
+
+`getLlmProviderOptions` bundles all four resolvers into a single `{ baseUrl, providerName, model, anthropicVersion }` object for `detectProvider`.
 
 ## Provider Detection
 
 Unit tests (always run). Verify `detectProvider` correctly identifies OpenAI (`sk-`), Vercel (`vck_`), rejects Anthropic (`sk-ant-`) with a helpful message, and rejects unknown prefixes.
+
+### Custom OpenAI-compatible endpoint
+
+With `baseUrl` set (and no `providerName`, or `providerName: 'openai'`), `detectProvider` builds a provider pointed at that URL using `Authorization: Bearer` headers and a default model when none is given.
+
+### Anthropic-compatible endpoint
+
+With `providerName: 'anthropic'`, `baseUrl`, and `model` all set, `detectProvider` builds a provider that sends `x-api-key` and `anthropic-version` headers instead of `Authorization: Bearer`, defaulting the version when not overridden.
+
+### Anthropic provider requires base URL and model
+
+`providerName: 'anthropic'` without `baseUrl` throws naming `LAT_LLM_BASE_URL`; without `model` (but with `baseUrl`) throws naming `LAT_LLM_MODEL`. Anthropic has no default embeddings endpoint or model to fall back to.
+
+### Model override clears static dimensions
+
+Passing `model` for a built-in provider (OpenAI or Vercel key prefix) overrides its model name and clears its statically known `dimensions`, since a non-default model may have a different vector size.
+
+## Dimension Resolution
+
+Tests in `tests/schema.test.ts`, exercising `resolveSchema()` against a minimal local embeddings stub. Verifies the vectors DB's `meta` table caching described in [[cli#Storage#Dimension Resolution]].
+
+### Probes and caches an unknown dimension
+
+When a provider has no static `dimensions`, the first call to `resolveSchema()` issues one embedding call to learn the vector length and stores it in the `meta` table.
+
+### Reuses cached dimension on repeat calls
+
+A second `resolveSchema()` call with the same provider signature (`name:apiBase:model`) reuses the cached dimension without issuing another embedding call.
+
+### Detects provider or model changes
+
+When the provider signature differs from the one cached in `meta` from a prior call, `resolveSchema()` reports `configChanged: true` so the caller can drop and rebuild the `sections` table.
 
 ## RAG Replay Tests
 

--- a/package.json
+++ b/package.json
@@ -1,16 +1,19 @@
 {
-  "name": "lat.md",
-  "version": "0.11.0",
+  "name": "@erbanku/lat.md",
+  "version": "0.11.2",
   "description": "A knowledge graph for your codebase, written in markdown",
   "type": "module",
   "packageManager": "pnpm@10.30.2",
   "license": "MIT",
-  "author": "Yury Selivanov",
+  "author": "Erban Ku",
   "repository": {
     "type": "git",
-    "url": "https://github.com/1st1/lat.md.git"
+    "url": "git+https://github.com/erbanku/lat.md.git"
   },
-  "homepage": "https://github.com/1st1/lat.md",
+  "homepage": "https://github.com/erbanku/lat.md",
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "markdown",
     "knowledge-graph",
@@ -21,7 +24,7 @@
     "codebase"
   ],
   "bin": {
-    "lat": "./dist/src/cli/index.js"
+    "lat": "dist/src/cli/index.js"
   },
   "files": [
     "dist/src",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -243,12 +243,34 @@ program
 
 program
   .command('config')
-  .description('Show configuration file path')
+  .description('Show configuration file path and resolved LLM settings')
   .action(async () => {
-    const { getConfigPath } = await import('../config.js');
+    const { getConfigPath, getLlmKey, getLlmProviderOptions } = await import(
+      '../config.js'
+    );
     const configPath = getConfigPath();
     const exists = existsSync(configPath);
     console.log(`Config file: ${configPath}${exists ? '' : ' (not found)'}`);
+
+    let hasKey = false;
+    try {
+      hasKey = !!getLlmKey();
+    } catch {
+      // key resolution failed (e.g. empty file) — treat as missing
+    }
+    const { baseUrl, providerName, model, anthropicVersion } =
+      getLlmProviderOptions();
+
+    console.log('');
+    console.log(`LLM key: ${hasKey ? 'configured' : 'not configured'}`);
+    console.log(`LLM base URL: ${baseUrl ?? '(default)'}`);
+    console.log(`LLM provider: ${providerName ?? '(default: openai)'}`);
+    console.log(`LLM model: ${model ?? '(default)'}`);
+    if (providerName === 'anthropic') {
+      console.log(
+        `LLM anthropic-version: ${anthropicVersion ?? '(default)'}`,
+      );
+    }
   });
 
 await program.parseAsync();

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1107,6 +1107,24 @@ async function setupLlmKey(
       ' for exact lookups, but will miss semantic matches.',
   );
   console.log('');
+  console.log(
+    '  Advanced: to use a self-hosted or 3rd-party endpoint (Ollama, LM Studio,',
+  );
+  console.log(
+    '  Azure OpenAI, an Anthropic-compatible proxy, etc.), set ' +
+      styleText('cyan', 'LAT_LLM_BASE_URL') +
+      ' (and optionally',
+  );
+  console.log(
+    '  ' +
+      styleText('cyan', 'LAT_LLM_PROVIDER') +
+      ', ' +
+      styleText('cyan', 'LAT_LLM_MODEL') +
+      ', ' +
+      styleText('cyan', 'LAT_LLM_ANTHROPIC_VERSION') +
+      ') instead of a key prefix below.',
+  );
+  console.log('');
 
   // Interactive prompt
   if (!rl) {

--- a/src/cli/search.ts
+++ b/src/cli/search.ts
@@ -1,6 +1,7 @@
 import type { CmdContext, CmdResult, Styler } from '../context.js';
 import { openDb, ensureSchema, closeDb } from '../search/db.js';
 import { detectProvider } from '../search/provider.js';
+import { resolveSchema } from '../search/schema.js';
 import { indexSections, type IndexStats } from '../search/index.js';
 import { searchSections } from '../search/search.js';
 import {
@@ -9,6 +10,7 @@ import {
   type SectionMatch,
 } from '../lattice.js';
 import { formatResultList, formatNavHints } from '../format.js';
+import { getLlmProviderOptions } from '../config.js';
 
 export type SearchResult = {
   query: string;
@@ -31,11 +33,22 @@ async function withDb<T>(
     provider: ReturnType<typeof detectProvider>,
   ) => Promise<T>,
 ): Promise<T> {
-  const provider = detectProvider(key);
+  const provider = detectProvider(key, getLlmProviderOptions());
   const db = openDb(latDir);
 
   try {
-    await ensureSchema(db, provider.dimensions);
+    const { dimensions, configChanged } = await resolveSchema(
+      db,
+      provider,
+      key,
+    );
+    if (configChanged) {
+      // Embedding provider/model changed since the last run — the fixed-size
+      // vector column can't hold vectors of a different dimension, so drop
+      // and rebuild from scratch.
+      await db.execute('DROP TABLE IF EXISTS sections');
+    }
+    await ensureSchema(db, dimensions);
 
     const countResult = await db.execute('SELECT COUNT(*) as n FROM sections');
     const isEmpty = (countResult.rows[0].n as number) === 0;
@@ -146,11 +159,20 @@ export async function searchCommand(
   }
 
   if (!query) {
-    await runIndex(ctx.latDir, key, progress);
+    try {
+      await runIndex(ctx.latDir, key, progress);
+    } catch (err) {
+      return { output: (err as Error).message, isError: true };
+    }
     return { output: '' };
   }
 
-  const result = await runSearch(ctx.latDir, query, key, opts.limit, progress);
+  let result: SearchResult;
+  try {
+    result = await runSearch(ctx.latDir, query, key, opts.limit, progress);
+  } catch (err) {
+    return { output: (err as Error).message, isError: true };
+  }
 
   if (result.matches.length === 0) {
     return { output: 'No results found.' };

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,10 @@ export function getConfigPath(): string {
 
 export type LatConfig = {
   llm_key?: string;
+  llm_base_url?: string;
+  llm_provider?: string;
+  llm_model?: string;
+  llm_anthropic_version?: string;
 };
 
 export function readConfig(): LatConfig {
@@ -78,4 +82,67 @@ export function getLlmKey(): string | undefined {
   if (config.llm_key) return config.llm_key;
 
   return undefined;
+}
+
+/**
+ * Returns a custom OpenAI/Anthropic-compatible embeddings API base URL from
+ * (in priority order): LAT_LLM_BASE_URL env var, then `llm_base_url` in the
+ * config file. Returns undefined if none is set (built-in providers apply).
+ */
+export function getLlmBaseUrl(): string | undefined {
+  const envVal = process.env.LAT_LLM_BASE_URL;
+  if (envVal) return envVal;
+  return readConfig().llm_base_url;
+}
+
+/**
+ * Returns the embedding request format ('openai' or 'anthropic') from (in
+ * priority order): LAT_LLM_PROVIDER env var, then `llm_provider` in the
+ * config file. Returns undefined if none is set (defaults to 'openai' when
+ * LAT_LLM_BASE_URL is set, or is ignored otherwise).
+ */
+export function getLlmProvider(): string | undefined {
+  const envVal = process.env.LAT_LLM_PROVIDER;
+  if (envVal) return envVal;
+  return readConfig().llm_provider;
+}
+
+/**
+ * Returns an embedding model override from (in priority order):
+ * LAT_LLM_MODEL env var, then `llm_model` in the config file. Returns
+ * undefined if none is set (the provider's default model applies).
+ */
+export function getLlmModel(): string | undefined {
+  const envVal = process.env.LAT_LLM_MODEL;
+  if (envVal) return envVal;
+  return readConfig().llm_model;
+}
+
+/**
+ * Returns the `anthropic-version` header value to send when
+ * LAT_LLM_PROVIDER=anthropic, from (in priority order):
+ * LAT_LLM_ANTHROPIC_VERSION env var, then `llm_anthropic_version` in the
+ * config file. Returns undefined if none is set (a default applies).
+ */
+export function getLlmAnthropicVersion(): string | undefined {
+  const envVal = process.env.LAT_LLM_ANTHROPIC_VERSION;
+  if (envVal) return envVal;
+  return readConfig().llm_anthropic_version;
+}
+
+export type LlmProviderOptions = {
+  baseUrl?: string;
+  providerName?: string;
+  model?: string;
+  anthropicVersion?: string;
+};
+
+/** Bundles the custom-endpoint resolvers above for `detectProvider()`. */
+export function getLlmProviderOptions(): LlmProviderOptions {
+  return {
+    baseUrl: getLlmBaseUrl(),
+    providerName: getLlmProvider(),
+    model: getLlmModel(),
+    anthropicVersion: getLlmAnthropicVersion(),
+  };
 }

--- a/src/search/provider.ts
+++ b/src/search/provider.ts
@@ -2,19 +2,50 @@ export type EmbeddingProvider = {
   name: string;
   apiBase: string;
   model: string;
-  dimensions: number;
+  /**
+   * Vector length for the embedding model. Known statically for the
+   * built-in providers; left undefined for custom base URLs or model
+   * overrides, in which case `resolveSchema()` probes it at runtime.
+   */
+  dimensions?: number;
   headers: (key: string) => Record<string, string>;
 };
+
+export type ProviderOptions = {
+  /** Custom OpenAI/Anthropic-compatible API root (LAT_LLM_BASE_URL). */
+  baseUrl?: string;
+  /** Request/header format: 'openai' (default) or 'anthropic' (LAT_LLM_PROVIDER). */
+  providerName?: string;
+  /** Embedding model override (LAT_LLM_MODEL). */
+  model?: string;
+  /** `anthropic-version` header value, only used when providerName is 'anthropic'. */
+  anthropicVersion?: string;
+};
+
+const DEFAULT_ANTHROPIC_VERSION = '2023-06-01';
+const DEFAULT_CUSTOM_MODEL = 'text-embedding-3-small';
+
+function openaiHeaders(key: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${key}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+function anthropicHeaders(key: string, version: string): Record<string, string> {
+  return {
+    'x-api-key': key,
+    'anthropic-version': version,
+    'Content-Type': 'application/json',
+  };
+}
 
 const openai: EmbeddingProvider = {
   name: 'openai',
   apiBase: 'https://api.openai.com/v1',
   model: 'text-embedding-3-small',
   dimensions: 1536,
-  headers: (key) => ({
-    Authorization: `Bearer ${key}`,
-    'Content-Type': 'application/json',
-  }),
+  headers: openaiHeaders,
 };
 
 const vercel: EmbeddingProvider = {
@@ -22,13 +53,17 @@ const vercel: EmbeddingProvider = {
   apiBase: 'https://ai-gateway.vercel.sh/v1',
   model: 'openai/text-embedding-3-small',
   dimensions: 1536,
-  headers: (key) => ({
-    Authorization: `Bearer ${key}`,
-    'Content-Type': 'application/json',
-  }),
+  headers: openaiHeaders,
 };
 
-export function detectProvider(key: string): EmbeddingProvider {
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+export function detectProvider(
+  key: string,
+  opts: ProviderOptions = {},
+): EmbeddingProvider {
   if (key.startsWith('REPLAY_LAT_LLM_KEY::')) {
     const replayUrl = key.slice('REPLAY_LAT_LLM_KEY::'.length);
     return {
@@ -39,14 +74,60 @@ export function detectProvider(key: string): EmbeddingProvider {
       headers: () => ({ 'Content-Type': 'application/json' }),
     };
   }
-  if (key.startsWith('sk-ant-')) {
+
+  if (opts.providerName === 'anthropic') {
+    if (!opts.baseUrl) {
+      throw new Error(
+        'LAT_LLM_PROVIDER=anthropic requires LAT_LLM_BASE_URL. Anthropic has no built-in embeddings API, so this must point at an Anthropic-compatible embeddings endpoint.',
+      );
+    }
+    if (!opts.model) {
+      throw new Error(
+        'LAT_LLM_PROVIDER=anthropic requires LAT_LLM_MODEL. Anthropic-compatible embedding services have no universal default model name.',
+      );
+    }
+    const version = opts.anthropicVersion || DEFAULT_ANTHROPIC_VERSION;
+    return {
+      name: 'anthropic-compatible',
+      apiBase: stripTrailingSlash(opts.baseUrl),
+      model: opts.model,
+      dimensions: undefined,
+      headers: (k) => anthropicHeaders(k, version),
+    };
+  }
+
+  if (opts.providerName && opts.providerName !== 'openai') {
     throw new Error(
-      "Anthropic doesn't offer an embedding model. Set LAT_LLM_KEY to an OpenAI (sk-...) or Vercel AI Gateway (vck_...) key.",
+      `Unrecognized LAT_LLM_PROVIDER "${opts.providerName}". Supported: openai, anthropic.`,
     );
   }
-  if (key.startsWith('vck_')) return vercel;
-  if (key.startsWith('sk-')) return openai;
+
+  if (opts.baseUrl) {
+    return {
+      name: 'openai-compatible',
+      apiBase: stripTrailingSlash(opts.baseUrl),
+      model: opts.model || DEFAULT_CUSTOM_MODEL,
+      dimensions: undefined,
+      headers: openaiHeaders,
+    };
+  }
+
+  if (key.startsWith('sk-ant-')) {
+    throw new Error(
+      "Anthropic doesn't offer an embedding model. Set LAT_LLM_KEY to an OpenAI (sk-...) or Vercel AI Gateway (vck_...) key, or configure LAT_LLM_BASE_URL for a custom endpoint.",
+    );
+  }
+  if (key.startsWith('vck_')) {
+    return opts.model
+      ? { ...vercel, model: opts.model, dimensions: undefined }
+      : vercel;
+  }
+  if (key.startsWith('sk-')) {
+    return opts.model
+      ? { ...openai, model: opts.model, dimensions: undefined }
+      : openai;
+  }
   throw new Error(
-    `Unrecognized LAT_LLM_KEY prefix. Supported: OpenAI (sk-...), Vercel AI Gateway (vck_...).`,
+    `Unrecognized LAT_LLM_KEY prefix. Supported: OpenAI (sk-...), Vercel AI Gateway (vck_...), or set LAT_LLM_BASE_URL for a custom endpoint.`,
   );
 }

--- a/src/search/schema.ts
+++ b/src/search/schema.ts
@@ -1,0 +1,87 @@
+import type { Client } from '@libsql/client';
+import type { EmbeddingProvider } from './provider.js';
+import { embed } from './embeddings.js';
+
+const CONFIG_META_KEY = 'embedding_config';
+const DIMENSIONS_META_KEY = 'embedding_dimensions';
+
+async function ensureMetaTable(db: Client): Promise<void> {
+  await db.execute(
+    `CREATE TABLE IF NOT EXISTS meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )`,
+  );
+}
+
+async function getMeta(db: Client, key: string): Promise<string | undefined> {
+  const res = await db.execute({
+    sql: 'SELECT value FROM meta WHERE key = ?',
+    args: [key],
+  });
+  return res.rows[0]?.value as string | undefined;
+}
+
+async function setMeta(db: Client, key: string, value: string): Promise<void> {
+  await db.execute({
+    sql: `INSERT INTO meta (key, value) VALUES (?, ?)
+          ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+    args: [key, value],
+  });
+}
+
+function providerSignature(provider: EmbeddingProvider): string {
+  return `${provider.name}:${provider.apiBase}:${provider.model}`;
+}
+
+export type SchemaResolution = {
+  /** Vector length to use for the `sections.embedding` column. */
+  dimensions: number;
+  /**
+   * True if the provider/model changed since the last run against this DB.
+   * Callers should drop and recreate the `sections` table before calling
+   * `ensureSchema()` with the new dimension count, since a fixed-size
+   * `F32_BLOB` column can't hold vectors of a different size.
+   */
+  configChanged: boolean;
+};
+
+/**
+ * Resolve the embedding vector size for `provider`, probing the API with a
+ * single embed call when the provider has no statically known dimension
+ * count (custom base URL or model override). The result is cached in the
+ * `meta` table keyed by a `name:apiBase:model` signature so repeated
+ * invocations don't re-probe, and provider/model changes are detected so
+ * callers can migrate the `sections` table.
+ */
+export async function resolveSchema(
+  db: Client,
+  provider: EmbeddingProvider,
+  key: string,
+): Promise<SchemaResolution> {
+  await ensureMetaTable(db);
+
+  const signature = providerSignature(provider);
+  const prevSignature = await getMeta(db, CONFIG_META_KEY);
+  const configChanged =
+    prevSignature !== undefined && prevSignature !== signature;
+
+  let dimensions = provider.dimensions;
+  if (dimensions === undefined && !configChanged) {
+    const cached = await getMeta(db, DIMENSIONS_META_KEY);
+    if (cached) dimensions = parseInt(cached, 10);
+  }
+  if (dimensions === undefined) {
+    const [probe] = await embed(
+      ['lat.md embedding dimension probe'],
+      provider,
+      key,
+    );
+    dimensions = probe.length;
+  }
+
+  await setMeta(db, CONFIG_META_KEY, signature);
+  await setMeta(db, DIMENSIONS_META_KEY, String(dimensions));
+
+  return { dimensions, configChanged };
+}

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -29,7 +29,7 @@ lat check                      # validate all links and code refs
 
 Run `lat --help` when in doubt about available commands or options.
 
-If `lat search` fails because no API key is configured, explain to the user that semantic search requires a key provided via `LAT_LLM_KEY` (direct value), `LAT_LLM_KEY_FILE` (path to key file), or `LAT_LLM_KEY_HELPER` (command that prints the key). Supported key prefixes: `sk-...` (OpenAI) or `vck_...` (Vercel). If the user doesn't want to set it up, use `lat locate` for direct lookups instead.
+If `lat search` fails because no API key is configured, explain to the user that semantic search requires a key provided via `LAT_LLM_KEY` (direct value), `LAT_LLM_KEY_FILE` (path to key file), or `LAT_LLM_KEY_HELPER` (command that prints the key). Supported key prefixes: `sk-...` (OpenAI) or `vck_...` (Vercel). For self-hosted or 3rd-party endpoints (Ollama, LM Studio, Azure OpenAI, an Anthropic-compatible proxy, etc.), set `LAT_LLM_BASE_URL` and `LAT_LLM_MODEL` (and optionally `LAT_LLM_PROVIDER=anthropic` for `x-api-key`-style auth) instead of relying on a key prefix. If the user doesn't want to set it up, use `lat locate` for direct lookups instead.
 
 # Syntax primer
 

--- a/templates/cursor-rules.md
+++ b/templates/cursor-rules.md
@@ -27,7 +27,7 @@ You have access to the following MCP tools from the `lat` server:
 - **lat_check** — validate all wiki links and code refs
 - **lat_refs** — find what references a section
 
-If `lat_search` fails because `LAT_LLM_KEY` is not set, explain to the user that semantic search requires an API key (`export LAT_LLM_KEY=sk-...` for OpenAI or `export LAT_LLM_KEY=vck_...` for Vercel). If the user doesn't want to set it up, use `lat_locate` for direct lookups instead.
+If `lat_search` fails because `LAT_LLM_KEY` is not set, explain to the user that semantic search requires an API key (`export LAT_LLM_KEY=sk-...` for OpenAI or `export LAT_LLM_KEY=vck_...` for Vercel). For self-hosted or 3rd-party endpoints (Ollama, LM Studio, Azure OpenAI, an Anthropic-compatible proxy, etc.), set `LAT_LLM_BASE_URL` and `LAT_LLM_MODEL` (and optionally `LAT_LLM_PROVIDER=anthropic` for `x-api-key`-style auth) instead of relying on a key prefix. If the user doesn't want to set it up, use `lat_locate` for direct lookups instead.
 
 # Syntax primer
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  getLlmBaseUrl,
+  getLlmProvider,
+  getLlmModel,
+  getLlmAnthropicVersion,
+  getLlmProviderOptions,
+} from '../src/config.js';
+
+const ENV_KEYS = [
+  'LAT_LLM_BASE_URL',
+  'LAT_LLM_PROVIDER',
+  'LAT_LLM_MODEL',
+  'LAT_LLM_ANTHROPIC_VERSION',
+] as const;
+
+describe('config custom-endpoint resolvers', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  // @lat: [[search#Configuration Resolution#Resolve from env vars]]
+  it('resolves each field from its env var', () => {
+    process.env.LAT_LLM_BASE_URL = 'http://localhost:11434/v1';
+    process.env.LAT_LLM_PROVIDER = 'anthropic';
+    process.env.LAT_LLM_MODEL = 'nomic-embed-text';
+    process.env.LAT_LLM_ANTHROPIC_VERSION = '2024-01-01';
+
+    expect(getLlmBaseUrl()).toBe('http://localhost:11434/v1');
+    expect(getLlmProvider()).toBe('anthropic');
+    expect(getLlmModel()).toBe('nomic-embed-text');
+    expect(getLlmAnthropicVersion()).toBe('2024-01-01');
+  });
+
+  // @lat: [[search#Configuration Resolution#Undefined when unset]]
+  it('returns undefined when no env var or config file value is set', () => {
+    expect(getLlmBaseUrl()).toBeUndefined();
+    expect(getLlmProvider()).toBeUndefined();
+    expect(getLlmModel()).toBeUndefined();
+    expect(getLlmAnthropicVersion()).toBeUndefined();
+  });
+
+  // @lat: [[search#Configuration Resolution#Bundles into provider options]]
+  it('getLlmProviderOptions bundles all four resolvers', () => {
+    process.env.LAT_LLM_BASE_URL = 'https://example.com/v1';
+    process.env.LAT_LLM_PROVIDER = 'openai';
+    process.env.LAT_LLM_MODEL = 'text-embedding-3-large';
+
+    expect(getLlmProviderOptions()).toEqual({
+      baseUrl: 'https://example.com/v1',
+      providerName: 'openai',
+      model: 'text-embedding-3-large',
+      anthropicVersion: undefined,
+    });
+  });
+});

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -80,7 +80,7 @@ describe('resolveSchema', () => {
 
   afterEach(async () => {
     await closeDb(db);
-    server.close();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
     try {
       rmSync(tmp, { recursive: true, force: true });
     } catch {

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { Client } from '@libsql/client';
+import { openDb, closeDb } from '../src/search/db.js';
+import { resolveSchema } from '../src/search/schema.js';
+import type { EmbeddingProvider } from '../src/search/provider.js';
+
+/** Minimal OpenAI-compatible /embeddings stub returning fixed-length vectors. */
+function startStubServer(
+  dimensions: number,
+): Promise<{ server: Server; url: string; callCount: () => number }> {
+  let calls = 0;
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      if (req.method !== 'POST') {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      let body = '';
+      req.on('data', (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      req.on('end', () => {
+        calls++;
+        const { input } = JSON.parse(body) as { input: string[] };
+        const data = input.map((_, i) => ({
+          object: 'embedding',
+          index: i,
+          embedding: new Array(dimensions).fill(0.1),
+        }));
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ object: 'list', data }));
+      });
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number };
+      resolve({
+        server,
+        url: `http://127.0.0.1:${addr.port}`,
+        callCount: () => calls,
+      });
+    });
+  });
+}
+
+function makeProvider(
+  apiBase: string,
+  model: string,
+  dimensions?: number,
+): EmbeddingProvider {
+  return {
+    name: 'stub',
+    apiBase,
+    model,
+    dimensions,
+    headers: () => ({ 'Content-Type': 'application/json' }),
+  };
+}
+
+describe('resolveSchema', () => {
+  let tmp: string;
+  let db: Client;
+  let server: Server;
+  let url: string;
+  let callCount: () => number;
+
+  beforeEach(async () => {
+    tmp = mkdtempSync(join(tmpdir(), 'lat-schema-'));
+    db = openDb(tmp);
+    const stub = await startStubServer(768);
+    server = stub.server;
+    url = stub.url;
+    callCount = stub.callCount;
+  });
+
+  afterEach(async () => {
+    await closeDb(db);
+    server.close();
+    try {
+      rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      // libsql's local-file client can hold the vectors.db file handle open
+      // briefly after close() on Windows (EBUSY). This is just cleanup of an
+      // OS temp directory, so a leftover file here doesn't affect test
+      // correctness — ignore it rather than fail the test.
+    }
+  });
+
+  // @lat: [[search#Dimension Resolution#Probes and caches an unknown dimension]]
+  it('probes an unknown dimension and caches it', async () => {
+    const provider = makeProvider(url, 'custom-model');
+    const result = await resolveSchema(db, provider, 'key');
+    expect(result.dimensions).toBe(768);
+    expect(result.configChanged).toBe(false);
+    expect(callCount()).toBe(1);
+  });
+
+  // @lat: [[search#Dimension Resolution#Reuses cached dimension on repeat calls]]
+  it('reuses the cached dimension without re-probing', async () => {
+    const provider = makeProvider(url, 'custom-model');
+    await resolveSchema(db, provider, 'key');
+    expect(callCount()).toBe(1);
+
+    const result = await resolveSchema(db, provider, 'key');
+    expect(result.dimensions).toBe(768);
+    expect(result.configChanged).toBe(false);
+    expect(callCount()).toBe(1); // no additional probe
+  });
+
+  // @lat: [[search#Dimension Resolution#Detects provider or model changes]]
+  it('reports configChanged when the provider signature changes', async () => {
+    const providerA = makeProvider(url, 'model-a');
+    await resolveSchema(db, providerA, 'key');
+
+    const providerB = makeProvider(url, 'model-b');
+    const result = await resolveSchema(db, providerB, 'key');
+    expect(result.configChanged).toBe(true);
+  });
+
+  it('does not probe when dimensions are statically known', async () => {
+    const provider = makeProvider(url, 'known-model', 1536);
+    const result = await resolveSchema(db, provider, 'key');
+    expect(result.dimensions).toBe(1536);
+    expect(callCount()).toBe(0);
+  });
+
+  it('does not report a change on the very first run', async () => {
+    const provider = makeProvider(url, 'custom-model');
+    const result = await resolveSchema(db, provider, 'key');
+    expect(result.configChanged).toBe(false);
+  });
+});

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -34,6 +34,94 @@ describe('detectProvider', () => {
   it('rejects unknown key', () => {
     expect(() => detectProvider('xyz_abc123')).toThrow(/Unrecognized/);
   });
+
+  // @lat: [[search#Provider Detection#Custom OpenAI-compatible endpoint]]
+  it('builds a custom openai-compatible provider from baseUrl', () => {
+    const p = detectProvider('ollama', {
+      baseUrl: 'http://localhost:11434/v1/',
+    });
+    expect(p.name).toBe('openai-compatible');
+    expect(p.apiBase).toBe('http://localhost:11434/v1'); // trailing slash stripped
+    expect(p.model).toBe('text-embedding-3-small'); // default
+    expect(p.dimensions).toBeUndefined();
+    expect(p.headers('ollama')).toEqual({
+      Authorization: 'Bearer ollama',
+      'Content-Type': 'application/json',
+    });
+  });
+
+  it('uses a custom model for a custom openai-compatible provider', () => {
+    const p = detectProvider('ollama', {
+      baseUrl: 'http://localhost:11434/v1',
+      model: 'nomic-embed-text',
+    });
+    expect(p.model).toBe('nomic-embed-text');
+  });
+
+  // @lat: [[search#Provider Detection#Anthropic-compatible endpoint]]
+  it('builds an anthropic-compatible provider with x-api-key headers', () => {
+    const p = detectProvider('sk-my-proxy-key', {
+      baseUrl: 'https://proxy.example.com/v1',
+      providerName: 'anthropic',
+      model: 'my-embed-model',
+    });
+    expect(p.name).toBe('anthropic-compatible');
+    expect(p.model).toBe('my-embed-model');
+    expect(p.dimensions).toBeUndefined();
+    expect(p.headers('sk-my-proxy-key')).toEqual({
+      'x-api-key': 'sk-my-proxy-key',
+      'anthropic-version': '2023-06-01',
+      'Content-Type': 'application/json',
+    });
+  });
+
+  it('overrides the anthropic-version header when given', () => {
+    const p = detectProvider('key', {
+      baseUrl: 'https://proxy.example.com/v1',
+      providerName: 'anthropic',
+      model: 'my-embed-model',
+      anthropicVersion: '2024-05-01',
+    });
+    expect(p.headers('key')['anthropic-version']).toBe('2024-05-01');
+  });
+
+  // @lat: [[search#Provider Detection#Anthropic provider requires base URL and model]]
+  it('rejects anthropic provider without a base URL', () => {
+    expect(() =>
+      detectProvider('key', { providerName: 'anthropic', model: 'm' }),
+    ).toThrow(/LAT_LLM_BASE_URL/);
+  });
+
+  it('rejects anthropic provider without a model', () => {
+    expect(() =>
+      detectProvider('key', {
+        providerName: 'anthropic',
+        baseUrl: 'https://proxy.example.com/v1',
+      }),
+    ).toThrow(/LAT_LLM_MODEL/);
+  });
+
+  it('rejects an unrecognized LAT_LLM_PROVIDER value', () => {
+    expect(() =>
+      detectProvider('sk-abc123', { providerName: 'not-a-real-provider' }),
+    ).toThrow(/Unrecognized LAT_LLM_PROVIDER/);
+  });
+
+  // @lat: [[search#Provider Detection#Model override clears static dimensions]]
+  it('overriding the model for a built-in provider clears its static dimensions', () => {
+    const openai = detectProvider('sk-abc123', { model: 'text-embedding-3-large' });
+    expect(openai.model).toBe('text-embedding-3-large');
+    expect(openai.dimensions).toBeUndefined();
+
+    const vercel = detectProvider('vck_abc123', { model: 'custom-model' });
+    expect(vercel.model).toBe('custom-model');
+    expect(vercel.dimensions).toBeUndefined();
+  });
+
+  it('leaves built-in provider dimensions intact without a model override', () => {
+    expect(detectProvider('sk-abc123').dimensions).toBe(1536);
+    expect(detectProvider('vck_abc123').dimensions).toBe(1536);
+  });
 });
 
 // --- RAG functional tests ---
@@ -91,7 +179,8 @@ describe.skipIf(!canRun)('search (rag)', () => {
     });
 
     db = openDb(latDir);
-    await ensureSchema(db, provider.dimensions);
+    // The replay provider always has a statically known dimension count.
+    await ensureSchema(db, provider.dimensions!);
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Add configurable provider, base URL, and model resolution for semantic search.
Enable OpenAI-compatible, Anthropic-compatible, local, and enterprise-hosted endpoints via environment variables.

Closes #72