### PR TITLE
Add Java source symbol support

### DIFF
--- a/lat.md/dev-process.md
+++ b/lat.md/dev-process.md
@@ -51,7 +51,7 @@ It wraps the `ignore-walk` npm package to ensure `.gitignore` rules are consiste
 
 ## Formatting
 
-Prettier with no semicolons, single quotes, trailing commas. Run `pnpm format` before committing.
+Prettier with semicolons, single quotes, trailing commas (see `.prettierrc`). Run `pnpm format` before committing.
 
 ## Publishing
 

--- a/lat.md/markdown.md
+++ b/lat.md/markdown.md
@@ -32,7 +32,7 @@ Resolution is handled by [[src/lattice.ts#resolveRef]]. See [[parser#Short Ref R
 
 ### Source Code Links
 
-Wiki links can reference symbols in TypeScript, JavaScript, Python, Rust, Go, and C source files:
+Wiki links can reference symbols in TypeScript, JavaScript, Python, Rust, Go, C, and Java source files:
 
 - **`[[src/config.ts#getConfigDir]]`** — the `getConfigDir` function in `src/config.ts`
 - **`[[src/server.ts#App#listen]]`** — the `listen` method on class `App` in `src/server.ts`
@@ -40,11 +40,14 @@ Wiki links can reference symbols in TypeScript, JavaScript, Python, Rust, Go, an
 - **`[[src/app.go#Greeter#Greet]]`** — the `Greet` method on type `Greeter` in Go
 - **`[[src/app.h#Greeter]]`** — the `Greeter` struct in a C header
 - **`[[src/app.h#Greeter#prefix]]`** — the `prefix` field of struct `Greeter` in C
+- **`[[src/Greeter.java#Greeter#greet]]`** — the `greet` method on class `Greeter` in Java
 - **`[[src/config.ts]]`** — link to the file itself (no symbol)
 
-Supported extensions: `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.rs`, `.go`, `.c`, `.h`.
+Supported extensions: `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.rs`, `.go`, `.c`, `.h`, `.java`.
 
 Python symbols: functions, classes, methods, module-level variables. Decorated definitions (`@decorator`) are unwrapped transparently — `[[file.py#my_func]]` resolves whether or not `my_func` has decorators, and `# @lat:` comments placed between decorators and the `def`/`class` line are scanned normally.
+
+Java symbols: classes, interfaces, enums, records, and annotation types (with their methods, constructors, fields, enum constants, and record components as `#Type#member`). Nested types resolve both standalone (`#Inner`) and qualified (`#Outer#Inner`).
 
 Rust symbols: functions, structs, enums, traits, impl methods, consts, statics, type aliases. Methods are resolved via `impl` blocks — `[[file.rs#Type#method]]` matches any `impl Type { fn method() }` or `impl Trait for Type { fn method() }`.
 

--- a/lat.md/tests/check-md.md
+++ b/lat.md/tests/check-md.md
@@ -15,6 +15,10 @@ Given a file with a wiki link pointing to a nonexistent section, [[cli#check#md]
 
 Given files where all wiki links resolve to existing sections, [[cli#check#md]] should report no errors.
 
+### Passes with Java symbol links
+
+Given `lat.md` links to Java classes, methods, constructors, fields, nested classes (standalone and `Outer#Inner`-qualified), interfaces, enums, records, and annotation types, [[cli#check#md]] should resolve them all as valid source symbols.
+
 ### Passes with C enum value links
 
 Given `lat.md` links to C enum members, including anonymous enums and `typedef enum` members, [[cli#check#md]] should resolve those values as valid source symbols.

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -60,6 +60,7 @@ const grammarMap: Record<string, string> = {
   '.go': 'tree-sitter-go.wasm',
   '.c': 'tree-sitter-c.wasm',
   '.h': 'tree-sitter-c.wasm',
+  '.java': 'tree-sitter-java.wasm',
 };
 
 /** All source file extensions that lat can parse (derived from grammarMap). */
@@ -517,6 +518,136 @@ function extractGoSymbols(tree: Tree): SourceSymbol[] {
   return symbols;
 }
 
+/** Java type-declaration node types and the symbol kind they map to. */
+const javaTypeKinds: Record<string, SourceSymbol['kind']> = {
+  class_declaration: 'class',
+  record_declaration: 'class',
+  enum_declaration: 'class',
+  interface_declaration: 'interface',
+  annotation_type_declaration: 'interface',
+};
+
+function extractJavaSymbols(tree: Tree): SourceSymbol[] {
+  const symbols: SourceSymbol[] = [];
+  collectJavaScope(tree.rootNode, null, symbols);
+  return symbols;
+}
+
+/**
+ * Walk a Java scope (program, class_body, interface_body, enum_body, ...)
+ * and collect type declarations and their members.
+ *
+ * Nested types are emitted both standalone and with `parent` set, so both
+ * `#Inner` and `#Outer#Inner` resolve (same dual-emit approach as C enum
+ * members). Members always carry their enclosing type as `parent`.
+ */
+function collectJavaScope(
+  scope: SyntaxNode,
+  parentName: string | null,
+  symbols: SourceSymbol[],
+): void {
+  for (let i = 0; i < scope.namedChildCount; i++) {
+    const node = scope.namedChild(i)!;
+    const startLine = node.startPosition.row + 1;
+    const endLine = node.endPosition.row + 1;
+
+    const typeKind = javaTypeKinds[node.type];
+    if (typeKind) {
+      const name = extractName(node);
+      if (!name) continue;
+      const sym: SourceSymbol = {
+        name,
+        kind: typeKind,
+        startLine,
+        endLine,
+        signature: firstLine(node.text),
+      };
+      symbols.push(sym);
+      if (parentName) {
+        // Nested type — also emit with parent so #Outer#Inner works
+        symbols.push({ ...sym, parent: parentName });
+      }
+      // Record components (`record Point(int x, int y)`) act as fields
+      if (node.type === 'record_declaration') {
+        const params = node.childForFieldName('parameters');
+        if (params) {
+          for (let j = 0; j < params.namedChildCount; j++) {
+            const param = params.namedChild(j)!;
+            if (param.type !== 'formal_parameter') continue;
+            const paramName = extractName(param);
+            if (!paramName) continue;
+            symbols.push({
+              name: paramName,
+              kind: 'variable',
+              parent: name,
+              startLine: param.startPosition.row + 1,
+              endLine: param.endPosition.row + 1,
+              signature: firstLine(param.text),
+            });
+          }
+        }
+      }
+      const body = node.childForFieldName('body');
+      if (body) collectJavaScope(body, name, symbols);
+      continue;
+    }
+
+    if (!parentName) continue;
+
+    if (
+      node.type === 'method_declaration' ||
+      node.type === 'constructor_declaration' ||
+      node.type === 'annotation_type_element_declaration'
+    ) {
+      const name = extractName(node);
+      if (name) {
+        symbols.push({
+          name,
+          kind: 'method',
+          parent: parentName,
+          startLine,
+          endLine,
+          signature: firstLine(node.text),
+        });
+      }
+    } else if (
+      node.type === 'field_declaration' ||
+      node.type === 'constant_declaration'
+    ) {
+      // One declaration can declare several fields: `private int a, b;`
+      for (let j = 0; j < node.namedChildCount; j++) {
+        const declarator = node.namedChild(j)!;
+        if (declarator.type !== 'variable_declarator') continue;
+        const name = extractName(declarator);
+        if (!name) continue;
+        symbols.push({
+          name,
+          kind: node.type === 'constant_declaration' ? 'const' : 'variable',
+          parent: parentName,
+          startLine: declarator.startPosition.row + 1,
+          endLine: declarator.endPosition.row + 1,
+          signature: firstLine(node.text),
+        });
+      }
+    } else if (node.type === 'enum_constant') {
+      const name = extractName(node);
+      if (name) {
+        symbols.push({
+          name,
+          kind: 'const',
+          parent: parentName,
+          startLine,
+          endLine,
+          signature: firstLine(node.text),
+        });
+      }
+    } else if (node.type === 'enum_body_declarations') {
+      // Methods/fields after the constants in an enum body
+      collectJavaScope(node, parentName, symbols);
+    }
+  }
+}
+
 /**
  * Extract the declarator name from a C function_declarator node.
  * Handles plain identifiers and pointer declarators (*name).
@@ -861,6 +992,9 @@ export async function parseSourceSymbols(
     }
     if (ext === '.c' || ext === '.h') {
       return extractCSymbols(tree);
+    }
+    if (ext === '.java') {
+      return extractJavaSymbols(tree);
     }
     return extractTsSymbols(tree);
   } finally {

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -35,8 +35,8 @@ If `lat search` fails because no API key is configured, explain to the user that
 
 - **Section ids**: `lat.md/path/to/file#Heading#SubHeading` — full form uses project-root-relative path (e.g. `lat.md/tests/search#RAG Replay Tests`). Short form uses bare file name when unique (e.g. `search#RAG Replay Tests`, `cli#search#Indexing`).
 - **Wiki links**: `[[target]]` or `[[target|alias]]` — cross-references between sections. Can also reference source code: `[[src/foo.ts#myFunction]]`.
-- **Source code links**: Wiki links in `lat.md/` files can reference functions, classes, constants, and methods in TypeScript/JavaScript/Python/Rust/Go/C files. Use the full path: `[[src/config.ts#getConfigDir]]`, `[[src/server.ts#App#listen]]` (class method), `[[lib/utils.py#parse_args]]`, `[[src/lib.rs#Greeter#greet]]` (Rust impl method), `[[src/app.go#Greeter#Greet]]` (Go method), `[[src/app.h#Greeter]]` (C struct). `lat check` validates these exist.
-- **Code refs**: `// @lat: [[section-id]]` (JS/TS/Rust/Go/C) or `# @lat: [[section-id]]` (Python) — ties source code to concepts
+- **Source code links**: Wiki links in `lat.md/` files can reference functions, classes, constants, and methods in TypeScript/JavaScript/Python/Rust/Go/C/Java files. Use the full path: `[[src/config.ts#getConfigDir]]`, `[[src/server.ts#App#listen]]` (class method), `[[lib/utils.py#parse_args]]`, `[[src/lib.rs#Greeter#greet]]` (Rust impl method), `[[src/app.go#Greeter#Greet]]` (Go method), `[[src/app.h#Greeter]]` (C struct), `[[src/Greeter.java#Greeter#greet]]` (Java method). `lat check` validates these exist.
+- **Code refs**: `// @lat: [[section-id]]` (JS/TS/Rust/Go/C/Java) or `# @lat: [[section-id]]` (Python) — ties source code to concepts
 
 # Test specs
 

--- a/templates/cursor-rules.md
+++ b/templates/cursor-rules.md
@@ -33,8 +33,8 @@ If `lat_search` fails because `LAT_LLM_KEY` is not set, explain to the user that
 
 - **Section ids**: `lat.md/path/to/file#Heading#SubHeading` — full form uses project-root-relative path (e.g. `lat.md/tests/search#RAG Replay Tests`). Short form uses bare file name when unique (e.g. `search#RAG Replay Tests`, `cli#search#Indexing`).
 - **Wiki links**: `[[target]]` or `[[target|alias]]` — cross-references between sections. Can also reference source code: `[[src/foo.ts#myFunction]]`.
-- **Source code links**: Wiki links in `lat.md/` files can reference functions, classes, constants, and methods in TypeScript/JavaScript/Python/Rust/Go/C files. Use the full path: `[[src/config.ts#getConfigDir]]`, `[[src/server.ts#App#listen]]` (class method), `[[lib/utils.py#parse_args]]`, `[[src/lib.rs#Greeter#greet]]` (Rust impl method), `[[src/app.go#Greeter#Greet]]` (Go method), `[[src/app.h#Greeter]]` (C struct). `lat check` validates these exist.
-- **Code refs**: `// @lat: [[section-id]]` (JS/TS/Rust/Go/C) or `# @lat: [[section-id]]` (Python) — ties source code to concepts
+- **Source code links**: Wiki links in `lat.md/` files can reference functions, classes, constants, and methods in TypeScript/JavaScript/Python/Rust/Go/C/Java files. Use the full path: `[[src/config.ts#getConfigDir]]`, `[[src/server.ts#App#listen]]` (class method), `[[lib/utils.py#parse_args]]`, `[[src/lib.rs#Greeter#greet]]` (Rust impl method), `[[src/app.go#Greeter#Greet]]` (Go method), `[[src/app.h#Greeter]]` (C struct), `[[src/Greeter.java#Greeter#greet]]` (Java method). `lat check` validates these exist.
+- **Code refs**: `// @lat: [[section-id]]` (JS/TS/Rust/Go/C/Java) or `# @lat: [[section-id]]` (Python) — ties source code to concepts
 
 # Test specs
 

--- a/templates/skill/SKILL.md
+++ b/templates/skill/SKILL.md
@@ -104,7 +104,7 @@ def init():
     ...
 ```
 
-Supported comment styles: `//` (JS/TS/Rust/Go/C) and `#` (Python).
+Supported comment styles: `//` (JS/TS/Rust/Go/C/Java) and `#` (Python).
 
 Place one `@lat:` comment per section, at the relevant code — not at the top of the file.
 

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -943,6 +943,48 @@ describe('error-source-ref-c-missing', () => {
   });
 });
 
+describe('source-ref-java-valid', () => {
+  // @lat: [[tests/check-md#Passes with valid links#Passes with Java symbol links]]
+  it('resolves Java class, method, constructor, field, nested class, interface, enum, record, and annotation type refs without errors', async () => {
+    // docs.md links: Greeter (class), Greeter#greet / Greeter#Greeter /
+    // Greeter#of (methods/constructor), Greeter#DEFAULT_NAME (field),
+    // Inner + Greeter#Inner (nested class, dual-emitted), Inner#innerMethod,
+    // Greeting (interface) + hello/bye/NAME_CONST members,
+    // Color (enum) + RED (constant) + label (method),
+    // Point (record) + x (component) + sum (method),
+    // Marker (annotation type) + value (element)
+    const { errors } = await checkMd(latDir('source-ref-java-valid'));
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe('error-source-ref-java-missing', () => {
+  it('check md reports all missing Java symbols', async () => {
+    const { errors } = await checkMd(latDir('error-source-ref-java-missing'));
+    expect(errors).toHaveLength(4);
+
+    const byTarget = new Map(errors.map((e) => [e.target, e]));
+
+    const fn = byTarget.get('src/Greeter.java#nonexistent')!;
+    expect(fn).toBeDefined();
+    expect(fn.message).toContain('symbol "nonexistent" not found');
+
+    const cls = byTarget.get('src/Greeter.java#MissingClass')!;
+    expect(cls).toBeDefined();
+    expect(cls.message).toContain('symbol "MissingClass" not found');
+
+    const cnst = byTarget.get('src/Greeter.java#MISSING_CONST')!;
+    expect(cnst).toBeDefined();
+    expect(cnst.message).toContain('symbol "MISSING_CONST" not found');
+
+    const method = byTarget.get('src/Greeter.java#Greeter#missingMethod')!;
+    expect(method).toBeDefined();
+    expect(method.message).toContain(
+      'symbol "Greeter#missingMethod" not found',
+    );
+  });
+});
+
 describe('error-source-ref-unsupported-ext', () => {
   it('check md reports unsupported extension with list of supported ones', async () => {
     const { errors } = await checkMd(

--- a/tests/cases/error-source-ref-java-missing/lat.md/docs.md
+++ b/tests/cases/error-source-ref-java-missing/lat.md/docs.md
@@ -1,0 +1,9 @@
+# Docs
+
+Missing method: [[src/Greeter.java#nonexistent]].
+
+Missing class: [[src/Greeter.java#MissingClass]].
+
+Missing const: [[src/Greeter.java#MISSING_CONST]].
+
+Missing method on class: [[src/Greeter.java#Greeter#missingMethod]].

--- a/tests/cases/error-source-ref-java-missing/src/Greeter.java
+++ b/tests/cases/error-source-ref-java-missing/src/Greeter.java
@@ -1,0 +1,9 @@
+package app;
+
+public class Greeter {
+  private String name;
+
+  public String greet() {
+    return "Hi, " + name;
+  }
+}

--- a/tests/cases/source-ref-java-valid/lat.md/docs.md
+++ b/tests/cases/source-ref-java-valid/lat.md/docs.md
@@ -1,0 +1,15 @@
+# Docs
+
+See [[src/Greeter.java#Greeter]] for the greeter class.
+
+Its method [[src/Greeter.java#Greeter#greet]], constructor [[src/Greeter.java#Greeter#Greeter]], static factory [[src/Greeter.java#Greeter#of]], and constant [[src/Greeter.java#Greeter#DEFAULT_NAME]].
+
+The nested class resolves standalone as [[src/Greeter.java#Inner]] and qualified as [[src/Greeter.java#Greeter#Inner]], with method [[src/Greeter.java#Inner#innerMethod]].
+
+The [[src/Greeter.java#Greeting]] interface has [[src/Greeter.java#Greeting#hello]], default method [[src/Greeter.java#Greeting#bye]], and constant [[src/Greeter.java#Greeting#NAME_CONST]].
+
+The [[src/Greeter.java#Color]] enum has constant [[src/Greeter.java#Color#RED]] and method [[src/Greeter.java#Color#label]].
+
+The [[src/Greeter.java#Point]] record has component [[src/Greeter.java#Point#x]] and method [[src/Greeter.java#Point#sum]].
+
+The [[src/Greeter.java#Marker]] annotation type has element [[src/Greeter.java#Marker#value]].

--- a/tests/cases/source-ref-java-valid/src/Greeter.java
+++ b/tests/cases/source-ref-java-valid/src/Greeter.java
@@ -1,0 +1,52 @@
+package app;
+
+public class Greeter implements Greeting {
+  public static final String DEFAULT_NAME = "World";
+
+  private String name;
+
+  public Greeter(String name) {
+    this.name = name;
+  }
+
+  public String greet() {
+    return "Hi, " + name;
+  }
+
+  public static Greeter of(String name) {
+    return new Greeter(name);
+  }
+
+  static class Inner {
+    void innerMethod() {}
+  }
+}
+
+interface Greeting {
+  String NAME_CONST = "greeting";
+
+  String hello();
+
+  default String bye() {
+    return "bye";
+  }
+}
+
+enum Color {
+  RED,
+  GREEN;
+
+  public String label() {
+    return name();
+  }
+}
+
+record Point(int x, int y) {
+  public int sum() {
+    return x + y;
+  }
+}
+
+@interface Marker {
+  String value() default "";
+}


### PR DESCRIPTION
## Summary

  Adds `.java` to the supported source-link languages: wiki links like
  `[[src/Greeter.java#Greeter#greet]]` now resolve, and `lat check` validates
  them — same treatment as the existing TS/JS/Python/Rust/Go/C support.

  The `tree-sitter-java.wasm` grammar was already shipped via
  `@repomix/tree-sitter-wasms`, so this adds **no new dependencies** — it wires
  up a grammar that was already in the package.

  ## Motivation

  `// @lat:` code refs already work in Java files (comment scanning is
  language-agnostic), but doc→code wiki links were rejected with *unsupported
  file extension ".java"*. For Java-heavy codebases that asymmetry means the
  lattice can't hold validated references into source, even though the Java
  grammar is already bundled with the package.

  ## What's included

  **`src/source-parser.ts`**

  - `.java` entry in `grammarMap` (`SOURCE_EXTENSIONS` and the "Supported:"
    error message pick it up automatically)
  - `extractJavaSymbols()` + a recursive scope walker, following the structure
    of the existing extractors

  **Symbols extracted**

  - Types: `class`, `interface`, `enum`, `record`, `@interface` (annotation
    type) — top-level and nested
  - Members (`#Type#member`): methods, constructors, fields (incl.
    multi-declarator `int a, b;`), interface constants, enum constants, record
    components, annotation type elements
  - Nested types are dual-emitted so both `[[File.java#Inner]]` and
    `[[File.java#Outer#Inner]]` resolve — the same approach `extractCSymbols`
    uses for enum members

  **Kind mapping:** `class`/`record`/`enum` → `class`, `interface`/`@interface`
  → `interface`, enum constants and interface constants → `const`, fields and
  record components → `variable`, methods/constructors/annotation elements →
  `method`.

  **Tests**

  - `tests/cases/source-ref-java-valid/` — 18 link kinds across all type/member
    forms, mirroring the Go/Rust fixtures
  - `tests/cases/error-source-ref-java-missing/` — 4 missing-symbol cases
    asserting the standard error messages
  - Spec section added to `lat.md/tests/check-md.md` with the corresponding
    `@lat:` ref (`require-code-mention` satisfied)

  **Docs** — Java added to the language lists in `templates/AGENTS.md`,
  `templates/cursor-rules.md`, `templates/skill/SKILL.md`, and
  `lat.md/markdown.md` (incl. a Java example bullet and a Java-symbols
  paragraph).

  ## Design notes / limitations

  - Symbol paths stay within the existing two-level limit, so
    `#Outer#Inner#method` does not resolve — consistent with the other
    languages. Members of nested types resolve via the standalone form
    (`#Inner#method`).
  - Overload resolution is name-based (existence check), like all other
    languages.
  - `lat section` doesn't surface Java source symbols — verified this matches
    current behavior for Go/C, so it's parity, not a regression.

  ## Testing

  - `tests/cases.test.ts`: 101/101 pass (99 existing + 2 new suites)
  - Repo self-check (`lat check`) passes
  - `tsc --noEmit` error count unchanged vs `main` (verified by stashing the
    diff)
