### PR TITLE
Fix responsive document navigation

### DIFF
--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -51,7 +51,7 @@ Below 64rem, files remain reachable through a sticky two-row header and a scroll
 
 The overlay exposes its expanded state, uses touch-sized file targets, locks document scrolling while open, and closes on navigation, Escape, or a return to desktop width. Content gutters narrow, code scrolls horizontally, and the graph stacks above its inspector.
 
-When the desktop TOC rail no longer fits, an `On this page` row expands its existing links in a bounded scrolling panel. On mobile it stays below the app header, retains active and Git/error states, closes after selection or Escape, and offsets fragment targets.
+When the desktop TOC rail no longer fits, a compact `On this page` control shares an aligned metadata row and expands its links in a bounded overlay without moving content. On mobile it becomes a full-width row below the app header, retains active and Git/error states, closes after selection or Escape, and offsets fragment targets.
 
 ## Renders the graph workspace
 

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -848,6 +848,9 @@ describe('lat ui', () => {
     expect(styles).toMatch(
       /@media \(max-width: 1340px\)[\s\S]*?\.document-layout \{[\s\S]*?align-items: stretch;/,
     );
+    expect(styles).toMatch(
+      /@media \(width < 64rem\)[\s\S]*?\.document-toc-toggle \{[\s\S]*?border-top: 0;/,
+    );
   });
 
   // @lat: [[lat.md/view/specs#View Tests#Exposes code-mention frontmatter as metadata]]

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -849,6 +849,18 @@ describe('lat ui', () => {
       /@media \(max-width: 1340px\)[\s\S]*?\.document-layout \{[\s\S]*?align-items: stretch;/,
     );
     expect(styles).toMatch(
+      /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?grid-template-areas:[\s\S]*?'metadata toc'[\s\S]*?'document document'/,
+    );
+    expect(styles).toMatch(
+      /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?\.sidebar-header \{[\s\S]*?min-height: 42px;[\s\S]*?\.document-toc-toggle \{[\s\S]*?min-height: 42px;/,
+    );
+    expect(styles).toMatch(
+      /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?\.document-toc-list \{[\s\S]*?position: absolute;[\s\S]*?top: 100%;/,
+    );
+    expect(styles).toMatch(
+      /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?\.document-toc \{[^}]*position: relative;[^}]*top: 0;/,
+    );
+    expect(styles).toMatch(
       /@media \(width < 64rem\)[\s\S]*?\.document-toc-toggle \{[\s\S]*?border-top: 0;/,
     );
   });

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -845,6 +845,9 @@ describe('lat ui', () => {
     );
     expect(styles).not.toContain('order: -1');
     expect(styles).toContain('min-height: 44px');
+    expect(styles).toMatch(
+      /@media \(max-width: 1340px\)[\s\S]*?\.document-layout \{[\s\S]*?align-items: stretch;/,
+    );
   });
 
   // @lat: [[lat.md/view/specs#View Tests#Exposes code-mention frontmatter as metadata]]

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -1849,6 +1849,59 @@ a.wiki-link-active {
   }
 }
 
+@media (min-width: 64rem) and (max-width: 1340px) {
+  .sidebar-header {
+    min-height: 42px;
+  }
+
+  .document-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(240px, 286px);
+    grid-template-areas:
+      'metadata toc'
+      'document document';
+    column-gap: var(--document-toc-gutter);
+    row-gap: 34px;
+    align-items: start;
+  }
+
+  .document-column {
+    display: contents;
+  }
+
+  .document-header {
+    grid-area: metadata;
+    min-width: 0;
+    margin: 0;
+  }
+
+  .document-metadata,
+  .document-toc-toggle {
+    min-height: 42px;
+  }
+
+  .document-toc {
+    grid-area: toc;
+    position: relative;
+    z-index: 1;
+    top: 0;
+    max-width: 286px;
+    margin: 0;
+  }
+
+  .document-toc-list {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    left: 0;
+  }
+
+  .markdown {
+    grid-area: document;
+    min-width: 0;
+  }
+}
+
 @media (width < 64rem) {
   body.mobile-navigation-open {
     overflow: hidden;

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -1784,6 +1784,7 @@ a.wiki-link-active {
     display: flex;
     flex-direction: column;
     gap: 0;
+    align-items: stretch;
   }
 
   .document-toc {

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -2002,6 +2002,7 @@ a.wiki-link-active {
     min-height: 56px;
     padding: 0 var(--mobile-gutter);
     background: color-mix(in srgb, var(--background) 94%, transparent);
+    border-top: 0;
     border-right: 0;
     border-left: 0;
     border-radius: 0;


### PR DESCRIPTION
## Summary

- prevent long preformatted code lines from widening documents on mobile
- keep stacked mobile header separators to a single pixel
- compact the collapsed page TOC into the document metadata row and render its expanded panel as an overlay without layout shift
- preserve vertical alignment among the logo, actions, breadcrumbs, and TOC control

## Test plan

- pnpm buildall
- pnpm test (218 tests)
- lat check
- visually verified the intermediate-width layout and TOC overlay in a production build