### PR TITLE
Add `lat check links` to validate relative markdown links

### DIFF
--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -63,7 +63,7 @@ Core logic in [[src/cli/refs.ts#findRefs]] (returns structured result), used by 
 
 Validation command group. Runs all checks when invoked without a subcommand.
 
-Usage: `lat check [md|code-refs|links|index|sections]`
+Usage: `lat check [md|links|code-refs|index|sections]`
 
 Emits a stale-init warning before any errors so the user sees setup issues first. The init version check compares `INIT_VERSION` in [[src/init-version.ts]] against the version in `lat.md/.cache/lat_init.json` written by [[cli#init]]. Missing LLM key warning appears only when all checks pass. If the total check took longer than one second and ripgrep is not installed, shows a tip suggesting the user install it for faster scanning. The first output line ("Scanned ...") includes the total elapsed time (e.g. "in 250ms" or "in 1.2s").
 
@@ -73,18 +73,16 @@ Implementation: [[src/cli/check.ts]]
 
 Validate that all [[parser#Wiki Links]] in `lat.md` markdown files point to existing sections.
 
+### links
+
+Validate that ordinary markdown links (`[text](path)`) in `lat.md/` files point to files that exist. See [[markdown#Relative Links]] for which destinations are checked and which are skipped.
+
 ### code-refs
 
 Two validations:
 
 1. Every `// @lat: [[...]]` or `# @lat: [[...]]` comment in source code must point to a real section in `lat.md/`
 2. For files with [[markdown#Frontmatter#require-code-mention]], every leaf section must be referenced by at least one `// @lat:` comment in the codebase
-
-### links
-
-Validate that ordinary markdown links (`[text](path)`) in `lat.md/` files point to files that exist — see [[markdown#Relative Links]] for the rules on what is and is not checked.
-
-Targets resolve against the containing file's directory, and existence on disk is the only test, so a link that deliberately leaves `lat.md/` (`../../AGENTS.md`) is validated the same way. Images and reference definitions are checked alongside inline links; a broken image is reported as a broken image.
 
 ### sections
 

--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -63,7 +63,7 @@ Core logic in [[src/cli/refs.ts#findRefs]] (returns structured result), used by 
 
 Validation command group. Runs all checks when invoked without a subcommand.
 
-Usage: `lat check [md|code-refs|index|sections]`
+Usage: `lat check [md|code-refs|links|index|sections]`
 
 Emits a stale-init warning before any errors so the user sees setup issues first. The init version check compares `INIT_VERSION` in [[src/init-version.ts]] against the version in `lat.md/.cache/lat_init.json` written by [[cli#init]]. Missing LLM key warning appears only when all checks pass. If the total check took longer than one second and ripgrep is not installed, shows a tip suggesting the user install it for faster scanning. The first output line ("Scanned ...") includes the total elapsed time (e.g. "in 250ms" or "in 1.2s").
 
@@ -79,6 +79,12 @@ Two validations:
 
 1. Every `// @lat: [[...]]` or `# @lat: [[...]]` comment in source code must point to a real section in `lat.md/`
 2. For files with [[markdown#Frontmatter#require-code-mention]], every leaf section must be referenced by at least one `// @lat:` comment in the codebase
+
+### links
+
+Validate that ordinary markdown links (`[text](path)`) in `lat.md/` files point to files that exist — see [[markdown#Relative Links]] for the rules on what is and is not checked.
+
+Targets resolve against the containing file's directory, and existence on disk is the only test, so a link that deliberately leaves `lat.md/` (`../../AGENTS.md`) is validated the same way. Images and reference definitions are checked alongside inline links; a broken image is reported as a broken image.
 
 ### sections
 

--- a/lat.md/markdown.md
+++ b/lat.md/markdown.md
@@ -64,15 +64,15 @@ Source code is parsed lazily with tree-sitter (via `web-tree-sitter`). Only file
 
 Ordinary markdown links (`[text](path)`) to local files are validated for existence, so a moved or deleted file is caught the same way a stale `[[wiki link]]` is.
 
-Targets resolve against the containing file's directory — the rule every markdown renderer applies — and existence on disk is the only test. A link pointing outside `lat.md/` (`../../AGENTS.md`) is therefore checked too. Inline links, images, and reference definitions (`[id]: ./path.md`) all participate. Because validation walks the mdast rather than matching text, a link inside a fenced or inline code block is correctly ignored.
+Targets resolve against the containing file's directory, and existence on disk is the only test — a link that leaves `lat.md/` (`../../AGENTS.md`) is checked like any other. Inline links, images, and reference definitions (`[id]: ./path.md`) all participate; a link inside a code block does not.
 
-These destinations are never treated as paths, and never reported:
+Destinations that are not local paths are skipped and never reported:
 
-- **Any URI scheme** — `https:`, `mailto:`, `tel:`, custom app schemes. A Windows absolute path (`C:/notes.md`) matches this rule and is skipped rather than misread as a relative path.
-- **Root-absolute** — `/img/logo.png`, and protocol-relative `//example.com/x`. Ambiguous between a site root and the filesystem root, so checking either way would invent false positives.
-- **Pure fragments** — `#section`, an anchor within the same file.
+- **Any URI scheme** — `https:`, `mailto:`, and a Windows absolute path like `C:/notes.md`.
+- **Root-absolute and protocol-relative** — `/img/logo.png`, `//example.com/x`. Ambiguous between a site root and the filesystem root.
+- **Bare fragments** — `#section`.
 
-A `?query` and `#fragment` are dropped before resolving, so `foo.md#some-heading` verifies that `foo.md` exists and `?tab=1` alone is skipped. The anchor itself is not validated — matching a heading to its slug depends on the target renderer's own anchor rules.
+A `?query` and `#fragment` are dropped before resolving, so `foo.md#some-heading` only checks that `foo.md` exists. The anchor itself is not validated — heading slugs depend on the rendering tool.
 
 Validated by [[cli#check#links]].
 

--- a/lat.md/markdown.md
+++ b/lat.md/markdown.md
@@ -60,6 +60,22 @@ Source code is parsed lazily with tree-sitter (via `web-tree-sitter`). Only file
 
 **Lenient** — `lat locate` and `lat expand` use `findSections()`, which applies tiered matching (exact → file stem → subsection tail → fuzzy). These commands are for interactive exploration and accept approximate queries.
 
+## Relative Links
+
+Ordinary markdown links (`[text](path)`) to local files are validated for existence, so a moved or deleted file is caught the same way a stale `[[wiki link]]` is.
+
+Targets resolve against the containing file's directory — the rule every markdown renderer applies — and existence on disk is the only test. A link pointing outside `lat.md/` (`../../AGENTS.md`) is therefore checked too. Inline links, images, and reference definitions (`[id]: ./path.md`) all participate. Because validation walks the mdast rather than matching text, a link inside a fenced or inline code block is correctly ignored.
+
+These destinations are never treated as paths, and never reported:
+
+- **Any URI scheme** — `https:`, `mailto:`, `tel:`, custom app schemes. A Windows absolute path (`C:/notes.md`) matches this rule and is skipped rather than misread as a relative path.
+- **Root-absolute** — `/img/logo.png`, and protocol-relative `//example.com/x`. Ambiguous between a site root and the filesystem root, so checking either way would invent false positives.
+- **Pure fragments** — `#section`, an anchor within the same file.
+
+A `?query` and `#fragment` are dropped before resolving, so `foo.md#some-heading` verifies that `foo.md` exists and `?tab=1` alone is skipped. The anchor itself is not validated — matching a heading to its slug depends on the target renderer's own anchor rules.
+
+Validated by [[cli#check#links]].
+
 ## Leading Paragraph
 
 Every section must have a leading paragraph — at least one sentence immediately after the heading, before any child headings.

--- a/lat.md/tests/check-links.md
+++ b/lat.md/tests/check-links.md
@@ -9,11 +9,11 @@ Tests for validating ordinary markdown links to local files in `lat.md/` files.
 
 ## Detects broken relative links
 
-Given links whose targets do not exist on disk, [[cli#check#links]] should report one error per broken target — covering the bare, `./`, `../`, and outside-the-graph forms.
+Given links whose targets do not exist on disk, [[cli#check#links]] should report one error per broken destination, at the line it was written on.
 
-## Reports anchors and images distinctly
+## Names the resolved file and the link kind
 
-Given an anchored link, [[cli#check#links]] should validate only the file part and name it in the error; given a broken image, it should report a broken image rather than a broken link.
+Given an anchored link, [[cli#check#links]] should name the file it resolved to, without the anchor; given a broken image, it should say image rather than link.
 
 ## Passes valid and skipped link forms
 

--- a/lat.md/tests/check-links.md
+++ b/lat.md/tests/check-links.md
@@ -1,0 +1,20 @@
+---
+lat:
+  require-code-mention: true
+---
+
+# Check Links
+
+Tests for validating ordinary markdown links to local files in `lat.md/` files.
+
+## Detects broken relative links
+
+Given links whose targets do not exist on disk, [[cli#check#links]] should report one error per broken target — covering the bare, `./`, `../`, and outside-the-graph forms.
+
+## Reports anchors and images distinctly
+
+Given an anchored link, [[cli#check#links]] should validate only the file part and name it in the error; given a broken image, it should report a broken image rather than a broken link.
+
+## Passes valid and skipped link forms
+
+Given links that resolve — including one leaving the graph directory and one resolved against a nested file's own directory — and destinations that are not local paths, [[cli#check#links]] should report no errors.

--- a/lat.md/tests/tests.md
+++ b/lat.md/tests/tests.md
@@ -16,6 +16,7 @@ Shared patterns for writing and organizing tests in this project.
 - [[ref-extraction]] — Extracting wiki link references from markdown files
 - [[section-preview]] — Formatting section previews for terminal output
 - [[check-md]] — Validating wiki links in lat.md markdown files
+- [[check-links]] — Validating relative markdown links to local files
 - [[check-code-refs]] — Validating @lat code references and coverage
 - [[locate]] — Finding sections by exact, subsection, and fuzzy matching
 - [[refs-e2e]] — End-to-end tests for the refs command

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -1,9 +1,10 @@
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { basename, dirname, extname, join, relative } from 'node:path';
+import { basename, dirname, extname, join, relative, resolve } from 'node:path';
 import {
   listLatticeFiles,
   loadAllSections,
+  extractLinks,
   extractRefs,
   flattenSections,
   parseFrontmatter,
@@ -14,7 +15,7 @@ import {
 } from '../lattice.js';
 import { scanCodeRefs } from '../code-refs.js';
 import { SOURCE_EXTENSIONS, clearSymbolCache } from '../source-parser.js';
-import { walkEntries } from '../walk.js';
+import { toPosix, walkEntries } from '../walk.js';
 import type { CmdContext, CmdResult, Styler } from '../context.js';
 import { INIT_VERSION, readInitVersion } from '../init-version.js';
 
@@ -181,6 +182,99 @@ export async function checkMd(latticeDir: string): Promise<CheckResult> {
   }
 
   return { errors, files: countByExt(files) };
+}
+
+// --- Relative link validation ---
+
+/** Matches a URI scheme prefix (`https:`, `mailto:`, `obsidian:`, …). */
+const URI_SCHEME = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+/**
+ * Whether a link destination denotes a path on disk that can be checked for
+ * existence. Everything else is out of scope and must never be reported:
+ *
+ * - **any URI scheme** — `https:`, `mailto:`, `tel:`, custom app schemes. This
+ *   also covers a Windows absolute path (`C:/notes.md`), which is skipped
+ *   rather than misread as a relative one.
+ * - **root-absolute** (`/img/logo.png`, and protocol-relative `//host/x`) —
+ *   ambiguous between a site root and the filesystem root, so resolving it
+ *   either way would invent false positives.
+ * - **pure fragment** (`#section`) — an anchor within the same file.
+ * - **empty**.
+ */
+function isLocalPathLink(url: string): boolean {
+  const u = url.trim();
+  if (u === '') return false;
+  if (u.startsWith('#')) return false;
+  if (u.startsWith('/')) return false;
+  return !URI_SCHEME.test(u);
+}
+
+/**
+ * Convert a link destination to the path it denotes on disk, dropping the
+ * `?query` and `#fragment` a URL may carry. Returns `''` when nothing but those
+ * remain (`?tab=1`), which the caller treats as having no path to check.
+ *
+ * Both are stripped *before* percent-decoding: `%23` decodes to a literal `#`
+ * and `%3F` to a `?`, so decoding first would split the path at a character
+ * that is part of the filename. A malformed escape (a stray `%`) is left as
+ * authored rather than throwing.
+ */
+function linkTargetToPath(url: string): string {
+  const hashIdx = url.indexOf('#');
+  const withoutFragment = hashIdx === -1 ? url : url.slice(0, hashIdx);
+  const queryIdx = withoutFragment.indexOf('?');
+  const path =
+    queryIdx === -1 ? withoutFragment : withoutFragment.slice(0, queryIdx);
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+/**
+ * Validate ordinary markdown links (`[text](path)`) in `lat.md/` files that
+ * point at local files. Wiki links are validated by [[src/cli/check.ts#checkMd]];
+ * this covers the plain-markdown half of the graph, which is otherwise
+ * unprotected against rot.
+ *
+ * Targets resolve against the containing file's directory — the same rule every
+ * markdown renderer applies — and existence on disk is the whole test, so a
+ * link that legitimately leaves `lat.md/` (`../../AGENTS.md`) is checked too.
+ * An anchor is dropped before resolving: `foo.md#heading` verifies `foo.md`.
+ */
+export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
+  const files = await listLatticeFiles(latticeDir);
+  const errors: CheckError[] = [];
+
+  for (const file of files) {
+    const content = await readFile(file, 'utf-8');
+    const relPath = relative(process.cwd(), file);
+
+    for (const link of extractLinks(content)) {
+      if (!isLocalPathLink(link.url)) continue;
+
+      const target = linkTargetToPath(link.url);
+      // Nothing but a query and/or fragment — no path to check.
+      if (target === '') continue;
+
+      const abs = resolve(dirname(file), target);
+      if (existsSync(abs)) continue;
+
+      const shown = toPosix(relative(process.cwd(), abs));
+      errors.push({
+        file: relPath,
+        line: link.line,
+        target: link.url,
+        message:
+          `broken ${link.kind === 'image' ? 'image' : 'link'} ` +
+          `(${link.url}) — "${shown}" does not exist`,
+      });
+    }
+  }
+
+  return errors;
 }
 
 export async function checkCodeRefs(latticeDir: string): Promise<CheckResult> {
@@ -487,11 +581,14 @@ export async function checkAllCommand(ctx: CmdContext): Promise<CmdResult> {
   const startTime = Date.now();
   const md = await checkMd(ctx.latDir);
   const code = await checkCodeRefs(ctx.latDir);
+  const linkErrors = await checkLinks(ctx.latDir);
   const indexErrors = await checkIndex(ctx.latDir);
   const sectionErrors = await checkSections(ctx.latDir);
   const elapsed = Date.now() - startTime;
 
-  const allErrors = [...md.errors, ...code.errors];
+  // `checkLinks` re-reads the same lat.md/ files as `checkMd`, so its errors
+  // are merged but its file counts are not — they would double the scan total.
+  const allErrors = [...md.errors, ...code.errors, ...linkErrors];
   const allFiles: FileStats = { ...md.files };
   for (const [ext, n] of Object.entries(code.files)) {
     allFiles[ext] = (allFiles[ext] || 0) + n;
@@ -589,6 +686,22 @@ export async function checkCodeRefsCommand(
   }
 
   lines.push(s.green('code-refs: All references OK'));
+  return { output: lines.join('\n') };
+}
+
+export async function checkLinksCommand(ctx: CmdContext): Promise<CmdResult> {
+  const errors = await checkLinks(ctx.latDir);
+  const s = ctx.styler;
+  const lines: string[] = [];
+
+  lines.push(...formatCheckErrors(errors, s));
+
+  if (errors.length > 0) {
+    lines.push(formatErrorCount(errors.length, s));
+    return { output: lines.join('\n'), isError: true };
+  }
+
+  lines.push(s.green('links: All relative links resolve'));
   return { output: lines.join('\n') };
 }
 

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -15,7 +15,7 @@ import {
 } from '../lattice.js';
 import { scanCodeRefs } from '../code-refs.js';
 import { SOURCE_EXTENSIONS, clearSymbolCache } from '../source-parser.js';
-import { toPosix, walkEntries } from '../walk.js';
+import { walkEntries } from '../walk.js';
 import type { CmdContext, CmdResult, Styler } from '../context.js';
 import { INIT_VERSION, readInitVersion } from '../init-version.js';
 
@@ -186,64 +186,28 @@ export async function checkMd(latticeDir: string): Promise<CheckResult> {
 
 // --- Relative link validation ---
 
-/** Matches a URI scheme prefix (`https:`, `mailto:`, `obsidian:`, …). */
-const URI_SCHEME = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
-
 /**
- * Whether a link destination denotes a path on disk that can be checked for
- * existence. Everything else is out of scope and must never be reported:
- *
- * - **any URI scheme** — `https:`, `mailto:`, `tel:`, custom app schemes. This
- *   also covers a Windows absolute path (`C:/notes.md`), which is skipped
- *   rather than misread as a relative one.
- * - **root-absolute** (`/img/logo.png`, and protocol-relative `//host/x`) —
- *   ambiguous between a site root and the filesystem root, so resolving it
- *   either way would invent false positives.
- * - **pure fragment** (`#section`) — an anchor within the same file.
- * - **empty**.
+ * The on-disk path a markdown link destination denotes, or null when it denotes
+ * none: a URI scheme (`https:`, `mailto:`, and a Windows `C:/x` drive letter),
+ * a root-absolute or protocol-relative path (ambiguous between the site root
+ * and the filesystem root), or a bare `#anchor` / `?query`.
  */
-function isLocalPathLink(url: string): boolean {
+function linkPath(url: string): string | null {
   const u = url.trim();
-  if (u === '') return false;
-  if (u.startsWith('#')) return false;
-  if (u.startsWith('/')) return false;
-  return !URI_SCHEME.test(u);
-}
+  if (u.startsWith('#') || u.startsWith('/')) return null;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(u)) return null;
 
-/**
- * Convert a link destination to the path it denotes on disk, dropping the
- * `?query` and `#fragment` a URL may carry. Returns `''` when nothing but those
- * remain (`?tab=1`), which the caller treats as having no path to check.
- *
- * Both are stripped *before* percent-decoding: `%23` decodes to a literal `#`
- * and `%3F` to a `?`, so decoding first would split the path at a character
- * that is part of the filename. A malformed escape (a stray `%`) is left as
- * authored rather than throwing.
- */
-function linkTargetToPath(url: string): string {
-  const hashIdx = url.indexOf('#');
-  const withoutFragment = hashIdx === -1 ? url : url.slice(0, hashIdx);
-  const queryIdx = withoutFragment.indexOf('?');
-  const path =
-    queryIdx === -1 ? withoutFragment : withoutFragment.slice(0, queryIdx);
+  // Split before decoding: `%23` and `%3F` decode to `#` and `?`, which would
+  // then truncate a filename that legitimately contains them.
+  const path = u.split(/[?#]/)[0];
+  if (path === '') return null;
   try {
     return decodeURIComponent(path);
   } catch {
-    return path;
+    return path; // Malformed escape — check it as authored rather than throw.
   }
 }
 
-/**
- * Validate ordinary markdown links (`[text](path)`) in `lat.md/` files that
- * point at local files. Wiki links are validated by [[src/cli/check.ts#checkMd]];
- * this covers the plain-markdown half of the graph, which is otherwise
- * unprotected against rot.
- *
- * Targets resolve against the containing file's directory — the same rule every
- * markdown renderer applies — and existence on disk is the whole test, so a
- * link that legitimately leaves `lat.md/` (`../../AGENTS.md`) is checked too.
- * An anchor is dropped before resolving: `foo.md#heading` verifies `foo.md`.
- */
 export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
   const files = await listLatticeFiles(latticeDir);
   const errors: CheckError[] = [];
@@ -253,23 +217,19 @@ export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
     const relPath = relative(process.cwd(), file);
 
     for (const link of extractLinks(content)) {
-      if (!isLocalPathLink(link.url)) continue;
-
-      const target = linkTargetToPath(link.url);
-      // Nothing but a query and/or fragment — no path to check.
-      if (target === '') continue;
+      const target = linkPath(link.url);
+      if (target === null) continue;
 
       const abs = resolve(dirname(file), target);
       if (existsSync(abs)) continue;
 
-      const shown = toPosix(relative(process.cwd(), abs));
+      const kind = link.kind === 'image' ? 'image' : 'link';
+      const shown = relative(process.cwd(), abs);
       errors.push({
         file: relPath,
         line: link.line,
         target: link.url,
-        message:
-          `broken ${link.kind === 'image' ? 'image' : 'link'} ` +
-          `(${link.url}) — "${shown}" does not exist`,
+        message: `broken ${kind} (${link.url}) — file "${shown}" not found`,
       });
     }
   }
@@ -580,15 +540,13 @@ function formatErrorCount(count: number, s: Styler): string {
 export async function checkAllCommand(ctx: CmdContext): Promise<CmdResult> {
   const startTime = Date.now();
   const md = await checkMd(ctx.latDir);
-  const code = await checkCodeRefs(ctx.latDir);
   const linkErrors = await checkLinks(ctx.latDir);
+  const code = await checkCodeRefs(ctx.latDir);
   const indexErrors = await checkIndex(ctx.latDir);
   const sectionErrors = await checkSections(ctx.latDir);
   const elapsed = Date.now() - startTime;
 
-  // `checkLinks` re-reads the same lat.md/ files as `checkMd`, so its errors
-  // are merged but its file counts are not — they would double the scan total.
-  const allErrors = [...md.errors, ...code.errors, ...linkErrors];
+  const allErrors = [...md.errors, ...linkErrors, ...code.errors];
   const allFiles: FileStats = { ...md.files };
   for (const [ext, n] of Object.entries(code.files)) {
     allFiles[ext] = (allFiles[ext] || 0) + n;
@@ -671,6 +629,22 @@ export async function checkMdCommand(ctx: CmdContext): Promise<CmdResult> {
   return { output: lines.join('\n') };
 }
 
+export async function checkLinksCommand(ctx: CmdContext): Promise<CmdResult> {
+  const errors = await checkLinks(ctx.latDir);
+  const s = ctx.styler;
+  const lines: string[] = [];
+
+  lines.push(...formatCheckErrors(errors, s));
+
+  if (errors.length > 0) {
+    lines.push(formatErrorCount(errors.length, s));
+    return { output: lines.join('\n'), isError: true };
+  }
+
+  lines.push(s.green('links: All relative links resolve'));
+  return { output: lines.join('\n') };
+}
+
 export async function checkCodeRefsCommand(
   ctx: CmdContext,
 ): Promise<CmdResult> {
@@ -686,22 +660,6 @@ export async function checkCodeRefsCommand(
   }
 
   lines.push(s.green('code-refs: All references OK'));
-  return { output: lines.join('\n') };
-}
-
-export async function checkLinksCommand(ctx: CmdContext): Promise<CmdResult> {
-  const errors = await checkLinks(ctx.latDir);
-  const s = ctx.styler;
-  const lines: string[] = [];
-
-  lines.push(...formatCheckErrors(errors, s));
-
-  if (errors.length > 0) {
-    lines.push(formatErrorCount(errors.length, s));
-    return { output: lines.join('\n'), isError: true };
-  }
-
-  lines.push(s.green('links: All relative links resolve'));
   return { output: lines.join('\n') };
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -102,21 +102,21 @@ check
   });
 
 check
+  .command('links')
+  .description('Validate relative markdown links in lat.md')
+  .action(async () => {
+    const ctx = resolveContext(program.opts());
+    const { checkLinksCommand } = await import('./check.js');
+    handleResult(await checkLinksCommand(ctx));
+  });
+
+check
   .command('code-refs')
   .description('Validate @lat code references and coverage')
   .action(async () => {
     const ctx = resolveContext(program.opts());
     const { checkCodeRefsCommand } = await import('./check.js');
     handleResult(await checkCodeRefsCommand(ctx));
-  });
-
-check
-  .command('links')
-  .description('Validate relative markdown links to local files')
-  .action(async () => {
-    const ctx = resolveContext(program.opts());
-    const { checkLinksCommand } = await import('./check.js');
-    handleResult(await checkLinksCommand(ctx));
   });
 
 check

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -111,6 +111,15 @@ check
   });
 
 check
+  .command('links')
+  .description('Validate relative markdown links to local files')
+  .action(async () => {
+    const ctx = resolveContext(program.opts());
+    const { checkLinksCommand } = await import('./check.js');
+    handleResult(await checkLinksCommand(ctx));
+  });
+
+check
   .command('index')
   .description('Validate directory index files in lat.md')
   .action(async () => {

--- a/src/lattice.ts
+++ b/src/lattice.ts
@@ -35,7 +35,7 @@ export type Ref = {
 
 /** An ordinary markdown link, image, or reference definition. */
 export type MdLink = {
-  /** Destination exactly as authored — percent-escapes, query and fragment intact. */
+  /** Destination exactly as authored, percent-escapes and all. */
   url: string;
   kind: 'link' | 'image' | 'definition';
   line: number;
@@ -702,23 +702,17 @@ export function extractRefs(
 }
 
 /**
- * Extract every ordinary markdown link destination: inline links, images, and
- * reference definitions. Wiki links are a distinct node type and are handled by
- * [[src/lattice.ts#extractRefs]] instead.
- *
- * Destinations are returned verbatim — deciding which denote a path on disk is
- * the caller's job. Walking the mdast (rather than matching `[..](..)` with a
- * regex) is what keeps destinations inside fenced and inline code out of the
- * results: a code sample showing `[x](./missing.md)` documents a link, it is
- * not one.
+ * Extract ordinary markdown link destinations; wiki links are a separate node
+ * type, handled by `extractRefs`. Walking the mdast rather than regex-matching
+ * `[..](..)` is what keeps links inside code samples out of the results.
  */
 export function extractLinks(content: string): MdLink[] {
   const tree = parse(content);
   const links: MdLink[] = [];
 
   visit(tree, ['link', 'image', 'definition'], (node) => {
-    const n = node as Link | Image | Definition;
-    links.push({ url: n.url, kind: n.type, line: n.position!.start.line });
+    const { url, type, position } = node as Link | Image | Definition;
+    links.push({ url, kind: type, line: position!.start.line });
   });
 
   return links;

--- a/src/lattice.ts
+++ b/src/lattice.ts
@@ -4,7 +4,14 @@ import { existsSync, statSync } from 'node:fs';
 import { parse } from './parser.js';
 import { toPosix, walkEntries } from './walk.js';
 import { visit } from 'unist-util-visit';
-import type { Heading, RootContent, Text } from 'mdast';
+import type {
+  Definition,
+  Heading,
+  Image,
+  Link,
+  RootContent,
+  Text,
+} from 'mdast';
 import type { WikiLink } from './extensions/wiki-link/types.js';
 
 export type Section = {
@@ -23,6 +30,14 @@ export type Ref = {
   target: string;
   fromSection: string;
   file: string;
+  line: number;
+};
+
+/** An ordinary markdown link, image, or reference definition. */
+export type MdLink = {
+  /** Destination exactly as authored — percent-escapes, query and fragment intact. */
+  url: string;
+  kind: 'link' | 'image' | 'definition';
   line: number;
 };
 
@@ -684,4 +699,27 @@ export function extractRefs(
   });
 
   return refs;
+}
+
+/**
+ * Extract every ordinary markdown link destination: inline links, images, and
+ * reference definitions. Wiki links are a distinct node type and are handled by
+ * [[src/lattice.ts#extractRefs]] instead.
+ *
+ * Destinations are returned verbatim — deciding which denote a path on disk is
+ * the caller's job. Walking the mdast (rather than matching `[..](..)` with a
+ * regex) is what keeps destinations inside fenced and inline code out of the
+ * results: a code sample showing `[x](./missing.md)` documents a link, it is
+ * not one.
+ */
+export function extractLinks(content: string): MdLink[] {
+  const tree = parse(content);
+  const links: MdLink[] = [];
+
+  visit(tree, ['link', 'image', 'definition'], (node) => {
+    const n = node as Link | Image | Definition;
+    links.push({ url: n.url, kind: n.type, line: n.position!.start.line });
+  });
+
+  return links;
 }

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -18,6 +18,7 @@ import {
   checkMd,
   checkCodeRefs,
   checkIndex,
+  checkLinks,
   checkSections,
 } from '../src/cli/check.js';
 import { scanCodeRefs } from '../src/code-refs.js';
@@ -344,6 +345,46 @@ describe('valid-links', () => {
   it('check md passes when all links resolve', async () => {
     const { errors } = await checkMd(latDir('valid-links'));
     expect(errors).toHaveLength(0);
+  });
+});
+
+// --- md-links ---
+
+describe('error-md-links', () => {
+  // @lat: [[check-links#Detects broken relative links]]
+  it('check links flags every relative form whose target is missing', async () => {
+    const errors = await checkLinks(latDir('error-md-links'));
+    expect(errors.map((e) => e.target)).toEqual([
+      'does-not-exist.md',
+      './does-not-exist.md',
+      '../does-not-exist.md',
+      './does-not-exist.md#Heading',
+      './does-not-exist.svg',
+    ]);
+    expect(errors[0].line).toBe(5);
+  });
+
+  // @lat: [[check-links#Reports anchors and images distinctly]]
+  it('check links drops the anchor when resolving and names images as images', async () => {
+    const errors = await checkLinks(latDir('error-md-links'));
+    const anchored = errors.find((e) => e.target.includes('#Heading'))!;
+    // The anchor is not part of the path, so the resolved file is reported
+    // without it. Whether `#Heading` itself exists is not validated.
+    expect(anchored.message).toContain('does-not-exist.md" does not exist');
+    expect(anchored.message).not.toContain('#Heading"');
+
+    const image = errors.find((e) => e.target.endsWith('.svg'))!;
+    expect(image.message).toContain('broken image');
+  });
+});
+
+// --- valid-md-links ---
+
+describe('valid-md-links', () => {
+  // @lat: [[check-links#Passes valid and skipped link forms]]
+  it('check links resolves local targets and skips non-path destinations', async () => {
+    const errors = await checkLinks(latDir('valid-md-links'));
+    expect(errors.map((e) => `${e.file}:${e.line} ${e.target}`)).toEqual([]);
   });
 });
 

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -352,29 +352,30 @@ describe('valid-links', () => {
 
 describe('error-md-links', () => {
   // @lat: [[check-links#Detects broken relative links]]
-  it('check links flags every relative form whose target is missing', async () => {
+  it('check links reports every broken destination at its line', async () => {
     const errors = await checkLinks(latDir('error-md-links'));
-    expect(errors.map((e) => e.target)).toEqual([
-      'does-not-exist.md',
-      './does-not-exist.md',
-      '../does-not-exist.md',
-      './does-not-exist.md#Heading',
-      './does-not-exist.svg',
+    expect(errors.map((e) => `${e.line}: ${e.target}`)).toEqual([
+      '5: does-not-exist.md',
+      '6: ./does-not-exist.md',
+      '7: ../does-not-exist.md',
+      '8: ./does-not-exist.md#Heading',
+      '9: ./50%.md',
+      '10: ./does-not-exist.svg',
+      '13: ./does-not-exist-def.md',
     ]);
-    expect(errors[0].line).toBe(5);
   });
 
-  // @lat: [[check-links#Reports anchors and images distinctly]]
-  it('check links drops the anchor when resolving and names images as images', async () => {
+  // @lat: [[check-links#Names the resolved file and the link kind]]
+  it('check links names the resolved file, with the anchor dropped', async () => {
     const errors = await checkLinks(latDir('error-md-links'));
-    const anchored = errors.find((e) => e.target.includes('#Heading'))!;
-    // The anchor is not part of the path, so the resolved file is reported
-    // without it. Whether `#Heading` itself exists is not validated.
-    expect(anchored.message).toContain('does-not-exist.md" does not exist');
-    expect(anchored.message).not.toContain('#Heading"');
+    const byTarget = new Map(errors.map((e) => [e.target, e]));
 
-    const image = errors.find((e) => e.target.endsWith('.svg'))!;
-    expect(image.message).toContain('broken image');
+    expect(byTarget.get('./does-not-exist.md#Heading')!.message).toContain(
+      'does-not-exist.md" not found',
+    );
+    expect(byTarget.get('./does-not-exist.svg')!.message).toContain(
+      'broken image',
+    );
   });
 });
 
@@ -384,7 +385,7 @@ describe('valid-md-links', () => {
   // @lat: [[check-links#Passes valid and skipped link forms]]
   it('check links resolves local targets and skips non-path destinations', async () => {
     const errors = await checkLinks(latDir('valid-md-links'));
-    expect(errors.map((e) => `${e.file}:${e.line} ${e.target}`)).toEqual([]);
+    expect(errors.map((e) => e.target)).toEqual([]);
   });
 });
 

--- a/tests/cases/error-md-links/lat.md/a.md
+++ b/tests/cases/error-md-links/lat.md/a.md
@@ -1,0 +1,9 @@
+# Alpha
+
+Broken links of every relative shape.
+
+- [bare](does-not-exist.md)
+- [dot slash](./does-not-exist.md)
+- [parent](../does-not-exist.md)
+- [anchored](./does-not-exist.md#Heading)
+- ![image](./does-not-exist.svg)

--- a/tests/cases/error-md-links/lat.md/a.md
+++ b/tests/cases/error-md-links/lat.md/a.md
@@ -6,4 +6,8 @@ Broken links of every relative shape.
 - [dot slash](./does-not-exist.md)
 - [parent](../does-not-exist.md)
 - [anchored](./does-not-exist.md#Heading)
+- [stray percent](./50%.md)
 - ![image](./does-not-exist.svg)
+- [reference][def]
+
+[def]: ./does-not-exist-def.md

--- a/tests/cases/valid-md-links/lat.md/a.md
+++ b/tests/cases/valid-md-links/lat.md/a.md
@@ -1,0 +1,23 @@
+# Alpha
+
+Every link form that must resolve, and every form that must be skipped.
+
+- [bare](b.md)
+- [dot slash](./b.md)
+- [nested](./sub/c.md)
+- [outside the graph](../outside.md)
+- [anchored](b.md#Bravo)
+- [with a query](b.md?raw=1)
+- [encoded space](./has%20space.md)
+- ![image](../logo.svg)
+
+Skipped forms:
+
+- [https](https://example.com/nope.md)
+- [mailto](mailto:nobody@example.com)
+- [protocol relative](//example.com/nope.md)
+- [root absolute](/nope.md)
+- [pure anchor](#alpha)
+- [query only](?tab=1)
+
+Code is not a link: `[fake](./nope.md)`

--- a/tests/cases/valid-md-links/lat.md/a.md
+++ b/tests/cases/valid-md-links/lat.md/a.md
@@ -3,21 +3,24 @@
 Every link form that must resolve, and every form that must be skipped.
 
 - [bare](b.md)
-- [dot slash](./b.md)
 - [nested](./sub/c.md)
 - [outside the graph](../outside.md)
 - [anchored](b.md#Bravo)
 - [with a query](b.md?raw=1)
 - [encoded space](./has%20space.md)
+- [reference][bravo]
 - ![image](../logo.svg)
 
 Skipped forms:
 
 - [https](https://example.com/nope.md)
 - [mailto](mailto:nobody@example.com)
+- [windows drive](C:/nope.md)
 - [protocol relative](//example.com/nope.md)
 - [root absolute](/nope.md)
 - [pure anchor](#alpha)
 - [query only](?tab=1)
 
 Code is not a link: `[fake](./nope.md)`
+
+[bravo]: ./b.md

--- a/tests/cases/valid-md-links/lat.md/b.md
+++ b/tests/cases/valid-md-links/lat.md/b.md
@@ -1,0 +1,3 @@
+# Bravo
+
+A sibling target inside the graph.

--- a/tests/cases/valid-md-links/lat.md/has space.md
+++ b/tests/cases/valid-md-links/lat.md/has space.md
@@ -1,0 +1,3 @@
+# Has Space
+
+A target whose name needs percent-encoding in a link.

--- a/tests/cases/valid-md-links/lat.md/sub/c.md
+++ b/tests/cases/valid-md-links/lat.md/sub/c.md
@@ -1,0 +1,6 @@
+# Charlie
+
+A nested file linking back up, to prove targets resolve against the
+containing file's directory rather than the graph root.
+
+- [up to bravo](../b.md)

--- a/tests/cases/valid-md-links/lat.md/sub/c.md
+++ b/tests/cases/valid-md-links/lat.md/sub/c.md
@@ -1,6 +1,5 @@
 # Charlie
 
-A nested file linking back up, to prove targets resolve against the
-containing file's directory rather than the graph root.
+A nested file linking back up, to prove targets resolve against the containing file's directory rather than the graph root.
 
 - [up to bravo](../b.md)

--- a/tests/cases/valid-md-links/logo.svg
+++ b/tests/cases/valid-md-links/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>

--- a/tests/cases/valid-md-links/outside.md
+++ b/tests/cases/valid-md-links/outside.md
@@ -1,0 +1,3 @@
+# Outside
+
+A file outside the graph directory, linked to from inside it.


### PR DESCRIPTION
## The gap

`lat check` validates `[[wiki links]]` and `// @lat:` code refs, but ignores ordinary markdown links completely. Verified on 0.12.2, with the wiki-link row as a positive control that the instrument works:

| Link written in a graph document | `lat check` result |
| --- | --- |
| `[[does-not-exist-xyz]]` | exit 1, flagged by name |
| `[x](does-not-exist.md)` | exit 0, not flagged |
| `[x](./does-not-exist.md)` | exit 0, not flagged |
| `[x](../design/does-not-exist.md)` | exit 0, not flagged |
| `[x](../../crates/does-not-exist.rs)` | exit 0, not flagged |

In the graph that prompted this, 221 cross-document references are ordinary relative links, none of them protected against the rot the tool exists to prevent.

## What this adds

A `checkLinks` validation and a `lat check links` subcommand, wired into `lat check`. Targets resolve against the containing file's directory, and existence on disk is the only test, so a link that deliberately leaves `lat.md/` (`../../AGENTS.md`) is validated the same way.

```
- lat.md/a.md:7: broken link (../does-not-exist.md) — file "does-not-exist.md" not found
- lat.md/a.md:10: broken image (./does-not-exist.svg) — file "lat.md/does-not-exist.svg" not found
```

Never treated as paths, and never reported: any URI scheme (`https:`, `mailto:`, custom app schemes, and a Windows `C:/…` absolute path), root-absolute and protocol-relative destinations, pure fragments, and empty destinations. A `?query` and `#fragment` are dropped before resolving.

## Design decisions

**A separate check family, not folded into `check md`.** This follows the shape of 672d5e1, which added `check sections`: its own validation function, its own subcommand, integrated into `lat check`. Wiki-link resolution and filesystem existence are different questions with different failure modes, and keeping them apart lets either be run alone.

**On by default, with no opt-out switch.** This is the part worth a maintainer decision, so here is the reasoning rather than just the choice. Precedent is that validity checks ship unconditionally — `check sections` landed in 0.6.0 as a new hard error and every graph without leading paragraphs went red on upgrade. The frontmatter switch that does exist, `require-code-mention`, gates a *coverage* requirement, which is project-specific in a way that a broken link is not. A validation that is off by default protects nobody. If you would rather this be opt-in for a release, it is a small change and I will make it.

**Images and reference definitions are included.** A broken `![](./diagram.png)` is the same rot as a broken link, and a `[id]: ./path.md` definition is a link destination that no other check covers. A broken image is reported as a broken image so the error names what the reader is looking for. If you would rather images stay out, that is a one-line filter.

**Nodes are read from the mdast, not matched with a regex.** This is what keeps destinations inside fenced and inline code out of the results — a code sample showing `[x](./missing.md)` documents a link, it is not one. There is a test for it.

## Deliberate omissions

**Anchors are not validated.** For `foo.md#some-heading`, only `foo.md` is checked. Resolving a heading to its slug depends on the target renderer's own anchor rules, so validating it would need a decision about which rules to implement. Stated as future work rather than left ambiguous.

**No change to the `templates/` files that `lat init` writes.** Two of them are now one item short: `templates/AGENTS.md`, and the check list in `templates/skill/SKILL.md`, which reads

```
Always run `lat check` after editing `lat.md/` files. It validates:
- All wiki links point to existing sections or source code symbols
- All `@lat:` code refs point to existing sections
```

and wants a `- All relative markdown links ([text](path)) point to files that exist` line. Both files are content-hashed into `lat_init.json`, so editing either is the kind of change `INIT_VERSION` exists to gate — a bump shows "your setup is outdated" to every existing user and asks them to re-run `lat init`. That is your call to make in one motion, not something to slip into a feature PR. Documentation went into `lat.md/cli.md` and `lat.md/markdown.md` instead.

**Case-only mismatches are not detected.** A link to `./FOO.md` when the file is `foo.md` passes on macOS and Windows and fails on Linux. Catching it needs a directory read per link rather than an `existsSync`, so it is out of scope here.

## Tests

Two fixtures under `tests/cases/`, following the existing layout and the `error-` prefix convention.

- `error-md-links` — broken bare, `./`, `../`, anchored, image, reference-definition, and malformed-percent-escape targets. Asserts the exact set, order, and line numbers; that the anchor is dropped from the resolved path; and that an image reports as an image.
- `valid-md-links` — bare, nested, anchored, query, percent-encoded space, reference definition, an image, and a target outside the graph directory; plus every skipped form (https, mailto, Windows drive letter, protocol-relative, root-absolute, pure fragment, query-only) and a link inside inline code. One target is reached from a nested file via `../`, which fails if resolution is done against the graph root instead of the containing file.

Each test was confirmed to fail for the right reason by mutating the implementation six ways and watching the specific expected assertion go red: removing the URI-scheme skip, removing the root-absolute skip, no longer stripping the fragment, no longer visiting `definition` nodes, resolving against the graph root, and removing the malformed-escape `catch` — the last of which crashes with `URIError` rather than reporting, which is why that fixture line exists.

## Verification

Run locally on Node 26.5.0 with the full `wasm32-unknown-unknown` toolchain, so the WASM engine and MiniLM weights are real rather than stubbed. CI covers Node 22 on Linux and Windows:

| Gate | Result |
| --- | --- |
| `pnpm buildall` | pass |
| `pnpm typecheck` | pass, 0 errors |
| `pnpm test` | pass, 169/169 in 7 files |
| `pnpm format:check` | pass |

Beyond the gates, the built CLI in `dist/` was run against this repo's own graph (`All checks passed`, including the new `check-links.md` spec and its `@lat:` coverage) and against the error fixture, where it exits 1 naming each broken link. Worth knowing when reading that first result: this repo's `lat.md/` contains exactly one ordinary markdown link node and zero that resolve to a path, so the clean run proves the check raises no false positives here — it is not evidence the check works. The fixtures are.
