### PR TITLE
Use website logo in Lat UI

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -6,7 +6,7 @@
 
 [[src/cli/ui.ts#uiCommand]] starts [[src/view/server.ts#startViewServer]] on loopback port 4242 and launches the browser without a shell. An occupied default advances to the next available port; an explicit `--port` is strict and reports the conflict.
 
-`--logo-text` overrides the top-left `lat.md` label as plain text for both the live server and static export; omitting it preserves the default.
+The website's Lat wordmark is the default top-left brand in both clients. `--logo-text` replaces it with safely rendered plain text for the live server or static export.
 
 The browser follows the lat website's monochrome visual system: pure black or white foundations, neutral surfaces and borders, and restrained Vercel-style controls. Color is reserved for links, graph categories, syntax, and semantic Git or diagnostic state.
 
@@ -22,7 +22,7 @@ The export preserves the file tree, rendered Markdown, wiki and ordinary Markdow
 
 Each unique source file has one shared raw-text and highlighted-line payload. Manifest entries combine it with small request-specific payloads for focus, context, and references, avoiding code duplication across links into the same file.
 
-The manifest stores the selected logo text with the document index so the static client renders the same branding as the live server.
+The manifest stores the selected logo text with the document index so the static client renders the default wordmark or the same plain-text override as the live server.
 
 The browser reads an immutable manifest instead of `/api/*`, never opens an event stream, and hides Git and search controls. Documents contain no Git diff projection, while graph nodes contain no Git status.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -11,7 +11,7 @@ Functional specifications for the browser server, static export, client navigati
 
 The loopback server exposes the visible Markdown index, redirects its root to the vault index, and serves the client shell for document routes.
 
-`lat ui --logo-text <text>` replaces the top-left `lat.md` label with safely rendered plain text; omitting the option preserves the default.
+By default the header renders the same Lat wordmark as the website. `lat ui --logo-text <text>` replaces it with safely rendered plain text.
 
 ## Builds a static deployment
 
@@ -21,7 +21,7 @@ The static client keeps Markdown and wiki navigation, backlinks, validation, sou
 
 Every source file stores its raw text and highlighted lines once. Request-specific focus, context, and reference metadata stays in small separate payloads, so multiple links into one file do not duplicate its code.
 
-`lat ui build --logo-text <text>` persists the same label override in the static manifest.
+`lat ui build --logo-text <text>` persists the same plain-text override in the static manifest; without it, the exported client uses the website wordmark.
 
 An absolute `--base` path nests the payload under that path as well as prefixing its URLs, so the output directory itself remains the deployment root.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -57,7 +57,7 @@ When the desktop TOC rail no longer fits, an `On this page` row expands its exis
 
 Graph mode consumes a cached projection of documents, source targets, and code mentions with stable nodes and weighted directed edges. Section links collapse into their owning document rather than producing section nodes.
 
-The client renders a 50/50 graph and inspector. The logo, active Graph toggle, and semantic filter float over the full-height graph while Git and page Search buttons are hidden. The right panel begins with the selected node preview and has no inspector toolbar.
+The client renders a 50/50 graph and inspector. The logo and Graph toggle retain their normal desktop positions while floating over the graph with the semantic filter; Git and page Search are hidden. The right panel begins with the node preview and has no toolbar.
 
 The graph button persists a namespaced `localStorage` presentation setting without changing the current URL or browser history. Toggling it off immediately reveals the exact selected target in the normal file/source layout, and reload restores the stored mode.
 

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -570,6 +570,13 @@ describe('lat ui', () => {
       ]),
     );
     expect(graphSearchNodeSizes(new Map([['only', 0.5]])).get('only')).toBe(14);
+
+    const styles = readFileSync(
+      join(import.meta.dirname, '..', 'view', 'src', 'styles.css'),
+      'utf8',
+    );
+    expect(styles).toContain('flex: 0 0 212px;');
+    expect(styles).toContain('padding: 0 18px 0 28px;');
   });
 
   // @lat: [[lat.md/view/specs#View Tests#Searches sections with embeddings]]

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -178,6 +178,19 @@ describe('lat ui', () => {
     const searchShell = await fetch(new URL('/search', view.url));
     expect(searchShell.status).toBe(200);
     expect(await searchShell.text()).toContain('lat ui shell');
+
+    const app = readFileSync(
+      join(import.meta.dirname, '..', 'view', 'src', 'App.tsx'),
+      'utf8',
+    );
+    const styles = readFileSync(
+      join(import.meta.dirname, '..', 'view', 'src', 'styles.css'),
+      'utf8',
+    );
+    expect(app).toContain('../../website/public/logo.svg?url');
+    expect(app).toContain('brandText === DEFAULT_VIEW_LOGO_TEXT');
+    expect(app).toContain('<BrandText text={brandText} />');
+    expect(styles).toContain('.brand-logo');
   });
 
   // @lat: [[lat.md/view/specs#View Tests#Builds a static deployment]]

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -88,6 +88,7 @@ import {
   getSourceWindow,
   getSourceWindowRows,
 } from '../view/src/source-window.js';
+import { staticViewAssetUrl } from '../view/src/static-mode.js';
 import {
   deterministicGraphPosition,
   graphDisplayLabel,
@@ -190,6 +191,7 @@ describe('lat ui', () => {
     expect(app).toContain('../../website/public/logo.svg?url');
     expect(app).toContain('brandText === DEFAULT_VIEW_LOGO_TEXT');
     expect(app).toContain('<BrandText text={brandText} />');
+    expect(app).toContain('src={staticViewAssetUrl(latLogoUrl)}');
     expect(styles).toContain('.brand-logo');
   });
 
@@ -198,6 +200,12 @@ describe('lat ui', () => {
     expect(normalizeStaticViewBasePath('/project')).toBe('/project/');
     expect(staticViewUrl('/graph?node=document%3Alat.md', '/project/')).toBe(
       '/project/graph/?node=document%3Alat.md',
+    );
+    expect(staticViewAssetUrl('/assets/logo.svg', '/project/')).toBe(
+      '/project/assets/logo.svg',
+    );
+    expect(staticViewAssetUrl('/assets/logo.svg', '/')).toBe(
+      '/assets/logo.svg',
     );
     expect(() => normalizeStaticViewBasePath('project')).toThrow(
       'absolute URL path',

--- a/view/src/App.tsx
+++ b/view/src/App.tsx
@@ -44,7 +44,12 @@ import {
 import { renderSectionBackReferences } from './section-back-references';
 import { SearchPage } from './SearchPage';
 import { sourceLineId, SourceView } from './SourceView';
-import { isStaticView, staticViewBasePath, viewPathname } from './static-mode';
+import {
+  isStaticView,
+  staticViewAssetUrl,
+  staticViewBasePath,
+  viewPathname,
+} from './static-mode';
 
 type ViewRoute =
   | { kind: 'search' }
@@ -119,7 +124,7 @@ function AppHeader({
           <img
             alt={DEFAULT_VIEW_LOGO_TEXT}
             className="brand-logo"
-            src={latLogoUrl}
+            src={staticViewAssetUrl(latLogoUrl)}
           />
         ) : (
           <BrandText text={brandText} />

--- a/view/src/App.tsx
+++ b/view/src/App.tsx
@@ -15,6 +15,7 @@ import type {
   ViewSourceDocument,
 } from '../../src/view/protocol';
 import { DEFAULT_VIEW_LOGO_TEXT } from '../../src/view/protocol';
+import latLogoUrl from '../../website/public/logo.svg?url';
 import { FileTree } from './FileTree';
 import { DocumentToc } from './DocumentToc';
 import { fetchViewJson } from './data-source';
@@ -104,15 +105,25 @@ function AppHeader({
   route: ViewRoute | null;
   searchEnabled: boolean;
 }) {
+  const brandText = index?.logoText ?? DEFAULT_VIEW_LOGO_TEXT;
+
   return (
     <div className={className}>
       <a
         className="brand"
         href={index ? documentUrl(index.entry) : '/'}
         onClick={index ? onNavigate : undefined}
-        title={index?.logoText ?? DEFAULT_VIEW_LOGO_TEXT}
+        title={brandText}
       >
-        <BrandText text={index?.logoText ?? DEFAULT_VIEW_LOGO_TEXT} />
+        {brandText === DEFAULT_VIEW_LOGO_TEXT ? (
+          <img
+            alt={DEFAULT_VIEW_LOGO_TEXT}
+            className="brand-logo"
+            src={latLogoUrl}
+          />
+        ) : (
+          <BrandText text={brandText} />
+        )}
       </a>
       <div className="sidebar-actions">
         {!graphActive && index?.git && (

--- a/view/src/static-mode.ts
+++ b/view/src/static-mode.ts
@@ -17,6 +17,15 @@ export function isStaticView(): boolean {
   return staticViewBasePath() !== null;
 }
 
+/** Prefix a Vite-emitted root asset with the static deployment base path. */
+export function staticViewAssetUrl(
+  assetUrl: string,
+  basePath: string | null = staticViewBasePath(),
+): string {
+  if (!basePath || !assetUrl.startsWith('/assets/')) return assetUrl;
+  return `${basePath}${assetUrl.slice(1)}`;
+}
+
 /** Strip the configured deployment prefix and static route trailing slash. */
 export function viewPathname(pathname: string): string {
   const basePath = staticViewBasePath();

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -1480,7 +1480,7 @@ a.wiki-link-active {
 .graph-topbar-graph .graph-header {
   display: flex;
   min-width: 0;
-  flex: 0 0 203px;
+  flex: 0 0 212px;
   align-items: center;
   justify-content: space-between;
 }
@@ -1751,7 +1751,7 @@ a.wiki-link-active {
 
 @media (width <= 1100px) and (width >= 64rem) {
   .graph-topbar-graph {
-    padding: 0 18px;
+    padding: 0 18px 0 28px;
     gap: 8px;
   }
 

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -132,8 +132,9 @@ a {
 }
 
 .brand {
-  display: inline-block;
+  display: inline-flex;
   min-width: 0;
+  align-items: center;
   overflow: hidden;
   color: var(--text);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
@@ -143,6 +144,13 @@ a {
   text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.brand-logo {
+  display: block;
+  width: auto;
+  height: 21px;
+  flex: none;
 }
 
 .brand span {
@@ -1852,6 +1860,10 @@ a.wiki-link-active {
     font-size: 18px;
   }
 
+  .sidebar-header .brand-logo {
+    height: 18px;
+  }
+
   .sidebar-actions {
     gap: 5px;
   }
@@ -2035,6 +2047,10 @@ a.wiki-link-active {
 
   .graph-header .brand {
     font-size: 18px;
+  }
+
+  .graph-header .brand-logo {
+    height: 18px;
   }
 
   .graph-header .sidebar-search,


### PR DESCRIPTION
## Summary

- replace the default `lat.md` text label with the existing website SVG wordmark
- preserve `--logo-text` as a plain-text override in both live and static UIs
- size the wordmark consistently across desktop, mobile, and graph headers
- document and test the default/override branding contract

## Validation

- `pnpm format`
- `pnpm buildall`
- `pnpm test` (218 tests)
- `lat check`