### PR TITLE
Validate Markdown links and explicit directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ my-project/
 
 ```bash
 lat init                        # scaffold a lat.md/ directory
-lat check                       # validate all wiki links and code refs
+lat check                       # run full graph and documentation validation
 lat locate "OAuth Flow"         # find sections by name (exact, fuzzy)
 lat section "auth#OAuth Flow"   # show a section with its links and refs
 lat refs "auth#OAuth Flow"      # find what references a section

--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -61,9 +61,22 @@ Core logic in [[src/cli/refs.ts#findRefs]] (returns structured result), used by 
 
 ## check
 
-Validation command group. Runs all checks when invoked without a subcommand.
+Validation command group. Without a subcommand it runs every check against the
+discovered `lat.md/`; an explicit `-- <directory>` suffix validates any
+Markdown directory instead.
 
-Usage: `lat check [md|links|code-refs|index|sections]`
+Usage: `lat check [md|links|code-refs|index|sections] [-- <directory>]`
+
+The separator is required. It keeps directory names distinct from subcommands:
+`lat check links` runs the relative-link subcommand against the discovered
+`lat.md/`, while `lat check -- links` runs every validator against a directory
+named `links`. Exactly one directory must follow `--`.
+
+Every subcommand supports the same suffix, such as
+`lat check code-refs -- docs`. For explicit directories, section ids remain
+relative to the containing project root and code references are scanned from
+that root. The full check skips the `lat init` version warning because the
+directory is not required to have lat setup metadata.
 
 Emits a stale-init warning before any errors so the user sees setup issues first. The init version check compares `INIT_VERSION` in [[src/init-version.ts]] against the version in `lat.md/.cache/lat_init.json` written by [[cli#init]]. If the total check took longer than one second and ripgrep is not installed, shows a tip suggesting the user install it for faster scanning. The first output line ("Scanned ...") includes the total elapsed time (e.g. "in 250ms" or "in 1.2s").
 
@@ -71,11 +84,11 @@ Implementation: [[src/cli/check.ts]]
 
 ### md
 
-Validate that all [[parser#Wiki Links]] in `lat.md` markdown files point to existing sections.
+Validate that all [[parser#Wiki Links]] in the checked markdown files point to existing sections.
 
 ### links
 
-Validate that ordinary markdown links in `lat.md/` files point to existing files, Markdown fragments use GitHub heading ids, and full or collapsed reference-style links have definitions. See [[markdown#Relative Links]] for exact rules.
+Validate that ordinary markdown links in the checked files point to existing files, Markdown fragments use GitHub heading ids, and full or collapsed reference-style links have definitions. See [[markdown#Relative Links]] for exact rules.
 
 ### code-refs
 
@@ -101,7 +114,7 @@ Each index file must contain a bullet list covering every visible file and subdi
 
 Four checks:
 
-1. **Non-markdown files** — any file without a `.md` extension is flagged as an error (only markdown belongs in `lat.md/`)
+1. **Non-markdown files** — any file without a `.md` extension is flagged as an error (only markdown belongs in the checked directory)
 2. **Missing index file** — errors with a ready-to-copy bullet list snippet
 3. **Missing entries** — index file exists but doesn't list all visible entries
 4. **Stale entries** — index file lists an entry that doesn't exist on disk

--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -75,7 +75,7 @@ Validate that all [[parser#Wiki Links]] in `lat.md` markdown files point to exis
 
 ### links
 
-Validate that ordinary markdown links (`[text](path)`) in `lat.md/` files point to files that exist. See [[markdown#Relative Links]] for which destinations are checked and which are skipped.
+Validate that ordinary markdown links in `lat.md/` files point to existing files and that full or collapsed reference-style links have definitions. See [[markdown#Relative Links]] for exact rules.
 
 ### code-refs
 

--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -374,7 +374,9 @@ All embedding generation is isolated in the `@lat.md/embed` package, exposed thr
 
 ### Storage
 
-Uses `@libsql/client` (Turso's libsql) in local file mode — pure JS/WASM, no native addons. Vector search is built into libsql via `F32_BLOB` column type, `libsql_vector_idx` for indexing, and `vector_top_k()` for KNN queries.
+Uses `@libsql/client` in local file mode. Under Node, file URLs load the native `libsql` platform binding, so database handles follow native OS lifetime and locking rules.
+
+Vector search is built into libsql via `F32_BLOB` column type, `libsql_vector_idx` for indexing, and `vector_top_k()` for KNN queries.
 
 Single `sections` table holds metadata, content, content hash, and the embedding vector. No separate vector table needed. The `meta` table records the embedding model + dimensions the index was built with ([[src/search/db.ts#getStoredModel]], e.g. `local:minilm-l6-v2:384` or `openai:1536`). This record is authoritative for [[cli#search#Backend selection]] — vectors from different models are not comparable, so a model change never silently rebuilds; [[cli#reindex]] drops (via [[src/search/db.ts#dropSections]]) and rebuilds explicitly.
 

--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -63,7 +63,7 @@ Core logic in [[src/cli/refs.ts#findRefs]] (returns structured result), used by 
 
 Validation command group. Runs all checks when invoked without a subcommand.
 
-Usage: `lat check [md|code-refs|links|index|sections]`
+Usage: `lat check [md|links|code-refs|index|sections]`
 
 Emits a stale-init warning before any errors so the user sees setup issues first. The init version check compares `INIT_VERSION` in [[src/init-version.ts]] against the version in `lat.md/.cache/lat_init.json` written by [[cli#init]]. If the total check took longer than one second and ripgrep is not installed, shows a tip suggesting the user install it for faster scanning. The first output line ("Scanned ...") includes the total elapsed time (e.g. "in 250ms" or "in 1.2s").
 
@@ -73,18 +73,16 @@ Implementation: [[src/cli/check.ts]]
 
 Validate that all [[parser#Wiki Links]] in `lat.md` markdown files point to existing sections.
 
+### links
+
+Validate that ordinary markdown links (`[text](path)`) in `lat.md/` files point to files that exist. See [[markdown#Relative Links]] for which destinations are checked and which are skipped.
+
 ### code-refs
 
 Two validations:
 
 1. Every `// @lat: [[...]]` or `# @lat: [[...]]` comment in source code must point to a real section in `lat.md/`
 2. For files with [[markdown#Frontmatter#require-code-mention]], every leaf section must be referenced by at least one `// @lat:` comment in the codebase
-
-### links
-
-Validate that ordinary markdown links (`[text](path)`) in `lat.md/` files point to files that exist — see [[markdown#Relative Links]] for the rules on what is and is not checked.
-
-Targets resolve against the containing file's directory, and existence on disk is the only test, so a link that deliberately leaves `lat.md/` (`../../AGENTS.md`) is validated the same way. Images and reference definitions are checked alongside inline links; a broken image is reported as a broken image.
 
 ### sections
 

--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -63,7 +63,7 @@ Core logic in [[src/cli/refs.ts#findRefs]] (returns structured result), used by 
 
 Validation command group. Runs all checks when invoked without a subcommand.
 
-Usage: `lat check [md|code-refs|index|sections]`
+Usage: `lat check [md|code-refs|links|index|sections]`
 
 Emits a stale-init warning before any errors so the user sees setup issues first. The init version check compares `INIT_VERSION` in [[src/init-version.ts]] against the version in `lat.md/.cache/lat_init.json` written by [[cli#init]]. If the total check took longer than one second and ripgrep is not installed, shows a tip suggesting the user install it for faster scanning. The first output line ("Scanned ...") includes the total elapsed time (e.g. "in 250ms" or "in 1.2s").
 
@@ -79,6 +79,12 @@ Two validations:
 
 1. Every `// @lat: [[...]]` or `# @lat: [[...]]` comment in source code must point to a real section in `lat.md/`
 2. For files with [[markdown#Frontmatter#require-code-mention]], every leaf section must be referenced by at least one `// @lat:` comment in the codebase
+
+### links
+
+Validate that ordinary markdown links (`[text](path)`) in `lat.md/` files point to files that exist — see [[markdown#Relative Links]] for the rules on what is and is not checked.
+
+Targets resolve against the containing file's directory, and existence on disk is the only test, so a link that deliberately leaves `lat.md/` (`../../AGENTS.md`) is validated the same way. Images and reference definitions are checked alongside inline links; a broken image is reported as a broken image.
 
 ### sections
 

--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -75,7 +75,7 @@ Validate that all [[parser#Wiki Links]] in `lat.md` markdown files point to exis
 
 ### links
 
-Validate that ordinary markdown links in `lat.md/` files point to existing files and that full or collapsed reference-style links have definitions. See [[markdown#Relative Links]] for exact rules.
+Validate that ordinary markdown links in `lat.md/` files point to existing files, Markdown fragments use GitHub heading ids, and full or collapsed reference-style links have definitions. See [[markdown#Relative Links]] for exact rules.
 
 ### code-refs
 

--- a/lat.md/dev-process.md
+++ b/lat.md/dev-process.md
@@ -35,7 +35,7 @@ Every test run includes a full `tsc --noEmit` pass over the entire codebase. If 
 
 CI (`.github/workflows/ci.yml`) runs the full `pnpm buildall` + `vitest` suite on a `[ubuntu-latest, windows-latest]` matrix (`fail-fast: false`) so platform-specific regressions — path separators (see [[parser#Short Ref Resolution]]) and line endings — are caught before release.
 
-Cross-platform correctness relies on two conventions: stored paths are always POSIX ([[src/walk.ts#toPosix]]), and a repo-root `.gitattributes` (`eol=lf`) keeps Windows checkouts from rewriting line endings and breaking the markdown roundtrip. Tests that hold the libsql index open (`lat.md/.cache/vectors.db`) or spawn a fake `git` must clean up temp dirs with `rmSync` retries, since Windows refuses to unlink open/locked files.
+Cross-platform correctness relies on two conventions: stored paths are always POSIX ([[src/walk.ts#toPosix]]), and a repo-root `.gitattributes` (`eol=lf`) keeps Windows checkouts from rewriting line endings and breaking the markdown roundtrip. Functional init tests run the built CLI and database seeding in child processes so native libsql handles close before temp cleanup. Lower-level tests that retain handles or spawn a fake `git` use [[tests/util.ts#rmDirBestEffort]].
 
 ## File Walking
 

--- a/lat.md/markdown.md
+++ b/lat.md/markdown.md
@@ -18,6 +18,8 @@ Aligned with Obsidian conventions:
 - **`[[foo#Bar]]`** — heading `Bar` in file `foo.md`. The path after `#` must be an exact heading chain — no intermediate headings can be omitted.
 - **`[[path/foo#Bar]]`** — fully qualified: file `path/foo.md`, heading `Bar`.
 
+Heading segments accept either their literal Obsidian form (`Some Section!`) or their GitHub slug (`some-section`). Resolution always returns and displays the canonical literal-heading section id, so existing links and CLI output remain unchanged. Literal matches win if the two forms collide.
+
 ### Short Path Disambiguation
 
 Short refs are supported for markdown files inside `lat.md/` only. When a file stem is unique across the vault, it can be used without its directory prefix.
@@ -64,7 +66,9 @@ Source code is parsed lazily with tree-sitter (via `web-tree-sitter`). Only file
 
 Ordinary markdown links (`[text](path)`) to local files are validated for existence, so a moved or deleted file is caught the same way a stale `[[wiki link]]` is.
 
-Targets resolve against the containing file's directory, and existence on disk is the only test — a link that leaves `lat.md/` (`../../AGENTS.md`) is checked like any other. Inline links, images, and reference definitions (`[id]: ./path.md`) all participate; code samples and bracket-like text in raw HTML do not.
+Targets resolve against the containing file's directory. A link that leaves `lat.md/` (`../../AGENTS.md`) is checked like any other. Inline links, images, and reference definitions (`[id]: ./path.md`) all participate; code samples and bracket-like text in raw HTML do not.
+
+Fragments targeting Markdown files must match a GitHub-style heading id. GitHub lowercases headings, removes punctuation, replaces spaces with hyphens, and suffixes duplicate ids with `-1`, `-2`, and so on. Bare fragments target the containing file and are validated the same way.
 
 Full (`[text][id]`) and collapsed (`[id][]`) references without a matching definition are errors. An undefined shortcut form (`[id]`) is indistinguishable from bracketed prose and remains text, following CommonMark parsing.
 
@@ -72,9 +76,8 @@ Destinations that are not local paths are skipped and never reported:
 
 - **Any URI scheme** — `https:`, `mailto:`, and a Windows absolute path like `C:/notes.md`.
 - **Root-absolute and protocol-relative** — `/img/logo.png`, `//example.com/x`. Ambiguous between a site root and the filesystem root.
-- **Bare fragments** — `#section`.
 
-A `?query` and `#fragment` are dropped before resolving, so `foo.md#some-heading` only checks that `foo.md` exists. The anchor itself is not validated — heading slugs depend on the rendering tool.
+A `?query` is dropped before resolving. Fragments on non-Markdown targets are ignored because they are not heading ids.
 
 Validated by [[cli#check#links]].
 

--- a/lat.md/markdown.md
+++ b/lat.md/markdown.md
@@ -79,6 +79,12 @@ Destinations that are not local paths are skipped and never reported:
 
 A `?query` is dropped before resolving. Fragments on non-Markdown targets are ignored because they are not heading ids.
 
+Local paths must use `/` separators on every operating system. Literal and
+percent-encoded backslashes are rejected because GitHub treats them as filename
+characters rather than Windows path separators. This restriction does not
+apply to lat wiki links or code references. Diagnostics display filesystem
+paths with `/` separators on every operating system.
+
 Validated by [[cli#check#links]].
 
 ## Leading Paragraph

--- a/lat.md/markdown.md
+++ b/lat.md/markdown.md
@@ -64,7 +64,9 @@ Source code is parsed lazily with tree-sitter (via `web-tree-sitter`). Only file
 
 Ordinary markdown links (`[text](path)`) to local files are validated for existence, so a moved or deleted file is caught the same way a stale `[[wiki link]]` is.
 
-Targets resolve against the containing file's directory, and existence on disk is the only test — a link that leaves `lat.md/` (`../../AGENTS.md`) is checked like any other. Inline links, images, and reference definitions (`[id]: ./path.md`) all participate; a link inside a code block does not.
+Targets resolve against the containing file's directory, and existence on disk is the only test — a link that leaves `lat.md/` (`../../AGENTS.md`) is checked like any other. Inline links, images, and reference definitions (`[id]: ./path.md`) all participate; code samples and bracket-like text in raw HTML do not.
+
+Full (`[text][id]`) and collapsed (`[id][]`) references without a matching definition are errors. An undefined shortcut form (`[id]`) is indistinguishable from bracketed prose and remains text, following CommonMark parsing.
 
 Destinations that are not local paths are skipped and never reported:
 

--- a/lat.md/markdown.md
+++ b/lat.md/markdown.md
@@ -64,15 +64,15 @@ Source code is parsed lazily with tree-sitter (via `web-tree-sitter`). Only file
 
 Ordinary markdown links (`[text](path)`) to local files are validated for existence, so a moved or deleted file is caught the same way a stale `[[wiki link]]` is.
 
-Targets resolve against the containing file's directory — the rule every markdown renderer applies — and existence on disk is the only test. A link pointing outside `lat.md/` (`../../AGENTS.md`) is therefore checked too. Inline links, images, and reference definitions (`[id]: ./path.md`) all participate. Because validation walks the mdast rather than matching text, a link inside a fenced or inline code block is correctly ignored.
+Targets resolve against the containing file's directory, and existence on disk is the only test — a link that leaves `lat.md/` (`../../AGENTS.md`) is checked like any other. Inline links, images, and reference definitions (`[id]: ./path.md`) all participate; a link inside a code block does not.
 
-These destinations are never treated as paths, and never reported:
+Destinations that are not local paths are skipped and never reported:
 
-- **Any URI scheme** — `https:`, `mailto:`, `tel:`, custom app schemes. A Windows absolute path (`C:/notes.md`) matches this rule and is skipped rather than misread as a relative path.
-- **Root-absolute** — `/img/logo.png`, and protocol-relative `//example.com/x`. Ambiguous between a site root and the filesystem root, so checking either way would invent false positives.
-- **Pure fragments** — `#section`, an anchor within the same file.
+- **Any URI scheme** — `https:`, `mailto:`, and a Windows absolute path like `C:/notes.md`.
+- **Root-absolute and protocol-relative** — `/img/logo.png`, `//example.com/x`. Ambiguous between a site root and the filesystem root.
+- **Bare fragments** — `#section`.
 
-A `?query` and `#fragment` are dropped before resolving, so `foo.md#some-heading` verifies that `foo.md` exists and `?tab=1` alone is skipped. The anchor itself is not validated — matching a heading to its slug depends on the target renderer's own anchor rules.
+A `?query` and `#fragment` are dropped before resolving, so `foo.md#some-heading` only checks that `foo.md` exists. The anchor itself is not validated — heading slugs depend on the rendering tool.
 
 Validated by [[cli#check#links]].
 

--- a/lat.md/markdown.md
+++ b/lat.md/markdown.md
@@ -60,6 +60,22 @@ Source code is parsed lazily with tree-sitter (via `web-tree-sitter`). Only file
 
 **Lenient** — `lat locate` and `lat expand` use `findSections()`, which applies tiered matching (exact → file stem → subsection tail → fuzzy). These commands are for interactive exploration and accept approximate queries.
 
+## Relative Links
+
+Ordinary markdown links (`[text](path)`) to local files are validated for existence, so a moved or deleted file is caught the same way a stale `[[wiki link]]` is.
+
+Targets resolve against the containing file's directory — the rule every markdown renderer applies — and existence on disk is the only test. A link pointing outside `lat.md/` (`../../AGENTS.md`) is therefore checked too. Inline links, images, and reference definitions (`[id]: ./path.md`) all participate. Because validation walks the mdast rather than matching text, a link inside a fenced or inline code block is correctly ignored.
+
+These destinations are never treated as paths, and never reported:
+
+- **Any URI scheme** — `https:`, `mailto:`, `tel:`, custom app schemes. A Windows absolute path (`C:/notes.md`) matches this rule and is skipped rather than misread as a relative path.
+- **Root-absolute** — `/img/logo.png`, and protocol-relative `//example.com/x`. Ambiguous between a site root and the filesystem root, so checking either way would invent false positives.
+- **Pure fragments** — `#section`, an anchor within the same file.
+
+A `?query` and `#fragment` are dropped before resolving, so `foo.md#some-heading` verifies that `foo.md` exists and `?tab=1` alone is skipped. The anchor itself is not validated — matching a heading to its slug depends on the target renderer's own anchor rules.
+
+Validated by [[cli#check#links]].
+
 ## Leading Paragraph
 
 Every section must have a leading paragraph — at least one sentence immediately after the heading, before any child headings.

--- a/lat.md/parser.md
+++ b/lat.md/parser.md
@@ -25,6 +25,7 @@ Each section has:
 - `children` — nested subsections forming a tree
 - `startLine` / `endLine` — source positions in the original file
 - `firstParagraph` — first paragraph text (used by [[cli#Section Preview]])
+- `githubSlug` — GitHub-compatible heading id, including duplicate suffixes within the document
 
 [[markdown#Frontmatter]] is handled by `remark-frontmatter`, which parses it as a `yaml` AST node so heading positions reflect the original file.
 
@@ -35,6 +36,8 @@ References can use just the file name (without directory path) when the name is 
 For example, `[[search#Provider Detection]]` resolves to `lat.md/tests/search#Search Tests#Provider Detection` if there's only one `search.md` in the vault. If multiple files share the same name, the full path is required — `lat check` reports ambiguous refs as errors.
 
 The root (h1) heading can be omitted in references: `[[backend#CORS]]` resolves to `lat.md/backend#Backend#CORS` because the h1 heading is implicit from the file. Both `resolveRef()` and `findSections()` handle this by trying to insert root headings when a direct match fails.
+
+[[src/lattice.ts#buildSectionSlugIndex]] maps GitHub-slugged heading paths back to canonical literal-heading ids. Strict and lenient resolution accept either form while continuing to return the original section ids used by existing CLI output.
 
 The file index ([[src/lattice.ts#buildFileIndex]]) maps all trailing path suffixes to their full paths. For `lat.md/guides/setup`, both `guides/setup` and `setup` are indexed. All keys are lowercase for case-insensitive lookup.
 

--- a/lat.md/tests/check-headless.md
+++ b/lat.md/tests/check-headless.md
@@ -1,0 +1,27 @@
+---
+lat:
+  require-code-mention: true
+---
+# Check Explicit Directories
+
+Functional tests cover validation of Markdown directories outside `lat.md/`.
+
+## Separator disambiguates directory names
+
+`lat check -- links` checks a directory named `links`, while `lat check links`
+continues to select the `links` subcommand and search for `lat.md/`.
+
+## Every subcommand accepts a directory
+
+Each check subcommand accepts `-- <directory>` and runs only its own validator
+against that explicit Markdown directory.
+
+## Target syntax requires one directory
+
+The explicit-target form rejects a missing directory or extra arguments after
+`--`, keeping its grammar unambiguous.
+
+## Default check runs every validator
+
+`lat check -- <directory>` runs markdown, ordinary-link, code-reference, index,
+and section-structure validation together.

--- a/lat.md/tests/check-index.md
+++ b/lat.md/tests/check-index.md
@@ -32,7 +32,7 @@ Given a subdirectory index file that lists a file which does not exist on disk, 
 
 ## Detects non-markdown file
 
-Given a `lat.md/` directory containing a file without a `.md` extension (e.g. `README`), `checkIndex` reports it as an error since only markdown files belong in `lat.md/`.
+Given a checked directory containing a file without a `.md` extension (e.g. `README`), `checkIndex` reports it as an error since only markdown files belong in the documentation directory.
 
 ## Non-markdown files excluded from index listing
 

--- a/lat.md/tests/check-links.md
+++ b/lat.md/tests/check-links.md
@@ -30,3 +30,8 @@ Running `lat check links` accepts GitHub fragments with punctuation removed and 
 ## Rejects non-GitHub heading fragments
 
 For ordinary Markdown links, `lat check links` rejects heading fragments that are not GitHub-style slugs. Wiki links are unaffected: they accept both literal Obsidian headings and GitHub slugs.
+
+## Rejects backslash path separators
+
+Regular Markdown links reject literal or percent-encoded backslashes in local
+paths and direct authors to use `/`, preventing Windows-only false positives.

--- a/lat.md/tests/check-links.md
+++ b/lat.md/tests/check-links.md
@@ -22,3 +22,11 @@ Running `lat check` without a subcommand includes [[cli#check#links]] and fails 
 ## Passes valid and skipped link forms
 
 Running `lat check links` with resolving paths, skipped non-local destinations, escaped reference syntax, and links inside code reports no errors.
+
+## Accepts GitHub heading fragments
+
+Running `lat check links` accepts GitHub fragments with punctuation removed and duplicate headings suffixed in document order.
+
+## Rejects non-GitHub heading fragments
+
+For ordinary Markdown links, `lat check links` rejects heading fragments that are not GitHub-style slugs. Wiki links are unaffected: they accept both literal Obsidian headings and GitHub slugs.

--- a/lat.md/tests/check-links.md
+++ b/lat.md/tests/check-links.md
@@ -5,16 +5,20 @@ lat:
 
 # Check Links
 
-Tests for validating ordinary markdown links to local files in `lat.md/` files.
+Tests for full CLI validation of ordinary markdown links to local files in `lat.md/` files.
 
 ## Detects broken relative links
 
-Given links whose targets do not exist on disk, [[cli#check#links]] should report one error per broken destination, at the line it was written on.
+Running `lat check links` with missing local targets or undefined full and collapsed reference-style links reports each error at the authored line.
 
 ## Names the resolved file and the link kind
 
 Given an anchored link, [[cli#check#links]] should name the file it resolved to, without the anchor; given a broken image, it should say image rather than link.
 
+## Default check validates relative links
+
+Running `lat check` without a subcommand includes [[cli#check#links]] and fails when an ordinary relative markdown link is broken.
+
 ## Passes valid and skipped link forms
 
-Given links that resolve — including one leaving the graph directory and one resolved against a nested file's own directory — and destinations that are not local paths, [[cli#check#links]] should report no errors.
+Running `lat check links` with resolving paths, skipped non-local destinations, escaped reference syntax, and links inside code reports no errors.

--- a/lat.md/tests/check-links.md
+++ b/lat.md/tests/check-links.md
@@ -9,11 +9,11 @@ Tests for validating ordinary markdown links to local files in `lat.md/` files.
 
 ## Detects broken relative links
 
-Given links whose targets do not exist on disk, [[cli#check#links]] should report one error per broken target — covering the bare, `./`, `../`, and outside-the-graph forms.
+Given links whose targets do not exist on disk, [[cli#check#links]] should report one error per broken destination, at the line it was written on.
 
-## Reports anchors and images distinctly
+## Names the resolved file and the link kind
 
-Given an anchored link, [[cli#check#links]] should validate only the file part and name it in the error; given a broken image, it should report a broken image rather than a broken link.
+Given an anchored link, [[cli#check#links]] should name the file it resolved to, without the anchor; given a broken image, it should say image rather than link.
 
 ## Passes valid and skipped link forms
 

--- a/lat.md/tests/check-links.md
+++ b/lat.md/tests/check-links.md
@@ -1,0 +1,20 @@
+---
+lat:
+  require-code-mention: true
+---
+
+# Check Links
+
+Tests for validating ordinary markdown links to local files in `lat.md/` files.
+
+## Detects broken relative links
+
+Given links whose targets do not exist on disk, [[cli#check#links]] should report one error per broken target — covering the bare, `./`, `../`, and outside-the-graph forms.
+
+## Reports anchors and images distinctly
+
+Given an anchored link, [[cli#check#links]] should validate only the file part and name it in the error; given a broken image, it should report a broken image rather than a broken link.
+
+## Passes valid and skipped link forms
+
+Given links that resolve — including one leaving the graph directory and one resolved against a nested file's own directory — and destinations that are not local paths, [[cli#check#links]] should report no errors.

--- a/lat.md/tests/init.md
+++ b/lat.md/tests/init.md
@@ -5,7 +5,7 @@ lat:
 
 # Init
 
-Tests in `tests/init.test.ts` verify embedding defaults applied by the initialization wizard.
+Tests run non-interactive database flows through the built CLI in child processes; TTY-only menu branches use isolated mocks.
 
 ## Embedding setup
 

--- a/lat.md/tests/ref-resolution.md
+++ b/lat.md/tests/ref-resolution.md
@@ -27,6 +27,10 @@ When two directories contain a file with the same stem, a `@lat:` code comment u
 
 When a file stem is unique in the vault (e.g. only one `setup.md` exists, under `guides/`), a wiki link using the short name `[[setup#Install]]` in a markdown file passes `check md` without errors.
 
+## Wiki links accept literal and GitHub headings
+
+`lat check md` accepts both `[[file#Some Section!]]` and `[[file#some-section]]`, resolving both to the same canonical literal-heading section id.
+
 ## Short ref passes check code-refs
 
 When a file stem is unique in the vault, a `@lat:` code comment using the short name (e.g. `// @lat: [[setup#Configure]]`) passes `check code-refs` without errors.

--- a/lat.md/tests/section.md
+++ b/lat.md/tests/section.md
@@ -19,6 +19,10 @@ Given a fully qualified section id like `lat.md/dev-process#Dev Process#Testing`
 
 Given a short-form id like `setup#Install` where the file stem is unique, `getSection` resolves it to the full section and returns its content.
 
+## CLI accepts literal and GitHub heading syntax
+
+`lat section` accepts literal Obsidian heading paths and GitHub-slugged paths, producing identical output with the canonical literal-heading section id.
+
 ## Section with no refs or links
 
 A section that neither contains wiki links nor is referenced by other sections returns empty `outgoingRefs` and `incomingRefs`.

--- a/lat.md/tests/tests.md
+++ b/lat.md/tests/tests.md
@@ -16,6 +16,7 @@ Shared patterns for writing and organizing tests in this project.
 - [[ref-extraction]] — Extracting wiki link references from markdown files
 - [[section-preview]] — Formatting section previews for terminal output
 - [[check-md]] — Validating wiki links in lat.md markdown files
+- [[check-links]] — Validating relative markdown links to local files
 - [[check-code-refs]] — Validating @lat code references and coverage
 - [[locate]] — Finding sections by exact, subsection, and fuzzy matching
 - [[refs-e2e]] — End-to-end tests for the refs command

--- a/lat.md/tests/tests.md
+++ b/lat.md/tests/tests.md
@@ -8,7 +8,7 @@ Shared patterns for writing and organizing tests in this project.
 
 **Functional over unit.** Prefer functional tests that exercise real `lat` commands against fixture directories over isolated unit tests. Unit tests are only for low-level edge cases that are hard to cover through fixtures (e.g. inline `parseSections` edge cases in `tests/lattice.test.ts`).
 
-**Fixture-based.** Each test scenario is a static directory under `tests/cases/` with its own `lat.md/` and source files — a self-contained mini-project. No temp dirs or runtime file creation.
+**Fixture-based.** Validation scenarios are static directories under `tests/cases/`, each a self-contained mini-project. Mutating commands such as `lat init` use isolated temp directories and invoke the built CLI in child processes.
 
 **Error cases use `error-` prefix.** Test fixture directories that assert error behavior are named with an `error-` prefix (e.g. `error-broken-links`, `error-stale-index`). Success/happy-path fixtures use plain descriptive names (e.g. `valid-links`, `short-ref`).
 

--- a/lat.md/tests/tests.md
+++ b/lat.md/tests/tests.md
@@ -27,6 +27,7 @@ Shared patterns for writing and organizing tests in this project.
 - [[mcp]] — MCP server tool listing and tool call responses
 - [[roundtrip]] — Parse → render fidelity for all markdown and wiki link features
 - [[check-sections]] — Validating section leading paragraphs
+- [[check-headless]] — Validating explicit Markdown directories
 - [[section]] — getSection core function and formatSectionOutput formatter
 - [[hook]] — Lifecycle hook context injection, conditional continuation, and setup merging
 - [[init]] — Initialization defaults for local-first semantic search

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@repomix/tree-sitter-wasms": "^0.1.16",
     "commander": "^14.0.3",
+    "github-slugger": "^2.0.0",
     "ignore-walk": "^8.0.0",
     "mdast-util-to-markdown": "^2.1.0",
     "remark-frontmatter": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       ignore-walk:
         specifier: ^8.0.0
         version: 8.0.0
@@ -788,6 +791,9 @@ packages:
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1999,6 +2005,8 @@ snapshots:
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  github-slugger@2.0.0: {}
 
   gopd@1.2.0: {}
 

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -138,11 +138,13 @@ async function tryResolveSourceRef(
   }
 }
 
-export async function checkMd(latticeDir: string): Promise<CheckResult> {
+export async function checkMd(
+  latticeDir: string,
+  projectRoot = dirname(latticeDir),
+): Promise<CheckResult> {
   clearSymbolCache();
-  const projectRoot = dirname(latticeDir);
   const files = await listLatticeFiles(latticeDir);
-  const allSections = await loadAllSections(latticeDir);
+  const allSections = await loadAllSections(latticeDir, projectRoot);
   const flat = flattenSections(allSections);
   const sectionIds = new Set(flat.map((s) => s.id.toLowerCase()));
   const fileIndex = buildFileIndex(allSections);
@@ -302,9 +304,11 @@ export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
   return errors;
 }
 
-export async function checkCodeRefs(latticeDir: string): Promise<CheckResult> {
-  const projectRoot = dirname(latticeDir);
-  const allSections = await loadAllSections(latticeDir);
+export async function checkCodeRefs(
+  latticeDir: string,
+  projectRoot = dirname(latticeDir),
+): Promise<CheckResult> {
+  const allSections = await loadAllSections(latticeDir, projectRoot);
   const flat = flattenSections(allSections);
   const sectionIds = new Set(flat.map((s) => s.id.toLowerCase()));
   const fileIndex = buildFileIndex(allSections);
@@ -413,14 +417,14 @@ export async function checkIndex(latticeDir: string): Promise<IndexError[]> {
   const errors: IndexError[] = [];
   const allPaths = await walkEntries(latticeDir);
 
-  // Flag non-.md files — only markdown belongs in lat.md/
+  // Flag non-.md files — only markdown belongs in the checked directory.
   for (const p of allPaths) {
     const name = p.includes('/') ? p.slice(p.lastIndexOf('/') + 1) : p;
     if (!name.endsWith('.md')) {
       const relDir = basename(latticeDir) + '/';
       errors.push({
         dir: relDir,
-        message: `"${p}" is not a .md file — only markdown files belong in lat.md/`,
+        message: `"${p}" is not a .md file — only markdown files belong in the checked directory`,
       });
     }
   }
@@ -517,8 +521,10 @@ function bodyTextLength(body: string): number {
   return body.replace(/\[\[[^\]]*\]\]/g, '').length;
 }
 
-export async function checkSections(latticeDir: string): Promise<CheckError[]> {
-  const projectRoot = dirname(latticeDir);
+export async function checkSections(
+  latticeDir: string,
+  projectRoot = dirname(latticeDir),
+): Promise<CheckError[]> {
   const files = await listLatticeFiles(latticeDir);
   const errors: CheckError[] = [];
 
@@ -606,11 +612,11 @@ function formatErrorCount(count: number, s: Styler): string {
 
 export async function checkAllCommand(ctx: CmdContext): Promise<CmdResult> {
   const startTime = Date.now();
-  const md = await checkMd(ctx.latDir);
+  const md = await checkMd(ctx.latDir, ctx.projectRoot);
   const linkErrors = await checkLinks(ctx.latDir);
-  const code = await checkCodeRefs(ctx.latDir);
+  const code = await checkCodeRefs(ctx.latDir, ctx.projectRoot);
   const indexErrors = await checkIndex(ctx.latDir);
-  const sectionErrors = await checkSections(ctx.latDir);
+  const sectionErrors = await checkSections(ctx.latDir, ctx.projectRoot);
   const elapsed = Date.now() - startTime;
 
   const allErrors = [...md.errors, ...linkErrors, ...code.errors];
@@ -627,27 +633,29 @@ export async function checkAllCommand(ctx: CmdContext): Promise<CmdResult> {
   ];
 
   // Init version warning first — user should fix setup before addressing errors
-  const storedVersion = readInitVersion(ctx.latDir);
-  if (storedVersion === null) {
-    lines.push(
-      '',
-      s.yellow('Warning:') +
-        ' No init version recorded — run ' +
-        s.cyan('lat init') +
-        ' to set up agent hooks and configuration.',
-    );
-  } else if (storedVersion < INIT_VERSION) {
-    lines.push(
-      '',
-      s.yellow('Warning:') +
-        ' Your setup is outdated (v' +
-        storedVersion +
-        ' → v' +
-        INIT_VERSION +
-        '). Re-run ' +
-        s.cyan('lat init') +
-        ' to update agent hooks and configuration.',
-    );
+  if (!ctx.headless) {
+    const storedVersion = readInitVersion(ctx.latDir);
+    if (storedVersion === null) {
+      lines.push(
+        '',
+        s.yellow('Warning:') +
+          ' No init version recorded — run ' +
+          s.cyan('lat init') +
+          ' to set up agent hooks and configuration.',
+      );
+    } else if (storedVersion < INIT_VERSION) {
+      lines.push(
+        '',
+        s.yellow('Warning:') +
+          ' Your setup is outdated (v' +
+          storedVersion +
+          ' → v' +
+          INIT_VERSION +
+          '). Re-run ' +
+          s.cyan('lat init') +
+          ' to update agent hooks and configuration.',
+      );
+    }
   }
 
   lines.push(...formatCheckErrors(allErrors, s));
@@ -681,7 +689,7 @@ export async function checkAllCommand(ctx: CmdContext): Promise<CmdResult> {
 }
 
 export async function checkMdCommand(ctx: CmdContext): Promise<CmdResult> {
-  const { errors, files } = await checkMd(ctx.latDir);
+  const { errors, files } = await checkMd(ctx.latDir, ctx.projectRoot);
   const s = ctx.styler;
   const lines: string[] = [formatFileStats(files, s)];
 
@@ -715,7 +723,7 @@ export async function checkLinksCommand(ctx: CmdContext): Promise<CmdResult> {
 export async function checkCodeRefsCommand(
   ctx: CmdContext,
 ): Promise<CmdResult> {
-  const { errors, files } = await checkCodeRefs(ctx.latDir);
+  const { errors, files } = await checkCodeRefs(ctx.latDir, ctx.projectRoot);
   const s = ctx.styler;
   const lines: string[] = [formatFileStats(files, s)];
 
@@ -749,7 +757,7 @@ export async function checkIndexCommand(ctx: CmdContext): Promise<CmdResult> {
 export async function checkSectionsCommand(
   ctx: CmdContext,
 ): Promise<CmdResult> {
-  const errors = await checkSections(ctx.latDir);
+  const errors = await checkSections(ctx.latDir, ctx.projectRoot);
   const s = ctx.styler;
   const lines: string[] = [];
 

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -10,6 +10,7 @@ import {
   parseFrontmatter,
   parseSections,
   buildFileIndex,
+  buildSectionSlugIndex,
   resolveRef,
   type Section,
 } from '../lattice.js';
@@ -145,6 +146,7 @@ export async function checkMd(latticeDir: string): Promise<CheckResult> {
   const flat = flattenSections(allSections);
   const sectionIds = new Set(flat.map((s) => s.id.toLowerCase()));
   const fileIndex = buildFileIndex(allSections);
+  const slugIndex = buildSectionSlugIndex(allSections);
 
   const errors: CheckError[] = [];
 
@@ -158,6 +160,7 @@ export async function checkMd(latticeDir: string): Promise<CheckResult> {
         ref.target,
         sectionIds,
         fileIndex,
+        slugIndex,
       );
       if (ambiguous) {
         errors.push({
@@ -186,31 +189,64 @@ export async function checkMd(latticeDir: string): Promise<CheckResult> {
 
 // --- Relative link validation ---
 
-/**
- * The on-disk path a markdown link destination denotes, or null when it denotes
- * none: a URI scheme (`https:`, `mailto:`, and a Windows `C:/x` drive letter),
- * a root-absolute or protocol-relative path (ambiguous between the site root
- * and the filesystem root), or a bare `#anchor` / `?query`.
- */
-function linkPath(url: string): string | null {
+type LocalLinkTarget = {
+  /** Decoded on-disk path, or null for a fragment in the current file. */
+  path: string | null;
+  /** Decoded fragment without `#`, or null when none was authored. */
+  fragment: string | null;
+};
+
+function decodeLinkPart(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/** Parse a local markdown destination without confusing escaped #/? in paths. */
+function localLinkTarget(url: string): LocalLinkTarget | null {
   const u = url.trim();
-  if (u.startsWith('#') || u.startsWith('/')) return null;
+  if (u.startsWith('/')) return null;
   if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(u)) return null;
 
   // Split before decoding: `%23` and `%3F` decode to `#` and `?`, which would
   // then truncate a filename that legitimately contains them.
-  const path = u.split(/[?#]/)[0];
-  if (path === '') return null;
-  try {
-    return decodeURIComponent(path);
-  } catch {
-    return path; // Malformed escape — check it as authored rather than throw.
-  }
+  const queryAt = u.indexOf('?');
+  const fragmentAt = u.indexOf('#');
+  const pathEnd = Math.min(
+    queryAt === -1 ? u.length : queryAt,
+    fragmentAt === -1 ? u.length : fragmentAt,
+  );
+  const rawPath = u.slice(0, pathEnd);
+  const fragment =
+    fragmentAt === -1 ? null : decodeLinkPart(u.slice(fragmentAt + 1));
+
+  if (rawPath === '' && fragment === null) return null;
+  return {
+    path: rawPath === '' ? null : decodeLinkPart(rawPath),
+    fragment,
+  };
 }
 
 export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
   const files = await listLatticeFiles(latticeDir);
   const errors: CheckError[] = [];
+  const headingCache = new Map<string, Set<string>>();
+
+  const headingsFor = async (file: string): Promise<Set<string>> => {
+    const cached = headingCache.get(file);
+    if (cached) return cached;
+
+    const content = await readFile(file, 'utf-8');
+    const headings = new Set(
+      flattenSections(parseSections(file, content)).map(
+        (section) => section.githubSlug!,
+      ),
+    );
+    headingCache.set(file, headings);
+    return headings;
+  };
 
   for (const file of files) {
     const content = await readFile(file, 'utf-8');
@@ -228,20 +264,38 @@ export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
         continue;
       }
 
-      const target = linkPath(link.url);
+      const target = localLinkTarget(link.url);
       if (target === null) continue;
 
-      const abs = resolve(dirname(file), target);
-      if (existsSync(abs)) continue;
+      const abs = target.path ? resolve(dirname(file), target.path) : file;
+      if (!existsSync(abs)) {
+        const kind = link.kind === 'image' ? 'image' : 'link';
+        const shown = relative(process.cwd(), abs);
+        errors.push({
+          file: relPath,
+          line: link.line,
+          target: link.url,
+          message: `broken ${kind} (${link.url}) — file "${shown}" not found`,
+        });
+        continue;
+      }
 
-      const kind = link.kind === 'image' ? 'image' : 'link';
-      const shown = relative(process.cwd(), abs);
-      errors.push({
-        file: relPath,
-        line: link.line,
-        target: link.url,
-        message: `broken ${kind} (${link.url}) — file "${shown}" not found`,
-      });
+      if (
+        target.fragment &&
+        extname(abs).toLowerCase() === '.md' &&
+        link.kind !== 'image'
+      ) {
+        const headings = await headingsFor(abs);
+        if (!headings.has(target.fragment)) {
+          const shown = relative(process.cwd(), abs);
+          errors.push({
+            file: relPath,
+            line: link.line,
+            target: link.url,
+            message: `broken link (${link.url}) — heading "#${target.fragment}" not found in "${shown}"`,
+          });
+        }
+      }
     }
   }
 
@@ -254,6 +308,7 @@ export async function checkCodeRefs(latticeDir: string): Promise<CheckResult> {
   const flat = flattenSections(allSections);
   const sectionIds = new Set(flat.map((s) => s.id.toLowerCase()));
   const fileIndex = buildFileIndex(allSections);
+  const slugIndex = buildSectionSlugIndex(allSections);
 
   const scan = await scanCodeRefs(projectRoot);
   const errors: CheckError[] = [];
@@ -264,6 +319,7 @@ export async function checkCodeRefs(latticeDir: string): Promise<CheckResult> {
       ref.target,
       sectionIds,
       fileIndex,
+      slugIndex,
     );
     mentionedSections.add(resolved.toLowerCase());
     const displayPath = relative(process.cwd(), join(projectRoot, ref.file));

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -1,9 +1,10 @@
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { basename, dirname, extname, join, relative } from 'node:path';
+import { basename, dirname, extname, join, relative, resolve } from 'node:path';
 import {
   listLatticeFiles,
   loadAllSections,
+  extractLinks,
   extractRefs,
   flattenSections,
   parseFrontmatter,
@@ -14,7 +15,7 @@ import {
 } from '../lattice.js';
 import { scanCodeRefs } from '../code-refs.js';
 import { SOURCE_EXTENSIONS, clearSymbolCache } from '../source-parser.js';
-import { walkEntries } from '../walk.js';
+import { toPosix, walkEntries } from '../walk.js';
 import type { CmdContext, CmdResult, Styler } from '../context.js';
 import { INIT_VERSION, readInitVersion } from '../init-version.js';
 
@@ -181,6 +182,99 @@ export async function checkMd(latticeDir: string): Promise<CheckResult> {
   }
 
   return { errors, files: countByExt(files) };
+}
+
+// --- Relative link validation ---
+
+/** Matches a URI scheme prefix (`https:`, `mailto:`, `obsidian:`, …). */
+const URI_SCHEME = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+/**
+ * Whether a link destination denotes a path on disk that can be checked for
+ * existence. Everything else is out of scope and must never be reported:
+ *
+ * - **any URI scheme** — `https:`, `mailto:`, `tel:`, custom app schemes. This
+ *   also covers a Windows absolute path (`C:/notes.md`), which is skipped
+ *   rather than misread as a relative one.
+ * - **root-absolute** (`/img/logo.png`, and protocol-relative `//host/x`) —
+ *   ambiguous between a site root and the filesystem root, so resolving it
+ *   either way would invent false positives.
+ * - **pure fragment** (`#section`) — an anchor within the same file.
+ * - **empty**.
+ */
+function isLocalPathLink(url: string): boolean {
+  const u = url.trim();
+  if (u === '') return false;
+  if (u.startsWith('#')) return false;
+  if (u.startsWith('/')) return false;
+  return !URI_SCHEME.test(u);
+}
+
+/**
+ * Convert a link destination to the path it denotes on disk, dropping the
+ * `?query` and `#fragment` a URL may carry. Returns `''` when nothing but those
+ * remain (`?tab=1`), which the caller treats as having no path to check.
+ *
+ * Both are stripped *before* percent-decoding: `%23` decodes to a literal `#`
+ * and `%3F` to a `?`, so decoding first would split the path at a character
+ * that is part of the filename. A malformed escape (a stray `%`) is left as
+ * authored rather than throwing.
+ */
+function linkTargetToPath(url: string): string {
+  const hashIdx = url.indexOf('#');
+  const withoutFragment = hashIdx === -1 ? url : url.slice(0, hashIdx);
+  const queryIdx = withoutFragment.indexOf('?');
+  const path =
+    queryIdx === -1 ? withoutFragment : withoutFragment.slice(0, queryIdx);
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+/**
+ * Validate ordinary markdown links (`[text](path)`) in `lat.md/` files that
+ * point at local files. Wiki links are validated by [[src/cli/check.ts#checkMd]];
+ * this covers the plain-markdown half of the graph, which is otherwise
+ * unprotected against rot.
+ *
+ * Targets resolve against the containing file's directory — the same rule every
+ * markdown renderer applies — and existence on disk is the whole test, so a
+ * link that legitimately leaves `lat.md/` (`../../AGENTS.md`) is checked too.
+ * An anchor is dropped before resolving: `foo.md#heading` verifies `foo.md`.
+ */
+export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
+  const files = await listLatticeFiles(latticeDir);
+  const errors: CheckError[] = [];
+
+  for (const file of files) {
+    const content = await readFile(file, 'utf-8');
+    const relPath = relative(process.cwd(), file);
+
+    for (const link of extractLinks(content)) {
+      if (!isLocalPathLink(link.url)) continue;
+
+      const target = linkTargetToPath(link.url);
+      // Nothing but a query and/or fragment — no path to check.
+      if (target === '') continue;
+
+      const abs = resolve(dirname(file), target);
+      if (existsSync(abs)) continue;
+
+      const shown = toPosix(relative(process.cwd(), abs));
+      errors.push({
+        file: relPath,
+        line: link.line,
+        target: link.url,
+        message:
+          `broken ${link.kind === 'image' ? 'image' : 'link'} ` +
+          `(${link.url}) — "${shown}" does not exist`,
+      });
+    }
+  }
+
+  return errors;
 }
 
 export async function checkCodeRefs(latticeDir: string): Promise<CheckResult> {
@@ -487,11 +581,14 @@ export async function checkAllCommand(ctx: CmdContext): Promise<CmdResult> {
   const startTime = Date.now();
   const md = await checkMd(ctx.latDir);
   const code = await checkCodeRefs(ctx.latDir);
+  const linkErrors = await checkLinks(ctx.latDir);
   const indexErrors = await checkIndex(ctx.latDir);
   const sectionErrors = await checkSections(ctx.latDir);
   const elapsed = Date.now() - startTime;
 
-  const allErrors = [...md.errors, ...code.errors];
+  // `checkLinks` re-reads the same lat.md/ files as `checkMd`, so its errors
+  // are merged but its file counts are not — they would double the scan total.
+  const allErrors = [...md.errors, ...code.errors, ...linkErrors];
   const allFiles: FileStats = { ...md.files };
   for (const [ext, n] of Object.entries(code.files)) {
     allFiles[ext] = (allFiles[ext] || 0) + n;
@@ -589,6 +686,22 @@ export async function checkCodeRefsCommand(
   }
 
   lines.push(s.green('code-refs: All references OK'));
+  return { output: lines.join('\n') };
+}
+
+export async function checkLinksCommand(ctx: CmdContext): Promise<CmdResult> {
+  const errors = await checkLinks(ctx.latDir);
+  const s = ctx.styler;
+  const lines: string[] = [];
+
+  lines.push(...formatCheckErrors(errors, s));
+
+  if (errors.length > 0) {
+    lines.push(formatErrorCount(errors.length, s));
+    return { output: lines.join('\n'), isError: true };
+  }
+
+  lines.push(s.green('links: All relative links resolve'));
   return { output: lines.join('\n') };
 }
 

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -217,6 +217,17 @@ export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
     const relPath = relative(process.cwd(), file);
 
     for (const link of extractLinks(content)) {
+      if ('identifier' in link) {
+        const kind = link.kind === 'imageReference' ? 'image' : 'link';
+        errors.push({
+          file: relPath,
+          line: link.line,
+          target: link.identifier,
+          message: `undefined ${kind} reference (${link.source}) — definition "[${link.identifier}]" not found`,
+        });
+        continue;
+      }
+
       const target = linkPath(link.url);
       if (target === null) continue;
 

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -16,7 +16,7 @@ import {
 } from '../lattice.js';
 import { scanCodeRefs } from '../code-refs.js';
 import { SOURCE_EXTENSIONS, clearSymbolCache } from '../source-parser.js';
-import { walkEntries } from '../walk.js';
+import { toPosix, walkEntries } from '../walk.js';
 import type { CmdContext, CmdResult, Styler } from '../context.js';
 import { INIT_VERSION, readInitVersion } from '../init-version.js';
 
@@ -191,12 +191,15 @@ export async function checkMd(
 
 // --- Relative link validation ---
 
-type LocalLinkTarget = {
-  /** Decoded on-disk path, or null for a fragment in the current file. */
-  path: string | null;
-  /** Decoded fragment without `#`, or null when none was authored. */
-  fragment: string | null;
-};
+type LocalLinkTarget =
+  | {
+      kind: 'target';
+      /** Decoded on-disk path, or null for a fragment in the current file. */
+      path: string | null;
+      /** Decoded fragment without `#`, or null when none was authored. */
+      fragment: string | null;
+    }
+  | { kind: 'invalid-backslash' };
 
 function decodeLinkPart(value: string): string {
   try {
@@ -210,7 +213,10 @@ function decodeLinkPart(value: string): string {
 function localLinkTarget(url: string): LocalLinkTarget | null {
   const u = url.trim();
   if (u.startsWith('/')) return null;
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(u)) return null;
+  const windowsDrivePath = /^[a-zA-Z]:\\/.test(u);
+  if (!windowsDrivePath && /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(u)) {
+    return null;
+  }
 
   // Split before decoding: `%23` and `%3F` decode to `#` and `?`, which would
   // then truncate a filename that legitimately contains them.
@@ -221,12 +227,15 @@ function localLinkTarget(url: string): LocalLinkTarget | null {
     fragmentAt === -1 ? u.length : fragmentAt,
   );
   const rawPath = u.slice(0, pathEnd);
+  const path = rawPath === '' ? null : decodeLinkPart(rawPath);
   const fragment =
     fragmentAt === -1 ? null : decodeLinkPart(u.slice(fragmentAt + 1));
 
   if (rawPath === '' && fragment === null) return null;
+  if (path?.includes('\\')) return { kind: 'invalid-backslash' };
   return {
-    path: rawPath === '' ? null : decodeLinkPart(rawPath),
+    kind: 'target',
+    path,
     fragment,
   };
 }
@@ -252,7 +261,7 @@ export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
 
   for (const file of files) {
     const content = await readFile(file, 'utf-8');
-    const relPath = relative(process.cwd(), file);
+    const relPath = toPosix(relative(process.cwd(), file));
 
     for (const link of extractLinks(content)) {
       if ('identifier' in link) {
@@ -269,10 +278,23 @@ export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
       const target = localLinkTarget(link.url);
       if (target === null) continue;
 
+      if (target.kind === 'invalid-backslash') {
+        const kind = link.kind === 'image' ? 'image' : 'link';
+        errors.push({
+          file: relPath,
+          line: link.line,
+          target: link.url,
+          message:
+            `invalid ${kind} (${link.url}) — backslashes are not path ` +
+            'separators in Markdown; use "/" instead',
+        });
+        continue;
+      }
+
       const abs = target.path ? resolve(dirname(file), target.path) : file;
       if (!existsSync(abs)) {
         const kind = link.kind === 'image' ? 'image' : 'link';
-        const shown = relative(process.cwd(), abs);
+        const shown = toPosix(relative(process.cwd(), abs));
         errors.push({
           file: relPath,
           line: link.line,
@@ -289,7 +311,7 @@ export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
       ) {
         const headings = await headingsFor(abs);
         if (!headings.has(target.fragment)) {
-          const shown = relative(process.cwd(), abs);
+          const shown = toPosix(relative(process.cwd(), abs));
           errors.push({
             file: relPath,
             line: link.line,

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -15,7 +15,7 @@ import {
 } from '../lattice.js';
 import { scanCodeRefs } from '../code-refs.js';
 import { SOURCE_EXTENSIONS, clearSymbolCache } from '../source-parser.js';
-import { toPosix, walkEntries } from '../walk.js';
+import { walkEntries } from '../walk.js';
 import type { CmdContext, CmdResult, Styler } from '../context.js';
 import { INIT_VERSION, readInitVersion } from '../init-version.js';
 
@@ -186,64 +186,28 @@ export async function checkMd(latticeDir: string): Promise<CheckResult> {
 
 // --- Relative link validation ---
 
-/** Matches a URI scheme prefix (`https:`, `mailto:`, `obsidian:`, …). */
-const URI_SCHEME = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
-
 /**
- * Whether a link destination denotes a path on disk that can be checked for
- * existence. Everything else is out of scope and must never be reported:
- *
- * - **any URI scheme** — `https:`, `mailto:`, `tel:`, custom app schemes. This
- *   also covers a Windows absolute path (`C:/notes.md`), which is skipped
- *   rather than misread as a relative one.
- * - **root-absolute** (`/img/logo.png`, and protocol-relative `//host/x`) —
- *   ambiguous between a site root and the filesystem root, so resolving it
- *   either way would invent false positives.
- * - **pure fragment** (`#section`) — an anchor within the same file.
- * - **empty**.
+ * The on-disk path a markdown link destination denotes, or null when it denotes
+ * none: a URI scheme (`https:`, `mailto:`, and a Windows `C:/x` drive letter),
+ * a root-absolute or protocol-relative path (ambiguous between the site root
+ * and the filesystem root), or a bare `#anchor` / `?query`.
  */
-function isLocalPathLink(url: string): boolean {
+function linkPath(url: string): string | null {
   const u = url.trim();
-  if (u === '') return false;
-  if (u.startsWith('#')) return false;
-  if (u.startsWith('/')) return false;
-  return !URI_SCHEME.test(u);
-}
+  if (u.startsWith('#') || u.startsWith('/')) return null;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(u)) return null;
 
-/**
- * Convert a link destination to the path it denotes on disk, dropping the
- * `?query` and `#fragment` a URL may carry. Returns `''` when nothing but those
- * remain (`?tab=1`), which the caller treats as having no path to check.
- *
- * Both are stripped *before* percent-decoding: `%23` decodes to a literal `#`
- * and `%3F` to a `?`, so decoding first would split the path at a character
- * that is part of the filename. A malformed escape (a stray `%`) is left as
- * authored rather than throwing.
- */
-function linkTargetToPath(url: string): string {
-  const hashIdx = url.indexOf('#');
-  const withoutFragment = hashIdx === -1 ? url : url.slice(0, hashIdx);
-  const queryIdx = withoutFragment.indexOf('?');
-  const path =
-    queryIdx === -1 ? withoutFragment : withoutFragment.slice(0, queryIdx);
+  // Split before decoding: `%23` and `%3F` decode to `#` and `?`, which would
+  // then truncate a filename that legitimately contains them.
+  const path = u.split(/[?#]/)[0];
+  if (path === '') return null;
   try {
     return decodeURIComponent(path);
   } catch {
-    return path;
+    return path; // Malformed escape — check it as authored rather than throw.
   }
 }
 
-/**
- * Validate ordinary markdown links (`[text](path)`) in `lat.md/` files that
- * point at local files. Wiki links are validated by [[src/cli/check.ts#checkMd]];
- * this covers the plain-markdown half of the graph, which is otherwise
- * unprotected against rot.
- *
- * Targets resolve against the containing file's directory — the same rule every
- * markdown renderer applies — and existence on disk is the whole test, so a
- * link that legitimately leaves `lat.md/` (`../../AGENTS.md`) is checked too.
- * An anchor is dropped before resolving: `foo.md#heading` verifies `foo.md`.
- */
 export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
   const files = await listLatticeFiles(latticeDir);
   const errors: CheckError[] = [];
@@ -253,23 +217,19 @@ export async function checkLinks(latticeDir: string): Promise<CheckError[]> {
     const relPath = relative(process.cwd(), file);
 
     for (const link of extractLinks(content)) {
-      if (!isLocalPathLink(link.url)) continue;
-
-      const target = linkTargetToPath(link.url);
-      // Nothing but a query and/or fragment — no path to check.
-      if (target === '') continue;
+      const target = linkPath(link.url);
+      if (target === null) continue;
 
       const abs = resolve(dirname(file), target);
       if (existsSync(abs)) continue;
 
-      const shown = toPosix(relative(process.cwd(), abs));
+      const kind = link.kind === 'image' ? 'image' : 'link';
+      const shown = relative(process.cwd(), abs);
       errors.push({
         file: relPath,
         line: link.line,
         target: link.url,
-        message:
-          `broken ${link.kind === 'image' ? 'image' : 'link'} ` +
-          `(${link.url}) — "${shown}" does not exist`,
+        message: `broken ${kind} (${link.url}) — file "${shown}" not found`,
       });
     }
   }
@@ -580,15 +540,13 @@ function formatErrorCount(count: number, s: Styler): string {
 export async function checkAllCommand(ctx: CmdContext): Promise<CmdResult> {
   const startTime = Date.now();
   const md = await checkMd(ctx.latDir);
-  const code = await checkCodeRefs(ctx.latDir);
   const linkErrors = await checkLinks(ctx.latDir);
+  const code = await checkCodeRefs(ctx.latDir);
   const indexErrors = await checkIndex(ctx.latDir);
   const sectionErrors = await checkSections(ctx.latDir);
   const elapsed = Date.now() - startTime;
 
-  // `checkLinks` re-reads the same lat.md/ files as `checkMd`, so its errors
-  // are merged but its file counts are not — they would double the scan total.
-  const allErrors = [...md.errors, ...code.errors, ...linkErrors];
+  const allErrors = [...md.errors, ...linkErrors, ...code.errors];
   const allFiles: FileStats = { ...md.files };
   for (const [ext, n] of Object.entries(code.files)) {
     allFiles[ext] = (allFiles[ext] || 0) + n;
@@ -671,6 +629,22 @@ export async function checkMdCommand(ctx: CmdContext): Promise<CmdResult> {
   return { output: lines.join('\n') };
 }
 
+export async function checkLinksCommand(ctx: CmdContext): Promise<CmdResult> {
+  const errors = await checkLinks(ctx.latDir);
+  const s = ctx.styler;
+  const lines: string[] = [];
+
+  lines.push(...formatCheckErrors(errors, s));
+
+  if (errors.length > 0) {
+    lines.push(formatErrorCount(errors.length, s));
+    return { output: lines.join('\n'), isError: true };
+  }
+
+  lines.push(s.green('links: All relative links resolve'));
+  return { output: lines.join('\n') };
+}
+
 export async function checkCodeRefsCommand(
   ctx: CmdContext,
 ): Promise<CmdResult> {
@@ -686,22 +660,6 @@ export async function checkCodeRefsCommand(
   }
 
   lines.push(s.green('code-refs: All references OK'));
-  return { output: lines.join('\n') };
-}
-
-export async function checkLinksCommand(ctx: CmdContext): Promise<CmdResult> {
-  const errors = await checkLinks(ctx.latDir);
-  const s = ctx.styler;
-  const lines: string[] = [];
-
-  lines.push(...formatCheckErrors(errors, s));
-
-  if (errors.length > 0) {
-    lines.push(formatErrorCount(errors.length, s));
-    return { output: lines.join('\n'), isError: true };
-  }
-
-  lines.push(s.green('links: All relative links resolve'));
   return { output: lines.join('\n') };
 }
 

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -1,4 +1,5 @@
-import { dirname } from 'node:path';
+import { statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import { styleText } from 'node:util';
 import { findLatticeDir } from '../lattice.js';
 import type { CmdContext, Styler } from '../context.js';
@@ -36,4 +37,38 @@ export function resolveContext(opts: {
 
   const projectRoot = dirname(latDir);
   return { latDir, projectRoot, styler: makeStyler(), mode: 'cli' };
+}
+
+export function resolveCheckContext(
+  opts: { dir?: string; color?: boolean },
+  target?: string,
+): CmdContext {
+  if (target === undefined) return resolveContext(opts);
+
+  if (opts.color === false) {
+    process.env.NO_COLOR = '1';
+  }
+
+  const projectRoot = resolve(opts.dir ?? process.cwd());
+  const latDir = resolve(projectRoot, target);
+  try {
+    if (!statSync(latDir).isDirectory()) {
+      console.error(
+        styleText('red', `Check target is not a directory: ${target}`),
+      );
+      process.exit(1);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    console.error(styleText('red', `Check directory not found: ${target}`));
+    process.exit(1);
+  }
+
+  return {
+    latDir,
+    projectRoot,
+    styler: makeStyler(),
+    mode: 'cli',
+    headless: true,
+  };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,8 +9,51 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
-import { resolveContext } from './context.js';
+import { resolveCheckContext, resolveContext } from './context.js';
 import type { CmdResult } from '../context.js';
+
+type CheckTargetArgs = {
+  args: string[];
+  target?: string;
+};
+
+/** Reserve `-- <directory>` for an explicit check target. */
+function splitCheckTarget(args: string[]): CheckTargetArgs {
+  let commandIndex = -1;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--dir') {
+      i++;
+      continue;
+    }
+    if (arg.startsWith('--dir=')) continue;
+    if (arg.startsWith('-')) continue;
+    commandIndex = i;
+    break;
+  }
+
+  if (commandIndex === -1 || args[commandIndex] !== 'check') {
+    return { args };
+  }
+
+  const separatorIndex = args.indexOf('--', commandIndex + 1);
+  if (separatorIndex === -1) return { args };
+
+  const targets = args.slice(separatorIndex + 1);
+  if (targets.length !== 1 || targets[0] === '') {
+    console.error(
+      'error: `lat check --` expects exactly one directory after `--`',
+    );
+    process.exit(1);
+  }
+
+  return {
+    args: args.slice(0, separatorIndex),
+    target: targets[0],
+  };
+}
+
+const checkTargetArgs = splitCheckTarget(process.argv.slice(2));
 
 function findPackageJson(): string {
   let dir = dirname(fileURLToPath(import.meta.url));
@@ -85,54 +128,60 @@ program
 
 const check = program
   .command('check')
-  .description('Validate links and code references')
+  .usage('[subcommand] [-- <directory>]')
+  .description('Validate markdown, links, code references, and structure')
   .action(async () => {
-    const ctx = resolveContext(program.opts());
+    const ctx = resolveCheckContext(program.opts(), checkTargetArgs.target);
     const { checkAllCommand } = await import('./check.js');
     handleResult(await checkAllCommand(ctx));
   });
 
 check
   .command('md')
-  .description('Validate wiki links in lat.md markdown files')
+  .usage('[-- <directory>]')
+  .description('Validate wiki links in markdown files')
   .action(async () => {
-    const ctx = resolveContext(program.opts());
+    const ctx = resolveCheckContext(program.opts(), checkTargetArgs.target);
     const { checkMdCommand } = await import('./check.js');
     handleResult(await checkMdCommand(ctx));
   });
 
 check
   .command('links')
-  .description('Validate relative markdown links in lat.md')
+  .usage('[-- <directory>]')
+  .description('Validate relative markdown links')
   .action(async () => {
-    const ctx = resolveContext(program.opts());
+    const ctx = resolveCheckContext(program.opts(), checkTargetArgs.target);
     const { checkLinksCommand } = await import('./check.js');
     handleResult(await checkLinksCommand(ctx));
   });
 
 check
   .command('code-refs')
+  .usage('[-- <directory>]')
   .description('Validate @lat code references and coverage')
   .action(async () => {
-    const ctx = resolveContext(program.opts());
+    const ctx = resolveCheckContext(program.opts(), checkTargetArgs.target);
     const { checkCodeRefsCommand } = await import('./check.js');
     handleResult(await checkCodeRefsCommand(ctx));
   });
 
 check
   .command('index')
-  .description('Validate directory index files in lat.md')
+  .usage('[-- <directory>]')
+  .description('Validate directory index files')
   .action(async () => {
-    const ctx = resolveContext(program.opts());
+    const ctx = resolveCheckContext(program.opts(), checkTargetArgs.target);
     const { checkIndexCommand } = await import('./check.js');
     handleResult(await checkIndexCommand(ctx));
   });
 
 check
   .command('sections')
-  .description('Validate section leading paragraphs in lat.md')
+  .usage('[-- <directory>]')
+  .description('Validate section leading paragraphs')
   .action(async () => {
-    const ctx = resolveContext(program.opts());
+    const ctx = resolveCheckContext(program.opts(), checkTargetArgs.target);
     const { checkSectionsCommand } = await import('./check.js');
     handleResult(await checkSectionsCommand(ctx));
   });
@@ -271,4 +320,4 @@ program
     console.log(`Config file: ${configPath}${exists ? '' : ' (not found)'}`);
   });
 
-await program.parseAsync();
+await program.parseAsync(checkTargetArgs.args, { from: 'user' });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -102,21 +102,21 @@ check
   });
 
 check
+  .command('links')
+  .description('Validate relative markdown links in lat.md')
+  .action(async () => {
+    const ctx = resolveContext(program.opts());
+    const { checkLinksCommand } = await import('./check.js');
+    handleResult(await checkLinksCommand(ctx));
+  });
+
+check
   .command('code-refs')
   .description('Validate @lat code references and coverage')
   .action(async () => {
     const ctx = resolveContext(program.opts());
     const { checkCodeRefsCommand } = await import('./check.js');
     handleResult(await checkCodeRefsCommand(ctx));
-  });
-
-check
-  .command('links')
-  .description('Validate relative markdown links to local files')
-  .action(async () => {
-    const ctx = resolveContext(program.opts());
-    const { checkLinksCommand } = await import('./check.js');
-    handleResult(await checkLinksCommand(ctx));
   });
 
 check

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -111,6 +111,15 @@ check
   });
 
 check
+  .command('links')
+  .description('Validate relative markdown links to local files')
+  .action(async () => {
+    const ctx = resolveContext(program.opts());
+    const { checkLinksCommand } = await import('./check.js');
+    handleResult(await checkLinksCommand(ctx));
+  });
+
+check
   .command('index')
   .description('Validate directory index files in lat.md')
   .action(async () => {

--- a/src/cli/refs.ts
+++ b/src/cli/refs.ts
@@ -8,6 +8,7 @@ import {
   extractRefs,
   flattenSections,
   buildFileIndex,
+  buildSectionSlugIndex,
   resolveRef,
   type Section,
   type SectionMatch,
@@ -194,7 +195,8 @@ export async function findRefs(
   const flat = flattenSections(allSections);
   const sectionIds = new Set(flat.map((s) => s.id.toLowerCase()));
   const fileIndex = buildFileIndex(allSections);
-  const { resolved } = resolveRef(query, sectionIds, fileIndex);
+  const slugIndex = buildSectionSlugIndex(allSections);
+  const { resolved } = resolveRef(query, sectionIds, fileIndex, slugIndex);
   const q = resolved.toLowerCase();
   let exactMatch = flat.find((s) => s.id.toLowerCase() === q);
 
@@ -232,6 +234,7 @@ export async function findRefs(
           ref.target,
           sectionIds,
           fileIndex,
+          slugIndex,
         );
         if (refResolved.toLowerCase() === targetId) {
           matchingFromSections.add(ref.fromSection.toLowerCase());
@@ -256,6 +259,7 @@ export async function findRefs(
         ref.target,
         sectionIds,
         fileIndex,
+        slugIndex,
       );
       if (codeResolved.toLowerCase() === targetId) {
         const displayPath = relative(

--- a/src/cli/section.ts
+++ b/src/cli/section.ts
@@ -6,6 +6,7 @@ import {
   flattenSections,
   extractRefs,
   buildFileIndex,
+  buildSectionSlugIndex,
   resolveRef,
   listLatticeFiles,
   type Section,
@@ -85,6 +86,7 @@ export async function getSection(
   const flat = flattenSections(allSections);
   const sectionIds = new Set(flat.map((s) => s.id.toLowerCase()));
   const fileIndex = buildFileIndex(allSections);
+  const slugIndex = buildSectionSlugIndex(allSections);
   const sectionRefs = extractRefs(absPath, fileContent, ctx.projectRoot);
   const sectionId = section.id.toLowerCase();
 
@@ -146,7 +148,12 @@ export async function getSection(
       }
       continue;
     }
-    const { resolved } = resolveRef(ref.target, sectionIds, fileIndex);
+    const { resolved } = resolveRef(
+      ref.target,
+      sectionIds,
+      fileIndex,
+      slugIndex,
+    );
     const resolvedLower = resolved.toLowerCase();
     if (seen.has(resolvedLower)) continue;
     seen.add(resolvedLower);
@@ -167,7 +174,12 @@ export async function getSection(
     const fc = await readFile(file, 'utf-8');
     const fileRefs = extractRefs(file, fc, ctx.projectRoot);
     for (const ref of fileRefs) {
-      const { resolved } = resolveRef(ref.target, sectionIds, fileIndex);
+      const { resolved } = resolveRef(
+        ref.target,
+        sectionIds,
+        fileIndex,
+        slugIndex,
+      );
       if (
         resolved.toLowerCase() === sectionId &&
         ref.fromSection.toLowerCase() !== sectionId
@@ -193,6 +205,7 @@ export async function getSection(
       ref.target,
       sectionIds,
       fileIndex,
+      slugIndex,
     );
     if (codeResolved.toLowerCase() === sectionId) {
       const absFile = join(ctx.projectRoot, ref.file);

--- a/src/context.ts
+++ b/src/context.ts
@@ -27,6 +27,8 @@ export type CmdContext = {
   projectRoot: string;
   styler: Styler;
   mode: 'cli' | 'mcp';
+  /** The check target was supplied explicitly instead of discovered as lat.md. */
+  headless?: boolean;
 };
 
 export type CmdResult = {

--- a/src/lattice.ts
+++ b/src/lattice.ts
@@ -232,8 +232,10 @@ export function parseSections(
   return roots;
 }
 
-export async function loadAllSections(latticeDir: string): Promise<Section[]> {
-  const projectRoot = dirname(latticeDir);
+export async function loadAllSections(
+  latticeDir: string,
+  projectRoot = dirname(latticeDir),
+): Promise<Section[]> {
   const files = await listLatticeFiles(latticeDir);
   const all: Section[] = [];
   for (const file of files) {

--- a/src/lattice.ts
+++ b/src/lattice.ts
@@ -35,7 +35,7 @@ export type Ref = {
 
 /** An ordinary markdown link, image, or reference definition. */
 export type MdLink = {
-  /** Destination exactly as authored — percent-escapes, query and fragment intact. */
+  /** Destination exactly as authored, percent-escapes and all. */
   url: string;
   kind: 'link' | 'image' | 'definition';
   line: number;
@@ -702,23 +702,17 @@ export function extractRefs(
 }
 
 /**
- * Extract every ordinary markdown link destination: inline links, images, and
- * reference definitions. Wiki links are a distinct node type and are handled by
- * [[src/lattice.ts#extractRefs]] instead.
- *
- * Destinations are returned verbatim — deciding which denote a path on disk is
- * the caller's job. Walking the mdast (rather than matching `[..](..)` with a
- * regex) is what keeps destinations inside fenced and inline code out of the
- * results: a code sample showing `[x](./missing.md)` documents a link, it is
- * not one.
+ * Extract ordinary markdown link destinations; wiki links are a separate node
+ * type, handled by `extractRefs`. Walking the mdast rather than regex-matching
+ * `[..](..)` is what keeps links inside code samples out of the results.
  */
 export function extractLinks(content: string): MdLink[] {
   const tree = parse(content);
   const links: MdLink[] = [];
 
   visit(tree, ['link', 'image', 'definition'], (node) => {
-    const n = node as Link | Image | Definition;
-    links.push({ url: n.url, kind: n.type, line: n.position!.start.line });
+    const { url, type, position } = node as Link | Image | Definition;
+    links.push({ url, kind: type, line: position!.start.line });
   });
 
   return links;

--- a/src/lattice.ts
+++ b/src/lattice.ts
@@ -33,13 +33,22 @@ export type Ref = {
   line: number;
 };
 
-/** An ordinary markdown link, image, or reference definition. */
-export type MdLink = {
-  /** Destination exactly as authored, percent-escapes and all. */
-  url: string;
-  kind: 'link' | 'image' | 'definition';
-  line: number;
-};
+/** An ordinary markdown destination or an undefined reference-style link. */
+export type MdLink =
+  | {
+      /** Destination exactly as authored, percent-escapes and all. */
+      url: string;
+      kind: 'link' | 'image' | 'definition';
+      line: number;
+    }
+  | {
+      /** Authored label that should have a matching definition. */
+      identifier: string;
+      /** Full reference syntax exactly as authored. */
+      source: string;
+      kind: 'linkReference' | 'imageReference';
+      line: number;
+    };
 
 export type LatFrontmatter = {
   requireCodeMention?: boolean;
@@ -701,11 +710,27 @@ export function extractRefs(
   return refs;
 }
 
-/**
- * Extract ordinary markdown link destinations; wiki links are a separate node
- * type, handled by `extractRefs`. Walking the mdast rather than regex-matching
- * `[..](..)` is what keeps links inside code samples out of the results.
- */
+function isEscapedAt(value: string, index: number): boolean {
+  let slashes = 0;
+  for (let i = index - 1; i >= 0 && value[i] === '\\'; i--) slashes++;
+  return slashes % 2 === 1;
+}
+
+function closingBracket(value: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < value.length; i++) {
+    if (isEscapedAt(value, i)) continue;
+    if (value[i] === '[') {
+      depth++;
+    } else if (value[i] === ']') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** Extract link destinations and undefined full/collapsed references. */
 export function extractLinks(content: string): MdLink[] {
   const tree = parse(content);
   const links: MdLink[] = [];
@@ -715,5 +740,79 @@ export function extractLinks(content: string): MdLink[] {
     links.push({ url, kind: type, line: position!.start.line });
   });
 
-  return links;
+  // CommonMark parses a reference with no matching definition as plain text,
+  // so it has no linkReference node to visit. Scan the authored syntax while
+  // excluding AST ranges where bracket text is data rather than prose.
+  const excluded: { start: number; end: number }[] = [];
+  visit(
+    tree,
+    [
+      'code',
+      'inlineCode',
+      'html',
+      'yaml',
+      'link',
+      'image',
+      'definition',
+      'linkReference',
+      'imageReference',
+      'wikiLink',
+    ],
+    (node) => {
+      const start = node.position?.start.offset;
+      const end = node.position?.end.offset;
+      if (start !== undefined && end !== undefined) {
+        excluded.push({ start, end });
+      }
+    },
+  );
+
+  const overlapsExcluded = (start: number, end: number) =>
+    excluded.some((range) => start < range.end && end > range.start);
+
+  for (let open = 0; open < content.length; open++) {
+    if (content[open] !== '[' || isEscapedAt(content, open)) continue;
+
+    const labelEnd = closingBracket(content, open);
+    const identifierStart = labelEnd + 1;
+    if (
+      labelEnd === -1 ||
+      content[identifierStart] !== '[' ||
+      isEscapedAt(content, identifierStart)
+    ) {
+      continue;
+    }
+
+    const identifierEnd = closingBracket(content, identifierStart);
+    if (identifierEnd === -1) continue;
+
+    const isImage =
+      open > 0 && content[open - 1] === '!' && !isEscapedAt(content, open - 1);
+    const start = isImage ? open - 1 : open;
+    const end = identifierEnd + 1;
+    if (overlapsExcluded(start, end)) {
+      open = identifierEnd;
+      continue;
+    }
+
+    const explicitIdentifier = content.slice(
+      identifierStart + 1,
+      identifierEnd,
+    );
+    const identifier = explicitIdentifier || content.slice(open + 1, labelEnd);
+    if (identifier.trim() === '') {
+      open = identifierEnd;
+      continue;
+    }
+
+    links.push({
+      identifier: identifier.trim(),
+      source: content.slice(start, end),
+      kind: isImage ? 'imageReference' : 'linkReference',
+      line: content.slice(0, start).split('\n').length,
+    });
+    open = identifierEnd;
+  }
+
+  return links.sort((a, b) => a.line - b.line);
 }

--- a/src/lattice.ts
+++ b/src/lattice.ts
@@ -4,7 +4,14 @@ import { existsSync, statSync } from 'node:fs';
 import { parse } from './parser.js';
 import { toPosix, walkEntries } from './walk.js';
 import { visit } from 'unist-util-visit';
-import type { Heading, RootContent, Text } from 'mdast';
+import type {
+  Definition,
+  Heading,
+  Image,
+  Link,
+  RootContent,
+  Text,
+} from 'mdast';
 import type { WikiLink } from './extensions/wiki-link/types.js';
 
 export type Section = {
@@ -23,6 +30,14 @@ export type Ref = {
   target: string;
   fromSection: string;
   file: string;
+  line: number;
+};
+
+/** An ordinary markdown link, image, or reference definition. */
+export type MdLink = {
+  /** Destination exactly as authored — percent-escapes, query and fragment intact. */
+  url: string;
+  kind: 'link' | 'image' | 'definition';
   line: number;
 };
 
@@ -684,4 +699,27 @@ export function extractRefs(
   });
 
   return refs;
+}
+
+/**
+ * Extract every ordinary markdown link destination: inline links, images, and
+ * reference definitions. Wiki links are a distinct node type and are handled by
+ * [[src/lattice.ts#extractRefs]] instead.
+ *
+ * Destinations are returned verbatim — deciding which denote a path on disk is
+ * the caller's job. Walking the mdast (rather than matching `[..](..)` with a
+ * regex) is what keeps destinations inside fenced and inline code out of the
+ * results: a code sample showing `[x](./missing.md)` documents a link, it is
+ * not one.
+ */
+export function extractLinks(content: string): MdLink[] {
+  const tree = parse(content);
+  const links: MdLink[] = [];
+
+  visit(tree, ['link', 'image', 'definition'], (node) => {
+    const n = node as Link | Image | Definition;
+    links.push({ url: n.url, kind: n.type, line: n.position!.start.line });
+  });
+
+  return links;
 }

--- a/src/lattice.ts
+++ b/src/lattice.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { dirname, join, basename, relative, resolve } from 'node:path';
 import { existsSync, statSync } from 'node:fs';
+import GithubSlugger from 'github-slugger';
 import { parse } from './parser.js';
 import { toPosix, walkEntries } from './walk.js';
 import { visit } from 'unist-util-visit';
@@ -24,6 +25,8 @@ export type Section = {
   startLine: number;
   endLine: number;
   firstParagraph: string;
+  /** GitHub-compatible anchor generated from the rendered heading text. */
+  githubSlug?: string;
 };
 
 export type Ref = {
@@ -98,6 +101,33 @@ function headingText(node: Heading): string {
     .join('');
 }
 
+/** Extract the rendered text GitHub uses as input to its heading slugger. */
+function githubHeadingText(node: unknown): string {
+  if (!node || typeof node !== 'object') return '';
+
+  const value = node as {
+    type?: string;
+    value?: string;
+    alt?: string | null;
+    data?: { alias?: string | null };
+    children?: unknown[];
+  };
+
+  if (value.type === 'text' || value.type === 'inlineCode') {
+    return value.value ?? '';
+  }
+  if (value.type === 'image' || value.type === 'imageReference') {
+    return value.alt ?? '';
+  }
+  if (value.type === 'wikiLink') {
+    return value.data?.alias ?? value.value ?? '';
+  }
+  if (value.children) {
+    return value.children.map(githubHeadingText).join('');
+  }
+  return '';
+}
+
 function inlineText(node: { children: RootContent[] }): string {
   return node.children
     .map((c) => {
@@ -131,6 +161,7 @@ export function parseSections(
   const roots: Section[] = [];
   const stack: Section[] = [];
   const flat: Section[] = [];
+  const slugger = new GithubSlugger();
 
   visit(tree, 'heading', (node: Heading) => {
     const heading = headingText(node);
@@ -155,6 +186,7 @@ export function parseSections(
       startLine,
       endLine: 0,
       firstParagraph: '',
+      githubSlug: slugger.slug(githubHeadingText(node)),
     };
 
     if (parent) {
@@ -282,6 +314,67 @@ export function buildFileIndex(sections: Section[]): Map<string, string[]> {
   return result;
 }
 
+export type SectionSlugIndex = ReadonlyMap<string, string>;
+
+/**
+ * Map GitHub-slugged heading paths back to canonical, literal-heading ids.
+ * Every path segment accepts either representation so an implicit literal h1
+ * can still prefix slugged child headings during short-ref resolution.
+ */
+export function buildSectionSlugIndex(
+  sections: Section[],
+): Map<string, string> {
+  const aliases = new Map<string, string>();
+  const stacks = new Map<
+    string,
+    { depth: number; literal: string; slug: string }[]
+  >();
+  const sluggers = new Map<string, GithubSlugger>();
+
+  for (const section of flattenSections(sections)) {
+    let slugger = sluggers.get(section.file);
+    if (!slugger) {
+      slugger = new GithubSlugger();
+      sluggers.set(section.file, slugger);
+    }
+
+    // Always advance the fallback slugger so manually constructed Section
+    // objects without githubSlug still get correct duplicate suffixes.
+    const fallbackSlug = slugger.slug(section.heading);
+    const headingSlug = section.githubSlug ?? fallbackSlug;
+    const stack = stacks.get(section.file) ?? [];
+    while (stack.length > 0 && stack[stack.length - 1].depth >= section.depth) {
+      stack.pop();
+    }
+
+    const levels = [
+      ...stack,
+      {
+        depth: section.depth,
+        literal: section.heading.toLowerCase(),
+        slug: headingSlug.toLowerCase(),
+      },
+    ];
+    let paths = [''];
+    for (const level of levels) {
+      const options = [...new Set([level.literal, level.slug])];
+      paths = paths.flatMap((path) =>
+        options.map((part) => (path ? `${path}#${part}` : part)),
+      );
+    }
+
+    for (const path of paths) {
+      const alias = `${section.file.toLowerCase()}#${path}`;
+      if (!aliases.has(alias)) aliases.set(alias, section.id);
+    }
+
+    stack.push(levels[levels.length - 1]);
+    stacks.set(section.file, stack);
+  }
+
+  return aliases;
+}
+
 export type ResolveResult = {
   resolved: string;
   ambiguous: string[] | null;
@@ -312,12 +405,36 @@ export function resolveRef(
   target: string,
   sectionIds: Set<string>,
   fileIndex: Map<string, string[]>,
+  slugIndex?: SectionSlugIndex,
 ): ResolveResult {
   target = normalizeRefFilePath(target);
 
+  const resolveKnown = (candidate: string): string | null => {
+    // Preserve existing wiki-link meaning when a literal heading happens to
+    // collide with a different heading's GitHub slug.
+    if (sectionIds.has(candidate.toLowerCase())) return candidate;
+    return slugIndex?.get(candidate.toLowerCase()) ?? null;
+  };
+
+  const resolveInFile = (file: string, rest: string): string | null => {
+    const direct = resolveKnown(file + rest);
+    if (direct) return direct;
+
+    // Try inserting root headings between file and rest. This also works for
+    // slugged child segments because the slug index contains mixed paths.
+    const rootHeadings = findRootHeadings(file, sectionIds);
+    for (const h1 of rootHeadings) {
+      const withRoot = rest ? `${file}#${h1}${rest}` : `${file}#${h1}`;
+      const resolved = resolveKnown(withRoot);
+      if (resolved) return resolved;
+    }
+    return null;
+  };
+
   // Already matches a known section — no resolution needed
-  if (sectionIds.has(target.toLowerCase())) {
-    return { resolved: target, ambiguous: null, suggested: null };
+  const direct = resolveKnown(target);
+  if (direct) {
+    return { resolved: direct, ambiguous: null, suggested: null };
   }
 
   // Extract the file segment (before first #) and try resolving it
@@ -334,31 +451,14 @@ export function resolveRef(
 
   if (filePaths.length === 1) {
     const fp = filePaths[0];
-    const expanded = fp + rest;
-    if (sectionIds.has(expanded.toLowerCase())) {
-      return { resolved: expanded, ambiguous: null, suggested: null };
-    }
-    // Try inserting root headings between file and rest.
-    // Handles Obsidian-style file#heading refs where the h1 is implicit.
-    const rootHeadings = findRootHeadings(fp, sectionIds);
-    for (const h1 of rootHeadings) {
-      const withRoot = rest ? `${fp}#${h1}${rest}` : `${fp}#${h1}`;
-      if (sectionIds.has(withRoot.toLowerCase())) {
-        return { resolved: withRoot, ambiguous: null, suggested: null };
-      }
+    const resolved = resolveInFile(fp, rest);
+    if (resolved) {
+      return { resolved, ambiguous: null, suggested: null };
     }
   } else if (filePaths.length > 1) {
     // Multiple files share this stem — ambiguous at the filename level
     const all = filePaths.map((c) => c + rest);
-    const valid = filePaths.filter((c) => {
-      if (sectionIds.has((c + rest).toLowerCase())) return true;
-      // Also try with root heading insertion
-      const rootHeadings = findRootHeadings(c, sectionIds);
-      return rootHeadings.some((h1) => {
-        const withRoot = rest ? `${c}#${h1}${rest}` : `${c}#${h1}`;
-        return sectionIds.has(withRoot.toLowerCase());
-      });
-    });
+    const valid = filePaths.filter((c) => resolveInFile(c, rest) !== null);
     return {
       resolved: target,
       ambiguous: all,
@@ -402,9 +502,21 @@ export function findSections(
   );
   const q = normalized.toLowerCase();
   const isFullPath = normalized.includes('#');
+  const byId = new Map(flat.map((s) => [s.id.toLowerCase(), s]));
+  const slugIndex = buildSectionSlugIndex(sections);
+
+  const sectionFor = (candidate: string): Section | undefined => {
+    const key = candidate.toLowerCase();
+    return byId.get(key) ?? byId.get(slugIndex.get(key)?.toLowerCase() ?? '');
+  };
 
   // Tier 1: exact full-id match
-  const exact = flat.filter((s) => s.id.toLowerCase() === q);
+  const literalExact = flat.filter((s) => s.id.toLowerCase() === q);
+  const slugExact =
+    literalExact.length === 0 && isFullPath
+      ? sectionFor(normalized)
+      : undefined;
+  const exact = slugExact ? [slugExact] : literalExact;
   const exactMatches: SectionMatch[] = exact.map((s) => ({
     section: s,
     reason: 'exact match',
@@ -459,11 +571,9 @@ export function findSections(
     const allPaths =
       stemPaths.length > 0 ? stemPaths : filePart ? [filePart] : [];
     for (const p of allPaths) {
-      const expanded = (p + rest).toLowerCase();
-      const s = flat.find(
-        (s) => s.id.toLowerCase() === expanded && !exact.includes(s),
-      );
+      const s = sectionFor(p + rest);
       if (s) {
+        if (exact.includes(s)) continue;
         stemMatches.push({
           section: s,
           reason:
@@ -480,11 +590,9 @@ export function findSections(
           !s.id.includes('#', s.file.length + 1),
       );
       for (const root of rootsOfFile) {
-        const withRoot = (root.id + rest).toLowerCase();
-        const match = flat.find(
-          (s) => s.id.toLowerCase() === withRoot && !exact.includes(s),
-        );
+        const match = sectionFor(root.id + rest);
         if (match) {
+          if (exact.includes(match)) continue;
           stemMatches.push({
             section: match,
             reason:
@@ -518,12 +626,32 @@ export function findSections(
     ...exact.map((s) => s.id),
     ...stemMatches.map((m) => m.section.id),
   ]);
+  const slugTailMatches = new Set<string>();
+  if (!isFullPath) {
+    for (const [alias, canonical] of slugIndex) {
+      if (alias.slice(alias.lastIndexOf('#') + 1) === q) {
+        slugTailMatches.add(canonical.toLowerCase());
+      }
+    }
+  }
+  const literalTailMatches = new Set(
+    isFullPath
+      ? []
+      : flat
+          .filter((s) =>
+            tailSegments(s.id).some((tail) => tail.toLowerCase() === q),
+          )
+          .map((s) => s.id.toLowerCase()),
+  );
   const subsection: SectionMatch[] = isFullPath
     ? []
     : flat
         .filter((s) => {
           if (seen.has(s.id)) return false;
-          return tailSegments(s.id).some((tail) => tail.toLowerCase() === q);
+          const id = s.id.toLowerCase();
+          return literalTailMatches.size > 0
+            ? literalTailMatches.has(id)
+            : slugTailMatches.has(id);
         })
         .map((s) => ({ section: s, reason: 'section name match' }));
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -75,7 +75,7 @@ export async function startMcpServer(): Promise<void> {
 
   server.tool(
     'lat_check',
-    'Validate all wiki links, code references, and directory indexes in lat.md',
+    'Run full lat.md validation: links, code references, indexes, and section structure',
     {},
     async () => toMcp(await checkAllCommand(ctx)),
   );

--- a/src/types/folder-xdg.d.ts
+++ b/src/types/folder-xdg.d.ts
@@ -10,5 +10,10 @@ declare module '@folder/xdg' {
     logs: string;
   }
 
-  export default function xdg(): XdgDirs;
+  interface XdgOptions {
+    env?: NodeJS.ProcessEnv;
+    platform?: NodeJS.Platform;
+  }
+
+  export default function xdg(options?: XdgOptions): XdgDirs;
 }

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -8,7 +8,7 @@
 After EVERY task, before responding to the user:
 
 - [ ] Update `lat.md/` if you added or changed any functionality, architecture, tests, or behavior
-- [ ] Run `lat check` — all wiki links and code refs must pass
+- [ ] Run `lat check` — all validations must pass
 - [ ] Do not skip these steps. Do not consider your task done until both are complete.
 
 ---
@@ -24,7 +24,7 @@ lat locate "Section Name"      # find a section by name (exact, fuzzy)
 lat refs "file#Section"        # find what references a section
 lat search "natural language"  # semantic search across all sections
 lat expand "user prompt text"  # expand [[refs]] to resolved locations
-lat check                      # validate all links and code refs
+lat check                      # run full graph and documentation validation
 ```
 
 Run `lat --help` when in doubt about available commands or options.

--- a/templates/cursor-rules.md
+++ b/templates/cursor-rules.md
@@ -8,7 +8,7 @@
 After EVERY task, before responding to the user:
 
 - [ ] Update `lat.md/` if you added or changed any functionality, architecture, tests, or behavior
-- [ ] Use the `lat_check` tool — all wiki links and code refs must pass
+- [ ] Use the `lat_check` tool — all validations must pass
 - [ ] Do not skip these steps. Do not consider your task done until both are complete.
 
 ---
@@ -24,7 +24,7 @@ You have access to the following MCP tools from the `lat` server:
 - **lat_locate** — find a section by name (exact, fuzzy)
 - **lat_search** — semantic search across all sections
 - **lat_expand** — expand `[[refs]]` in text to resolved locations
-- **lat_check** — validate all wiki links and code refs
+- **lat_check** — run full graph and documentation validation
 - **lat_refs** — find what references a section
 
 If `lat_search` fails because `LAT_LLM_KEY` is not set, explain to the user that semantic search requires an API key (`export LAT_LLM_KEY=sk-...` for OpenAI or `export LAT_LLM_KEY=vck_...` for Vercel). If the user doesn't want to set it up, use `lat_locate` for direct lookups instead.

--- a/templates/opencode-plugin.ts
+++ b/templates/opencode-plugin.ts
@@ -68,7 +68,7 @@ export const LatPlugin: Plugin = async (ctx) => {
 
       lat_check: tool({
         description:
-          "Validate all wiki links and code refs in lat.md. Returns errors or 'All checks passed'",
+          "Run full lat.md validation. Returns errors or 'All checks passed'",
         args: {},
         async execute() {
           try {

--- a/templates/pi-extension.ts
+++ b/templates/pi-extension.ts
@@ -146,8 +146,8 @@ export default function (pi: ExtensionAPI) {
     name: "lat_check",
     label: "lat check",
     description:
-      "Validate all wiki links and code refs in lat.md. Returns errors or 'All checks passed'",
-    promptSnippet: "Validate lat.md links and code refs",
+      "Run full lat.md validation. Returns errors or 'All checks passed'",
+    promptSnippet: "Run full lat.md validation",
     parameters: Type.Object({}),
     async execute() {
       try {

--- a/templates/skill/SKILL.md
+++ b/templates/skill/SKILL.md
@@ -164,6 +164,9 @@ Currently the only supported field is `require-code-mention` for test spec enfor
 
 Always run `lat check` after editing `lat.md/` files. It validates:
 - All wiki links point to existing sections or source code symbols
+- All relative markdown links point to existing files
+- Full and collapsed reference-style links have definitions
 - All `@lat:` code refs point to existing sections
 - Every section has a leading paragraph (≤250 chars)
 - All `require-code-mention` leaf sections are referenced in code
+- Every `lat.md/` directory has an accurate index

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -18,6 +18,7 @@ import {
   checkMd,
   checkCodeRefs,
   checkIndex,
+  checkLinks,
   checkSections,
 } from '../src/cli/check.js';
 import { scanCodeRefs } from '../src/code-refs.js';
@@ -344,6 +345,46 @@ describe('valid-links', () => {
   it('check md passes when all links resolve', async () => {
     const { errors } = await checkMd(latDir('valid-links'));
     expect(errors).toHaveLength(0);
+  });
+});
+
+// --- md-links ---
+
+describe('error-md-links', () => {
+  // @lat: [[check-links#Detects broken relative links]]
+  it('check links flags every relative form whose target is missing', async () => {
+    const errors = await checkLinks(latDir('error-md-links'));
+    expect(errors.map((e) => e.target)).toEqual([
+      'does-not-exist.md',
+      './does-not-exist.md',
+      '../does-not-exist.md',
+      './does-not-exist.md#Heading',
+      './does-not-exist.svg',
+    ]);
+    expect(errors[0].line).toBe(5);
+  });
+
+  // @lat: [[check-links#Reports anchors and images distinctly]]
+  it('check links drops the anchor when resolving and names images as images', async () => {
+    const errors = await checkLinks(latDir('error-md-links'));
+    const anchored = errors.find((e) => e.target.includes('#Heading'))!;
+    // The anchor is not part of the path, so the resolved file is reported
+    // without it. Whether `#Heading` itself exists is not validated.
+    expect(anchored.message).toContain('does-not-exist.md" does not exist');
+    expect(anchored.message).not.toContain('#Heading"');
+
+    const image = errors.find((e) => e.target.endsWith('.svg'))!;
+    expect(image.message).toContain('broken image');
+  });
+});
+
+// --- valid-md-links ---
+
+describe('valid-md-links', () => {
+  // @lat: [[check-links#Passes valid and skipped link forms]]
+  it('check links resolves local targets and skips non-path destinations', async () => {
+    const errors = await checkLinks(latDir('valid-md-links'));
+    expect(errors.map((e) => `${e.file}:${e.line} ${e.target}`)).toEqual([]);
   });
 });
 

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -352,29 +352,30 @@ describe('valid-links', () => {
 
 describe('error-md-links', () => {
   // @lat: [[check-links#Detects broken relative links]]
-  it('check links flags every relative form whose target is missing', async () => {
+  it('check links reports every broken destination at its line', async () => {
     const errors = await checkLinks(latDir('error-md-links'));
-    expect(errors.map((e) => e.target)).toEqual([
-      'does-not-exist.md',
-      './does-not-exist.md',
-      '../does-not-exist.md',
-      './does-not-exist.md#Heading',
-      './does-not-exist.svg',
+    expect(errors.map((e) => `${e.line}: ${e.target}`)).toEqual([
+      '5: does-not-exist.md',
+      '6: ./does-not-exist.md',
+      '7: ../does-not-exist.md',
+      '8: ./does-not-exist.md#Heading',
+      '9: ./50%.md',
+      '10: ./does-not-exist.svg',
+      '13: ./does-not-exist-def.md',
     ]);
-    expect(errors[0].line).toBe(5);
   });
 
-  // @lat: [[check-links#Reports anchors and images distinctly]]
-  it('check links drops the anchor when resolving and names images as images', async () => {
+  // @lat: [[check-links#Names the resolved file and the link kind]]
+  it('check links names the resolved file, with the anchor dropped', async () => {
     const errors = await checkLinks(latDir('error-md-links'));
-    const anchored = errors.find((e) => e.target.includes('#Heading'))!;
-    // The anchor is not part of the path, so the resolved file is reported
-    // without it. Whether `#Heading` itself exists is not validated.
-    expect(anchored.message).toContain('does-not-exist.md" does not exist');
-    expect(anchored.message).not.toContain('#Heading"');
+    const byTarget = new Map(errors.map((e) => [e.target, e]));
 
-    const image = errors.find((e) => e.target.endsWith('.svg'))!;
-    expect(image.message).toContain('broken image');
+    expect(byTarget.get('./does-not-exist.md#Heading')!.message).toContain(
+      'does-not-exist.md" not found',
+    );
+    expect(byTarget.get('./does-not-exist.svg')!.message).toContain(
+      'broken image',
+    );
   });
 });
 
@@ -384,7 +385,7 @@ describe('valid-md-links', () => {
   // @lat: [[check-links#Passes valid and skipped link forms]]
   it('check links resolves local targets and skips non-path destinations', async () => {
     const errors = await checkLinks(latDir('valid-md-links'));
-    expect(errors.map((e) => `${e.file}:${e.line} ${e.target}`)).toEqual([]);
+    expect(errors.map((e) => e.target)).toEqual([]);
   });
 });
 

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -370,6 +370,15 @@ describe('valid-links', () => {
     const { errors } = await checkMd(latDir('valid-links'));
     expect(errors).toHaveLength(0);
   });
+
+  // @lat: [[ref-resolution#Wiki links accept literal and GitHub headings]]
+  it('lat check md accepts literal headings and GitHub slugs', () => {
+    const { stdout, stderr, exitCode } = runCli('valid-links', ['check', 'md']);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe('');
+    expect(stdout).toContain('md: All links OK\n');
+  });
 });
 
 // --- md-links ---
@@ -395,11 +404,25 @@ describe('error-md-links', () => {
       'lat.md/a.md:12: undefined link reference',
       'lat.md/a.md:13: undefined image reference',
       'lat.md/a.md:14: undefined link reference',
-      'lat.md/a.md:16: broken link (./does-not-exist-def.md)',
+      'lat.md/a.md:15: broken link (#Alpha)',
+      'lat.md/a.md:17: broken link (./does-not-exist-def.md)',
     ]) {
       expect(output).toContain(expected);
     }
-    expect(output).toContain('10 errors found');
+    expect(output).toContain('11 errors found');
+  });
+
+  // @lat: [[check-links#Rejects non-GitHub heading fragments]]
+  it('lat check links rejects an Obsidian-style heading fragment', () => {
+    const { stderr: output, exitCode } = runCli('error-md-links', [
+      'check',
+      'links',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(output).toContain(
+      'broken link (#Alpha) — heading "#Alpha" not found in "lat.md/a.md"',
+    );
   });
 
   // @lat: [[check-links#Names the resolved file and the link kind]]
@@ -425,7 +448,7 @@ describe('error-md-links', () => {
     expect(exitCode).toBe(1);
     expect(stdout).toBe('');
     expect(output).toContain('lat.md/a.md:5: broken link (does-not-exist.md)');
-    expect(output).toContain('10 errors found');
+    expect(output).toContain('11 errors found');
     expect(output).not.toContain('missing index file');
   });
 });
@@ -435,6 +458,18 @@ describe('error-md-links', () => {
 describe('valid-md-links', () => {
   // @lat: [[check-links#Passes valid and skipped link forms]]
   it('lat check links accepts valid and skipped destinations', () => {
+    const { stdout, stderr, exitCode } = runCli('valid-md-links', [
+      'check',
+      'links',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe('');
+    expect(stdout).toBe('links: All relative links resolve\n');
+  });
+
+  // @lat: [[check-links#Accepts GitHub heading fragments]]
+  it('lat check links accepts punctuation and duplicate heading slugs', () => {
     const { stdout, stderr, exitCode } = runCli('valid-md-links', [
       'check',
       'links',
@@ -1160,6 +1195,26 @@ describe('getSection', () => {
     expect(result.kind).toBe('found');
     if (result.kind !== 'found') return;
     expect(result.section.id).toBe('lat.md/guides/setup#Setup#Install');
+  });
+
+  // @lat: [[tests/section#CLI accepts literal and GitHub heading syntax]]
+  it('lat section resolves literal and GitHub-slugged heading paths', () => {
+    const literal = runCli('basic-project', [
+      'section',
+      'dev-process#Testing#Running Tests',
+    ]);
+    const github = runCli('basic-project', [
+      'section',
+      'dev-process#testing#running-tests',
+    ]);
+
+    expect(literal.exitCode).toBe(0);
+    expect(github.exitCode).toBe(0);
+    expect(github.stderr).toBe('');
+    expect(stripAnsi(github.stdout)).toBe(stripAnsi(literal.stdout));
+    expect(stripAnsi(github.stdout)).toContain(
+      '[[lat.md/dev-process#Dev Process#Testing#Running Tests]]',
+    );
   });
 
   // @lat: [[tests/section#Section with no refs or links]]

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -405,11 +405,29 @@ describe('error-md-links', () => {
       'lat.md/a.md:13: undefined image reference',
       'lat.md/a.md:14: undefined link reference',
       'lat.md/a.md:15: broken link (#Alpha)',
-      'lat.md/a.md:17: broken link (./does-not-exist-def.md)',
+      'lat.md/a.md:20: broken link (./does-not-exist-def.md)',
     ]) {
       expect(output).toContain(expected);
     }
-    expect(output).toContain('11 errors found');
+    expect(output).toContain('14 errors found');
+  });
+
+  // @lat: [[check-links#Rejects backslash path separators]]
+  it('lat check links rejects Windows path separators', () => {
+    const { stderr: output, exitCode } = runCli('error-md-links', [
+      'check',
+      'links',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(output).toContain('invalid link (.\\a.md)');
+    expect(output).toContain('invalid link (.%5Ca.md)');
+    expect(output).toContain('invalid link (C:\\notes.md)');
+    expect(
+      output.match(
+        /backslashes are not path separators in Markdown; use "\/" instead/g,
+      ),
+    ).toHaveLength(3);
   });
 
   // @lat: [[check-links#Rejects non-GitHub heading fragments]]
@@ -448,7 +466,7 @@ describe('error-md-links', () => {
     expect(exitCode).toBe(1);
     expect(stdout).toBe('');
     expect(output).toContain('lat.md/a.md:5: broken link (does-not-exist.md)');
-    expect(output).toContain('11 errors found');
+    expect(output).toContain('14 errors found');
     expect(output).not.toContain('missing index file');
   });
 });

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -481,6 +481,80 @@ describe('valid-md-links', () => {
   });
 });
 
+// --- headless check targets ---
+
+describe('headless-check', () => {
+  // @lat: [[tests/check-headless#Separator disambiguates directory names]]
+  it('treats a name after -- as a directory, not a subcommand', () => {
+    const full = runCli('headless-check', ['check', '--', 'links']);
+    const subcommand = runCli('headless-check', ['check', 'links']);
+
+    expect(full.exitCode).toBe(0);
+    expect(full.stderr).toBe('');
+    expect(full.stdout).toContain('All checks passed');
+    expect(full.stdout).not.toContain('No init version recorded');
+
+    expect(subcommand.exitCode).toBe(0);
+    expect(subcommand.stderr).toBe('');
+    expect(subcommand.stdout).toBe('links: All relative links resolve\n');
+  });
+
+  // @lat: [[tests/check-headless#Every subcommand accepts a directory]]
+  it('runs every check subcommand against the explicit directory', () => {
+    const expected = new Map([
+      ['md', 'md: All links OK'],
+      ['links', 'links: All relative links resolve'],
+      ['code-refs', 'code-refs: All references OK'],
+      ['index', 'index: All directory index files OK'],
+      ['sections', 'sections: All sections have valid leading paragraphs'],
+    ]);
+
+    for (const [subcommand, message] of expected) {
+      const result = runCli('headless-check', [
+        'check',
+        subcommand,
+        '--',
+        'links',
+      ]);
+      expect(result.exitCode, subcommand).toBe(0);
+      expect(result.stderr, subcommand).toBe('');
+      expect(result.stdout, subcommand).toContain(message);
+    }
+  });
+
+  // @lat: [[tests/check-headless#Target syntax requires one directory]]
+  it('requires exactly one directory after the separator', () => {
+    for (const args of [
+      ['check', '--'],
+      ['check', '--', 'links', 'extra'],
+    ]) {
+      const result = runCli('headless-check', args);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('expects exactly one directory');
+    }
+  });
+});
+
+describe('error-headless-check', () => {
+  // @lat: [[tests/check-headless#Default check runs every validator]]
+  it('runs every validator against the explicit directory', () => {
+    const { stdout, stderr, exitCode } = runCli('error-headless-check', [
+      'check',
+      '--',
+      'links',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('broken link [[missing]]');
+    expect(stderr).toContain('broken link (missing.md)');
+    expect(stderr).toContain('@lat: [[cli#locate]]');
+    expect(stderr).toContain('missing index file "links.md"');
+    expect(stderr).toContain('has no leading paragraph');
+    expect(stderr).toContain('5 errors found');
+  });
+});
+
 // --- dangling-code-ref ---
 
 describe('error-dangling-code-ref', () => {

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import {
   findLatticeDir,
@@ -18,7 +18,6 @@ import {
   checkMd,
   checkCodeRefs,
   checkIndex,
-  checkLinks,
   checkSections,
 } from '../src/cli/check.js';
 import { scanCodeRefs } from '../src/code-refs.js';
@@ -29,6 +28,31 @@ import { getSection, formatSectionOutput } from '../src/cli/section.js';
 const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
 
 const casesDir = join(import.meta.dirname, 'cases');
+const cliPath = join(
+  import.meta.dirname,
+  '..',
+  'dist',
+  'src',
+  'cli',
+  'index.js',
+);
+
+function runCli(
+  caseName: string,
+  args: string[],
+): { stdout: string; stderr: string; exitCode: number } {
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: caseDir(caseName),
+    encoding: 'utf-8',
+    env: process.env,
+  });
+
+  return {
+    stdout: (result.stdout ?? '').replaceAll('\\', '/'),
+    stderr: result.stderr ?? '',
+    exitCode: result.status ?? 1,
+  };
+}
 
 function caseDir(name: string): string {
   return join(casesDir, name);
@@ -352,30 +376,57 @@ describe('valid-links', () => {
 
 describe('error-md-links', () => {
   // @lat: [[check-links#Detects broken relative links]]
-  it('check links reports every broken destination at its line', async () => {
-    const errors = await checkLinks(latDir('error-md-links'));
-    expect(errors.map((e) => `${e.line}: ${e.target}`)).toEqual([
-      '5: does-not-exist.md',
-      '6: ./does-not-exist.md',
-      '7: ../does-not-exist.md',
-      '8: ./does-not-exist.md#Heading',
-      '9: ./50%.md',
-      '10: ./does-not-exist.svg',
-      '13: ./does-not-exist-def.md',
-    ]);
+  it('lat check links reports every broken destination at its line', () => {
+    const {
+      stdout,
+      stderr: output,
+      exitCode,
+    } = runCli('error-md-links', ['check', 'links']);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe('');
+    for (const expected of [
+      'lat.md/a.md:5: broken link (does-not-exist.md)',
+      'lat.md/a.md:6: broken link (./does-not-exist.md)',
+      'lat.md/a.md:7: broken link (../does-not-exist.md)',
+      'lat.md/a.md:8: broken link (./does-not-exist.md#Heading)',
+      'lat.md/a.md:9: broken link (./50%.md)',
+      'lat.md/a.md:10: broken image (./does-not-exist.svg)',
+      'lat.md/a.md:12: undefined link reference',
+      'lat.md/a.md:13: undefined image reference',
+      'lat.md/a.md:14: undefined link reference',
+      'lat.md/a.md:16: broken link (./does-not-exist-def.md)',
+    ]) {
+      expect(output).toContain(expected);
+    }
+    expect(output).toContain('10 errors found');
   });
 
   // @lat: [[check-links#Names the resolved file and the link kind]]
-  it('check links names the resolved file, with the anchor dropped', async () => {
-    const errors = await checkLinks(latDir('error-md-links'));
-    const byTarget = new Map(errors.map((e) => [e.target, e]));
+  it('lat check links names resolved files and distinguishes images', () => {
+    const { stderr: output } = runCli('error-md-links', ['check', 'links']);
 
-    expect(byTarget.get('./does-not-exist.md#Heading')!.message).toContain(
-      'does-not-exist.md" not found',
+    expect(output).toContain(
+      'broken link (./does-not-exist.md#Heading) — file "lat.md/does-not-exist.md" not found',
     );
-    expect(byTarget.get('./does-not-exist.svg')!.message).toContain(
-      'broken image',
+    expect(output).toContain(
+      'undefined image reference (![undefined image][missing-image])',
     );
+  });
+
+  // @lat: [[check-links#Default check validates relative links]]
+  it('lat check includes relative-link validation', () => {
+    const {
+      stdout,
+      stderr: output,
+      exitCode,
+    } = runCli('error-md-links', ['check']);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe('');
+    expect(output).toContain('lat.md/a.md:5: broken link (does-not-exist.md)');
+    expect(output).toContain('10 errors found');
+    expect(output).not.toContain('missing index file');
   });
 });
 
@@ -383,9 +434,15 @@ describe('error-md-links', () => {
 
 describe('valid-md-links', () => {
   // @lat: [[check-links#Passes valid and skipped link forms]]
-  it('check links resolves local targets and skips non-path destinations', async () => {
-    const errors = await checkLinks(latDir('valid-md-links'));
-    expect(errors.map((e) => e.target)).toEqual([]);
+  it('lat check links accepts valid and skipped destinations', () => {
+    const { stdout, stderr, exitCode } = runCli('valid-md-links', [
+      'check',
+      'links',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe('');
+    expect(stdout).toBe('links: All relative links resolve\n');
   });
 });
 

--- a/tests/cases/error-headless-check/links/note.md
+++ b/tests/cases/error-headless-check/links/note.md
@@ -1,0 +1,9 @@
+# Note
+
+This page contains failures from independent validators.
+
+## Missing overview
+
+## Broken links
+
+These point to [[missing]] and [a missing file](missing.md).

--- a/tests/cases/error-headless-check/src/example.ts
+++ b/tests/cases/error-headless-check/src/example.ts
@@ -1,0 +1,3 @@
+// This resolves in lat.md itself but not in this fixture's checked directory.
+// @lat: [[cli#locate]]
+export const checked = false;

--- a/tests/cases/error-md-links/lat.md/a.md
+++ b/tests/cases/error-md-links/lat.md/a.md
@@ -9,5 +9,8 @@ Broken links of every relative shape.
 - [stray percent](./50%.md)
 - ![image](./does-not-exist.svg)
 - [reference][def]
+- [undefined reference][missing-def]
+- ![undefined image][missing-image]
+- [undefined collapsed][]
 
 [def]: ./does-not-exist-def.md

--- a/tests/cases/error-md-links/lat.md/a.md
+++ b/tests/cases/error-md-links/lat.md/a.md
@@ -12,5 +12,6 @@ Broken links of every relative shape.
 - [undefined reference][missing-def]
 - ![undefined image][missing-image]
 - [undefined collapsed][]
+- [Obsidian-style heading](#Alpha)
 
 [def]: ./does-not-exist-def.md

--- a/tests/cases/error-md-links/lat.md/a.md
+++ b/tests/cases/error-md-links/lat.md/a.md
@@ -13,5 +13,8 @@ Broken links of every relative shape.
 - ![undefined image][missing-image]
 - [undefined collapsed][]
 - [Obsidian-style heading](#Alpha)
+- [Windows separator](.\a.md)
+- [encoded Windows separator](.%5Ca.md)
+- [Windows absolute path](C:\notes.md)
 
 [def]: ./does-not-exist-def.md

--- a/tests/cases/error-md-links/lat.md/a.md
+++ b/tests/cases/error-md-links/lat.md/a.md
@@ -1,0 +1,9 @@
+# Alpha
+
+Broken links of every relative shape.
+
+- [bare](does-not-exist.md)
+- [dot slash](./does-not-exist.md)
+- [parent](../does-not-exist.md)
+- [anchored](./does-not-exist.md#Heading)
+- ![image](./does-not-exist.svg)

--- a/tests/cases/error-md-links/lat.md/a.md
+++ b/tests/cases/error-md-links/lat.md/a.md
@@ -6,4 +6,8 @@ Broken links of every relative shape.
 - [dot slash](./does-not-exist.md)
 - [parent](../does-not-exist.md)
 - [anchored](./does-not-exist.md#Heading)
+- [stray percent](./50%.md)
 - ![image](./does-not-exist.svg)
+- [reference][def]
+
+[def]: ./does-not-exist-def.md

--- a/tests/cases/error-md-links/lat.md/lat.md
+++ b/tests/cases/error-md-links/lat.md/lat.md
@@ -1,0 +1,3 @@
+Project index for the broken-link fixture.
+
+- [[a]] — Markdown containing broken relative links

--- a/tests/cases/headless-check/links/cli.md
+++ b/tests/cases/headless-check/links/cli.md
@@ -1,0 +1,7 @@
+---
+lat:
+  require-code-mention: true
+---
+# check
+
+This page proves that headless code references resolve from the project root.

--- a/tests/cases/headless-check/links/links.md
+++ b/tests/cases/headless-check/links/links.md
@@ -1,0 +1,7 @@
+# Links
+
+This directory is deliberately named like a check subcommand.
+
+- [[cli]] — A page that is covered by a source-code reference.
+
+See the [check command](cli.md#check).

--- a/tests/cases/headless-check/src/example.ts
+++ b/tests/cases/headless-check/src/example.ts
@@ -1,0 +1,2 @@
+// @lat: [[cli#check]]
+export const checked = true;

--- a/tests/cases/valid-links/lat.md/a.md
+++ b/tests/cases/valid-links/lat.md/a.md
@@ -3,3 +3,7 @@
 ## Beta
 
 See [[a#Beta]] here.
+
+## Some Section!
+
+Both [[a#Some Section!]] and [[a#some-section]] resolve to this section.

--- a/tests/cases/valid-md-links/lat.md/a.md
+++ b/tests/cases/valid-md-links/lat.md/a.md
@@ -23,4 +23,16 @@ Skipped forms:
 
 Code is not a link: `[fake](./nope.md)`
 
+Escaped reference syntax is not a link: \[fake][missing]
+
+Undefined shortcut brackets remain text: [not-a-reference]
+
+HTML is not markdown link syntax: <span data-example="[fake][missing]">text</span>
+
+Fenced code is not a link:
+
+```markdown
+[fake][missing]
+```
+
 [bravo]: ./b.md

--- a/tests/cases/valid-md-links/lat.md/a.md
+++ b/tests/cases/valid-md-links/lat.md/a.md
@@ -1,0 +1,23 @@
+# Alpha
+
+Every link form that must resolve, and every form that must be skipped.
+
+- [bare](b.md)
+- [dot slash](./b.md)
+- [nested](./sub/c.md)
+- [outside the graph](../outside.md)
+- [anchored](b.md#Bravo)
+- [with a query](b.md?raw=1)
+- [encoded space](./has%20space.md)
+- ![image](../logo.svg)
+
+Skipped forms:
+
+- [https](https://example.com/nope.md)
+- [mailto](mailto:nobody@example.com)
+- [protocol relative](//example.com/nope.md)
+- [root absolute](/nope.md)
+- [pure anchor](#alpha)
+- [query only](?tab=1)
+
+Code is not a link: `[fake](./nope.md)`

--- a/tests/cases/valid-md-links/lat.md/a.md
+++ b/tests/cases/valid-md-links/lat.md/a.md
@@ -3,21 +3,24 @@
 Every link form that must resolve, and every form that must be skipped.
 
 - [bare](b.md)
-- [dot slash](./b.md)
 - [nested](./sub/c.md)
 - [outside the graph](../outside.md)
 - [anchored](b.md#Bravo)
 - [with a query](b.md?raw=1)
 - [encoded space](./has%20space.md)
+- [reference][bravo]
 - ![image](../logo.svg)
 
 Skipped forms:
 
 - [https](https://example.com/nope.md)
 - [mailto](mailto:nobody@example.com)
+- [windows drive](C:/nope.md)
 - [protocol relative](//example.com/nope.md)
 - [root absolute](/nope.md)
 - [pure anchor](#alpha)
 - [query only](?tab=1)
 
 Code is not a link: `[fake](./nope.md)`
+
+[bravo]: ./b.md

--- a/tests/cases/valid-md-links/lat.md/a.md
+++ b/tests/cases/valid-md-links/lat.md/a.md
@@ -5,7 +5,9 @@ Every link form that must resolve, and every form that must be skipped.
 - [bare](b.md)
 - [nested](./sub/c.md)
 - [outside the graph](../outside.md)
-- [anchored](b.md#Bravo)
+- [anchored](b.md#bravo)
+- [punctuation heading](b.md#hello-world)
+- [duplicate heading](b.md#repeat-1)
 - [with a query](b.md?raw=1)
 - [encoded space](./has%20space.md)
 - [reference][bravo]

--- a/tests/cases/valid-md-links/lat.md/b.md
+++ b/tests/cases/valid-md-links/lat.md/b.md
@@ -1,3 +1,15 @@
 # Bravo
 
 A sibling target inside the graph.
+
+## Hello, World!
+
+GitHub removes punctuation when it forms this heading's fragment.
+
+## Repeat
+
+The first repeated heading owns the unsuffixed fragment.
+
+## Repeat
+
+The second repeated heading receives GitHub's `-1` suffix.

--- a/tests/cases/valid-md-links/lat.md/b.md
+++ b/tests/cases/valid-md-links/lat.md/b.md
@@ -1,0 +1,3 @@
+# Bravo
+
+A sibling target inside the graph.

--- a/tests/cases/valid-md-links/lat.md/has space.md
+++ b/tests/cases/valid-md-links/lat.md/has space.md
@@ -1,0 +1,3 @@
+# Has Space
+
+A target whose name needs percent-encoding in a link.

--- a/tests/cases/valid-md-links/lat.md/sub/c.md
+++ b/tests/cases/valid-md-links/lat.md/sub/c.md
@@ -1,0 +1,6 @@
+# Charlie
+
+A nested file linking back up, to prove targets resolve against the
+containing file's directory rather than the graph root.
+
+- [up to bravo](../b.md)

--- a/tests/cases/valid-md-links/lat.md/sub/c.md
+++ b/tests/cases/valid-md-links/lat.md/sub/c.md
@@ -1,6 +1,5 @@
 # Charlie
 
-A nested file linking back up, to prove targets resolve against the
-containing file's directory rather than the graph root.
+A nested file linking back up, to prove targets resolve against the containing file's directory rather than the graph root.
 
 - [up to bravo](../b.md)

--- a/tests/cases/valid-md-links/logo.svg
+++ b/tests/cases/valid-md-links/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>

--- a/tests/cases/valid-md-links/outside.md
+++ b/tests/cases/valid-md-links/outside.md
@@ -1,0 +1,3 @@
+# Outside
+
+A file outside the graph directory, linked to from inside it.

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,31 +1,56 @@
+import { spawnSync } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import xdg from '@folder/xdg';
 import {
   INIT_VERSION,
   readInitVersion,
   writeInitMeta,
 } from '../src/init-version.js';
-import {
-  closeDb,
-  ensureMeta,
-  openDb,
-  setStoredModel,
-} from '../src/search/db.js';
+
+const cliPath = join(
+  import.meta.dirname,
+  '..',
+  'dist',
+  'src',
+  'cli',
+  'index.js',
+);
+const disableNetworkUrl = pathToFileURL(
+  join(import.meta.dirname, 'support', 'disable-network.mjs'),
+).href;
+const seedDbPath = join(import.meta.dirname, 'support', 'seed-model.mjs');
 
 const {
+  closeDb,
+  ensureMeta,
   getLlmKey,
   getRepoEmbedding,
-  setRepoEmbedding,
-  selectMenu,
+  getStoredModel,
+  openDb,
   reindexCommand,
+  selectMenu,
+  setRepoEmbedding,
 } = vi.hoisted(() => ({
+  closeDb: vi.fn(async () => {}),
+  ensureMeta: vi.fn(async () => {}),
   getLlmKey: vi.fn(),
   getRepoEmbedding: vi.fn(),
-  setRepoEmbedding: vi.fn(),
-  selectMenu: vi.fn(),
+  getStoredModel: vi.fn(async () => null as string | null),
+  openDb: vi.fn(() => ({})),
   reindexCommand: vi.fn(),
+  selectMenu: vi.fn(),
+  setRepoEmbedding: vi.fn(),
 }));
 
 vi.mock('../src/config.js', () => ({
@@ -42,30 +67,116 @@ vi.mock('../src/cli/checklist-menu.js', () => ({
 }));
 vi.mock('../src/cli/select-menu.js', () => ({ selectMenu }));
 vi.mock('../src/cli/reindex.js', () => ({ reindexCommand }));
+vi.mock('../src/search/db.js', () => ({
+  closeDb,
+  ensureMeta,
+  getStoredModel,
+  openDb,
+}));
 
 import { initCmd } from '../src/cli/init.js';
+
+type CliResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
 
 describe('lat init embedding setup', () => {
   let root: string;
   let stdinIsTTY: PropertyDescriptor | undefined;
 
+  function latDir(): string {
+    return join(root, 'lat.md');
+  }
+
+  function configPath(): string {
+    const env = {
+      ...process.env,
+      XDG_CONFIG_HOME: join(root, '.config'),
+    };
+    return join(xdg({ env }).config, 'lat', 'config.json');
+  }
+
+  function createLatDir(): void {
+    mkdirSync(latDir(), { recursive: true });
+  }
+
   /** Stamp a setup one version behind, so init treats it as outdated. */
-  function writeOutdatedInitMeta(latDir: string): void {
-    mkdirSync(join(latDir, '.cache'), { recursive: true });
+  function writeOutdatedInitMeta(): void {
+    createLatDir();
+    writeInitMeta(latDir(), {});
+    const path = join(latDir(), '.cache', 'lat_init.json');
+    const meta = JSON.parse(readFileSync(path, 'utf-8')) as {
+      init_version: number;
+    };
+    meta.init_version = INIT_VERSION - 1;
+    writeFileSync(path, JSON.stringify(meta, null, 2) + '\n');
+  }
+
+  function writeRepoEmbedding(embedding: 'local'): void {
+    const path = configPath();
+    mkdirSync(dirname(path), { recursive: true });
     writeFileSync(
-      join(latDir, '.cache', 'lat_init.json'),
-      JSON.stringify({ init_version: INIT_VERSION - 1, file_hashes: {} }),
+      path,
+      JSON.stringify(
+        { repos: { [resolve(latDir())]: { embedding } } },
+        null,
+        2,
+      ) + '\n',
     );
   }
 
-  async function writeStoredModel(
-    latDir: string,
-    model: string,
-  ): Promise<void> {
-    const db = openDb(latDir);
-    await ensureMeta(db);
-    await setStoredModel(db, model);
-    await closeDb(db);
+  function readRepoEmbedding(): 'local' | undefined {
+    if (!existsSync(configPath())) return undefined;
+    const config = JSON.parse(readFileSync(configPath(), 'utf-8')) as {
+      repos?: Record<string, { embedding?: 'local' }>;
+    };
+    return config.repos?.[resolve(latDir())]?.embedding;
+  }
+
+  function seedStoredModel(model: string): void {
+    createLatDir();
+    const result = spawnSync(process.execPath, [seedDbPath, latDir(), model], {
+      encoding: 'utf-8',
+    });
+    if (result.error) throw result.error;
+    expect(result.status, result.stderr).toBe(0);
+  }
+
+  function mockStoredModel(model: string): void {
+    mkdirSync(join(latDir(), '.cache'), { recursive: true });
+    writeFileSync(join(latDir(), '.cache', 'vectors.db'), '');
+    getStoredModel.mockResolvedValue(model);
+  }
+
+  function runInit(key?: string): CliResult {
+    const result = spawnSync(
+      process.execPath,
+      ['--import', disableNetworkUrl, cliPath, '--no-color', 'init', root],
+      {
+        cwd: root,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          XDG_CONFIG_HOME: join(root, '.config'),
+          LAT_LLM_KEY: key ?? '',
+          LAT_LLM_KEY_FILE: '',
+          LAT_LLM_KEY_HELPER: '',
+          NO_COLOR: '1',
+        },
+      },
+    );
+    if (result.error) throw result.error;
+    return {
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      exitCode: result.status ?? 1,
+    };
+  }
+
+  function expectSuccess(result: CliResult): void {
+    expect(result.exitCode, result.stderr).toBe(0);
   }
 
   function setInteractive(interactive: boolean): void {
@@ -79,12 +190,17 @@ describe('lat init embedding setup', () => {
     root = mkdtempSync(join(tmpdir(), 'lat-init-'));
     stdinIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
     setInteractive(false);
+    closeDb.mockClear();
+    ensureMeta.mockClear();
     getLlmKey.mockReset();
     getRepoEmbedding.mockReset();
-    setRepoEmbedding.mockClear();
-    selectMenu.mockReset();
+    getStoredModel.mockReset();
+    getStoredModel.mockResolvedValue(null);
+    openDb.mockClear();
     reindexCommand.mockReset();
     reindexCommand.mockResolvedValue({ output: 'Reindexed.' });
+    selectMenu.mockReset();
+    setRepoEmbedding.mockClear();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
@@ -101,24 +217,17 @@ describe('lat init embedding setup', () => {
   });
 
   // @lat: [[init#Embedding setup#Fresh init pins local embeddings]]
-  it('pins local embeddings before agent selection on a fresh init', async () => {
-    getLlmKey.mockReturnValue('sk-test');
+  it('pins local embeddings before agent selection on a fresh init', () => {
+    const result = runInit('sk-test');
 
-    await initCmd(root);
-
-    expect(selectMenu).not.toHaveBeenCalled();
-    expect(setRepoEmbedding).toHaveBeenCalledOnce();
-    expect(setRepoEmbedding).toHaveBeenCalledWith(
-      resolve(root, 'lat.md'),
-      'local',
-    );
-    expect(readInitVersion(resolve(root, 'lat.md'))).toBe(INIT_VERSION);
+    expectSuccess(result);
+    expect(readRepoEmbedding()).toBe('local');
+    expect(readInitVersion(latDir())).toBe(INIT_VERSION);
   });
 
   // @lat: [[init#Embedding setup#Configured key asks for a backend]]
   it('allows a configured key to opt the repo into hosted embeddings', async () => {
-    const latDir = join(root, 'lat.md');
-    mkdirSync(latDir, { recursive: true });
+    createLatDir();
     getLlmKey.mockReturnValue('sk-test');
     selectMenu.mockResolvedValue('remote');
     setInteractive(true);
@@ -133,14 +242,13 @@ describe('lat init embedding setup', () => {
       'Embedding backend',
       0,
     );
-    expect(setRepoEmbedding).toHaveBeenCalledWith(latDir, null);
+    expect(setRepoEmbedding).toHaveBeenCalledWith(latDir(), null);
   });
 
   // @lat: [[init#Embedding setup#Backend mismatch offers reindexing]]
   it('offers and runs a local reindex for an existing remote index', async () => {
-    const latDir = join(root, 'lat.md');
-    mkdirSync(latDir, { recursive: true });
-    await writeStoredModel(latDir, 'openai:1536');
+    createLatDir();
+    mockStoredModel('openai:1536');
     selectMenu.mockResolvedValue('now');
     setInteractive(true);
 
@@ -152,29 +260,32 @@ describe('lat init embedding setup', () => {
       0,
     );
     expect(reindexCommand).toHaveBeenCalledWith(
-      expect.objectContaining({ latDir, projectRoot: root, mode: 'cli' }),
+      expect.objectContaining({
+        latDir: latDir(),
+        projectRoot: root,
+        mode: 'cli',
+      }),
       { local: true },
     );
   });
 
   // @lat: [[init#Embedding setup#Current setup preserves explicit backend choice]]
-  it('does not overwrite the backend choice on a current re-run', async () => {
-    const latDir = join(root, 'lat.md');
-    mkdirSync(latDir, { recursive: true });
-    writeInitMeta(latDir, {});
-    getRepoEmbedding.mockReturnValue('local');
+  it('does not overwrite the backend choice on a current re-run', () => {
+    createLatDir();
+    writeInitMeta(latDir(), {});
+    writeRepoEmbedding('local');
 
-    await initCmd(root);
+    const result = runInit();
 
-    expect(setRepoEmbedding).not.toHaveBeenCalled();
+    expectSuccess(result);
+    expect(readRepoEmbedding()).toBe('local');
   });
 
   // @lat: [[init#Embedding setup#Hosted re-run defaults to hosted]]
   it('defaults an interactive hosted re-run to its existing backend', async () => {
-    const latDir = join(root, 'lat.md');
-    mkdirSync(latDir, { recursive: true });
-    writeInitMeta(latDir, {});
-    await writeStoredModel(latDir, 'openai:1536');
+    createLatDir();
+    writeInitMeta(latDir(), {});
+    mockStoredModel('openai:1536');
     getLlmKey.mockReturnValue('sk-test');
     selectMenu.mockResolvedValue('remote');
     setInteractive(true);
@@ -186,87 +297,71 @@ describe('lat init embedding setup', () => {
       'Embedding backend',
       1,
     );
-    expect(setRepoEmbedding).toHaveBeenCalledWith(latDir, null);
+    expect(setRepoEmbedding).toHaveBeenCalledWith(latDir(), null);
     expect(reindexCommand).not.toHaveBeenCalled();
   });
 
   // @lat: [[init#Embedding setup#Non-interactive re-run does not choose]]
-  it('does not prompt or mutate a current hosted repo without a TTY', async () => {
-    const latDir = join(root, 'lat.md');
-    mkdirSync(latDir, { recursive: true });
-    writeInitMeta(latDir, {});
-    await writeStoredModel(latDir, 'openai:1536');
-    getLlmKey.mockReturnValue('sk-test');
+  it('does not prompt or mutate a current hosted repo without a TTY', () => {
+    createLatDir();
+    writeInitMeta(latDir(), {});
+    seedStoredModel('openai:1536');
 
-    await initCmd(root);
+    const result = runInit('sk-test');
 
-    expect(selectMenu).not.toHaveBeenCalled();
-    expect(setRepoEmbedding).not.toHaveBeenCalled();
-    expect(reindexCommand).not.toHaveBeenCalled();
+    expectSuccess(result);
+    expect(result.stdout).not.toContain('Embedding backend');
+    expect(readRepoEmbedding()).toBeUndefined();
   });
 
   // @lat: [[init#Embedding setup#Outdated re-run keeps a working hosted index]]
-  it('leaves an outdated hosted repo on its existing backend', async () => {
-    const latDir = join(root, 'lat.md');
-    mkdirSync(latDir, { recursive: true });
-    writeOutdatedInitMeta(latDir);
-    await writeStoredModel(latDir, 'openai:1536');
-    getLlmKey.mockReturnValue('sk-test');
+  it('leaves an outdated hosted repo on its existing backend', () => {
+    writeOutdatedInitMeta();
+    seedStoredModel('openai:1536');
 
-    await initCmd(root);
+    const result = runInit('sk-test');
 
-    expect(setRepoEmbedding).not.toHaveBeenCalled();
-    expect(reindexCommand).not.toHaveBeenCalled();
-    expect(console.log).not.toHaveBeenCalledWith(
-      expect.stringContaining('lat reindex --local'),
-    );
+    expectSuccess(result);
+    expect(readRepoEmbedding()).toBeUndefined();
+    expect(result.stdout).not.toContain('lat reindex --local');
   });
 
   // @lat: [[init#Embedding setup#Outdated hosted provider mismatch defaults local]]
-  it('defaults an outdated hosted repo to local when its key provider changed', async () => {
-    const latDir = join(root, 'lat.md');
-    mkdirSync(latDir, { recursive: true });
-    writeOutdatedInitMeta(latDir);
-    await writeStoredModel(latDir, 'openai:1536');
-    getLlmKey.mockReturnValue('vck_test');
+  it('defaults an outdated hosted repo to local when its key provider changed', () => {
+    writeOutdatedInitMeta();
+    seedStoredModel('openai:1536');
 
-    await initCmd(root);
+    const result = runInit('vck_test');
 
-    expect(setRepoEmbedding).toHaveBeenCalledWith(latDir, 'local');
-    expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('lat reindex --local'),
-    );
+    expectSuccess(result);
+    expect(readRepoEmbedding()).toBe('local');
+    expect(result.stdout).toContain('lat reindex --local');
   });
 
   // @lat: [[init#Embedding setup#Hosted provider mismatch offers reindexing]]
-  it('prints a remote reindex command when the hosted provider changed', async () => {
-    const latDir = join(root, 'lat.md');
-    mkdirSync(latDir, { recursive: true });
-    writeInitMeta(latDir, {});
-    await writeStoredModel(latDir, 'openai:1536');
-    getLlmKey.mockReturnValue('vck_test');
+  it('prints a remote reindex command when the hosted provider changed', () => {
+    createLatDir();
+    writeInitMeta(latDir(), {});
+    seedStoredModel('openai:1536');
 
-    await initCmd(root);
+    const result = runInit('vck_test');
 
-    expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('lat reindex --remote'),
-    );
-    expect(reindexCommand).not.toHaveBeenCalled();
+    expectSuccess(result);
+    expect(result.stdout).toContain('lat reindex --remote');
+    expect(readRepoEmbedding()).toBeUndefined();
   });
 
   // @lat: [[init#Embedding setup#Non-interactive mismatch prints command]]
-  it('prints the reindex command for a non-interactive mismatch', async () => {
-    const latDir = join(root, 'lat.md');
-    mkdirSync(latDir, { recursive: true });
-    writeInitMeta(latDir, {});
-    await writeStoredModel(latDir, 'openai:1536');
-    getRepoEmbedding.mockReturnValue('local');
+  it('prints the reindex command for a non-interactive mismatch', () => {
+    createLatDir();
+    writeInitMeta(latDir(), {});
+    seedStoredModel('openai:1536');
+    writeRepoEmbedding('local');
 
-    await initCmd(root);
+    const result = runInit();
 
-    expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('lat reindex --local'),
-    );
-    expect(reindexCommand).not.toHaveBeenCalled();
+    expectSuccess(result);
+    expect(result.stdout).toContain('lat reindex --local');
+    expect(readRepoEmbedding()).toBe('local');
   });
 });

--- a/tests/support/disable-network.mjs
+++ b/tests/support/disable-network.mjs
@@ -1,0 +1,1 @@
+globalThis.fetch = async () => new Response(null, { status: 503 });

--- a/tests/support/seed-model.mjs
+++ b/tests/support/seed-model.mjs
@@ -1,0 +1,19 @@
+import {
+  closeDb,
+  ensureMeta,
+  openDb,
+  setStoredModel,
+} from '../../dist/src/search/db.js';
+
+const [latDir, model] = process.argv.slice(2);
+if (!latDir || !model) {
+  throw new Error('usage: seed-model.mjs <lat-dir> <model>');
+}
+
+const db = openDb(latDir);
+try {
+  await ensureMeta(db);
+  await setStoredModel(db, model);
+} finally {
+  await closeDb(db);
+}


### PR DESCRIPTION
## Context

Supersedes #86, preserving its commits and authorship while incorporating the
follow-up compatibility and CLI work from review.

Closes #87.

## What changed

- Add regular Markdown link validation to the default lat check and expose it
  separately through lat check links.
- Validate local files, images, reference-style links, and GitHub-style heading
  fragments.
- Reject literal and percent-encoded backslashes in local Markdown paths; `/`
  is the portable separator on every operating system.
- Keep literal Obsidian heading paths canonical for wiki links while also
  accepting GitHub-style heading slugs transparently.
- Add explicit directory validation with lat check -- <directory>.
- Support the same explicit directory suffix on md, links, code-refs, index,
  and sections subcommands.
- Resolve section IDs and code references from the containing project root.
- Skip lat init metadata warnings for explicit directories that have not yet
  adopted the full lat.md setup.

The -- separator is intentional: lat check links selects the links subcommand,
while lat check -- links performs every validation against a directory named
links.

## Compatibility

Existing lat check behavior remains the full validation path for lat.md/. Wiki
link output and canonical IDs remain unchanged; GitHub slugs are accepted as an
additional input form.

## Verification

- pnpm test: 191 tests passed
- lat check: passed
- Functional fixtures cover aggregate validation, every subcommand, GitHub
  fragments, portable path separators, and subcommand-directory ambiguity.