### PR TITLE
Clarify ownership of generated lat guidance

### DIFF
--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -241,6 +241,12 @@ All setup steps are idempotent — existing configuration is detected and skippe
 
 `.gitignore` entries are only added if the target path is not already tracked in git (`git ls-files`); if tracked, the step prints a warning and skips to avoid a no-op ignore rule.
 
+### Generated instruction ownership
+
+Generated agent instructions and `lat-md` skills direct project-specific documentation into `lat.md/` so it survives setup refreshes.
+
+The `AGENTS.md` and `lat-md` `SKILL.md` templates state that these generated files are owned by lat tooling and may be replaced by a later `lat init`. Agents must record project guidance in `lat.md/` rather than changing generated copies.
+
 ### Marker-based append mode
 
 Shared files use `appendTemplateSection` to preserve user content outside lat's managed section.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -17,6 +17,8 @@ After EVERY task, before responding to the user:
 
 This project uses [lat.md](https://www.npmjs.com/package/lat.md) to maintain a structured knowledge graph of its architecture, design decisions, and test specs in the `lat.md/` directory. It is a set of cross-linked markdown files that describe **what** this project does and **why** — the domain concepts, key design decisions, business logic, and test specifications. Use it to ground your work in the actual architecture rather than guessing. Do not treat `lat.md/` as a journal or changelog; it should be a focused snapshot of current or planned state, and should not grow just to note insignificant details.
 
+Project-specific lat documentation belongs in `lat.md/`. Do not modify this generated instruction file or a generated `lat-md` `SKILL.md` to record project guidance: both are owned by lat tooling and may be replaced by a later `lat init`.
+
 # Commands
 
 ```bash

--- a/templates/skill/SKILL.md
+++ b/templates/skill/SKILL.md
@@ -10,6 +10,8 @@ description: >-
 
 This skill covers the syntax, structure rules, and conventions for writing `lat.md/` files. Load it whenever you need to create or edit sections in the `lat.md/` directory.
 
+Project-specific lat documentation belongs in `lat.md/`. Do not modify this generated skill or a generated `AGENTS.md` to record project guidance: both are owned by lat tooling and may be replaced by a later `lat init`.
+
 ## What belongs in lat.md
 
 `lat.md/` files describe **what** the project does and **why** — domain concepts, key design decisions, business logic, and test specifications. They do NOT duplicate source code. Think of each section as an anchor that source code references back to.


### PR DESCRIPTION
Tell agents to record project-specific lat documentation in lat.md/
instead of editing generated `AGENTS.md` or lat-md skill files. Putting
this warning in the canonical templates ensures it survives lat init
refreshes and prevents guidance from being lost when tooling-owned files
are regenerated.
