### PR TITLE
Keep code link badges with labels

### DIFF
--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -83,7 +83,7 @@ Documents expose [[markdown#Frontmatter#require-code-mention]] separately from r
 
 Resolved Markdown sections and validated source definitions become client-side links, while unresolved wiki targets remain authored text.
 
-Unaliased code links show a language badge and visually separate muted path context from the final target.
+Code links show a language badge bound to the label's first word so it cannot wrap alone, while unaliased links visually separate muted path context from the final target.
 
 Every resolved wiki link shows the total number of distinct reference locations for its canonical target. The current paragraph counts once, duplicate links in one paragraph do not inflate the total, and section totals include `@lat:` code references.
 

--- a/src/view/markdown.ts
+++ b/src/view/markdown.ts
@@ -39,6 +39,7 @@ const CODE_LINK_CLASSES = [
   'wiki-link-code',
   'wiki-link-active',
   'code-link-language',
+  'code-link-leading',
   'code-language-ts',
   'code-language-js',
   'code-language-py',
@@ -222,6 +223,37 @@ function languageIcon(language: {
     },
     children: [{ type: 'text', value: language.label }],
   } as RootContent;
+}
+
+function codeLinkContent(
+  language: { className: string; label: string },
+  children: RootContent[],
+): RootContent[] {
+  const [first, ...rest] = children;
+  if (!first) return [languageIcon(language)];
+
+  let leading = first;
+  let remainder: RootContent | null = null;
+  if (first.type === 'text') {
+    const breakAt = first.value.search(/\s/);
+    if (breakAt > 0) {
+      leading = { ...first, value: first.value.slice(0, breakAt) };
+      remainder = { ...first, value: first.value.slice(breakAt) };
+    }
+  }
+
+  return [
+    {
+      type: 'emphasis',
+      data: {
+        hName: 'span',
+        hProperties: { className: ['code-link-leading'] },
+      },
+      children: [languageIcon(language), leading],
+    } as RootContent,
+    ...(remainder ? [remainder] : []),
+    ...rest,
+  ];
 }
 
 function externalLinkIcon(): PhrasingContent {
@@ -440,8 +472,9 @@ export async function renderMarkdown(
               }
             : undefined,
         children: [
-          ...(language ? [languageIcon(language)] : []),
-          ...content.children,
+          ...(language
+            ? codeLinkContent(language, content.children)
+            : content.children),
           ...(referenceCount > 1 ? [referenceCountBadge(referenceCount)] : []),
         ],
       } as RootContent;

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -888,16 +888,26 @@ describe('lat ui', () => {
     expect(document.html).toContain(
       'class="code-link-language code-language-ts"',
     );
+    expect(document.html).toContain('class="code-link-leading"');
     expect(document.html).toContain('aria-hidden="true"');
     expect(document.html).toContain(
       '<span class="wiki-link-leaf">run</span><span class="wiki-link-ref-count" aria-label="2 references">2</span>',
     );
     expect(document.html).toContain(
-      'runner file<span class="wiki-link-ref-count" aria-label="3 references">3</span>',
+      'runner</span> file<span class="wiki-link-ref-count" aria-label="3 references">3</span>',
     );
     expect(document.html).toContain(
-      'same file<span class="wiki-link-ref-count" aria-label="3 references">3</span>',
+      'same</span> file<span class="wiki-link-ref-count" aria-label="3 references">3</span>',
     );
+
+    const styles = readFileSync(
+      join(import.meta.dirname, '..', 'view', 'src', 'styles.css'),
+      'utf8',
+    );
+    const leadingRule = styles.match(/\.code-link-leading\s*\{([^}]*)\}/)?.[1];
+    expect(leadingRule).toContain('display: inline-flex;');
+    expect(leadingRule).toContain('align-items: baseline;');
+    expect(leadingRule).toContain('white-space: nowrap;');
 
     for (const referenceCount of [0, 1]) {
       const sparseReferences = await renderMarkdown(

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -1263,6 +1263,12 @@ a.wiki-link-segmented > .wiki-link-leaf {
   border-radius: 3px;
 }
 
+.code-link-leading {
+  display: inline-flex;
+  align-items: baseline;
+  white-space: nowrap;
+}
+
 a.wiki-link-active {
   padding: 0.12em 0.28em;
   margin: -0.12em -0.28em;


### PR DESCRIPTION
## Summary

- group each code-language badge with the first label segment in an atomic inline wrapper
- prevent badges from being stranded at the end of a line while allowing the rest of multi-word labels to wrap normally
- preserve path/target styling and reference-count placement
- document and test the wrapping invariant

## Validation

- `pnpm buildall`
- `pnpm test` (218 tests)
- `lat check`