### PR TITLE
Read each lat.md file once when indexing sections

### DIFF
--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -392,7 +392,9 @@ Implementation: [[src/search/db.ts]]
 
 ### Indexing
 
-Sections are extracted via `loadAllSections()` + `flattenSections()`. For each section, the raw markdown between `startLine` and `endLine` is read (not just `firstParagraph`) for richer semantic signal.
+Sections come from `loadAllSections()` + `flattenSections()`. Each file is read once ([[src/search/index.ts#loadFileLines]]) and each section's raw markdown (`startLine`–`endLine`, not just `firstParagraph`) is sliced from it for richer semantic signal.
+
+Never read per section: that is O(sections × file size), and a 3.5 MB file holding 12k sections cost ~95 s per search before the query even ran.
 
 Content freshness is tracked via SHA-256 hashes. On each run:
 

--- a/lat.md/tests/search.md
+++ b/lat.md/tests/search.md
@@ -52,6 +52,14 @@ Re-index unchanged content, verify all sections reported as unchanged with zero 
 
 Remove `testing.md`, re-index, verify 4 sections removed and 5 architecture sections remain.
 
+### Reads each file once when indexing
+
+A passthrough `readFile` spy verifies indexing reads each `lat.md` file a bounded number of times
+however many sections it holds: the parser reads it once and section slicing reuses that read.
+
+Before this was pinned, a 3.5 MB file holding 12k sections was re-read once per section — 12k
+times on every search.
+
 ### Rebuilds a legacy cache with no recorded model
 
 Seed a 1536-dim `sections` table with rows but no `meta.embedding_model`, then run a local-backed

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -9,14 +9,33 @@ function hashContent(text: string): string {
   return createHash('sha256').update(text).digest('hex');
 }
 
-async function sectionContent(
-  section: Section,
+/**
+ * Read each lat.md file once, keyed by project-relative path. Section text is
+ * sliced from these lines by range: reading the file per section instead is
+ * O(sections × file size) — a 3.5 MB file holding 12k sections was re-read 12k
+ * times (~42 GB of string work) on every search.
+ */
+async function loadFileLines(
+  sections: Section[],
   projectRoot: string,
-): Promise<string> {
-  const filePath = join(projectRoot, section.filePath);
-  const content = await readFile(filePath, 'utf-8');
-  const lines = content.split('\n');
-  return lines.slice(section.startLine - 1, section.endLine).join('\n');
+): Promise<Map<string, string[]>> {
+  const lines = new Map<string, string[]>();
+  for (const { filePath } of sections) {
+    if (lines.has(filePath)) continue;
+    const content = await readFile(join(projectRoot, filePath), 'utf-8');
+    lines.set(filePath, content.split('\n'));
+  }
+  return lines;
+}
+
+function sectionContent(
+  section: Section,
+  lines: Map<string, string[]>,
+): string {
+  return lines
+    .get(section.filePath)!
+    .slice(section.startLine - 1, section.endLine)
+    .join('\n');
 }
 
 export type IndexStats = {
@@ -41,8 +60,9 @@ export async function indexSections(
     string,
     { section: Section; content: string; hash: string }
   >();
+  const lines = await loadFileLines(flat, projectRoot);
   for (const s of flat) {
-    const text = await sectionContent(s, projectRoot);
+    const text = sectionContent(s, lines);
     current.set(s.id, { section: s, content: text, hash: hashContent(text) });
   }
 

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { mkdtempSync, rmSync, cpSync } from 'node:fs';
 import { join } from 'node:path';
 import { rmDirBestEffort } from './util.js';
@@ -17,6 +17,15 @@ import { runSearch } from '../src/cli/search.js';
 import { startReplayServer, hasReplayData } from './rag-replay-server.js';
 import type { Client } from '@libsql/client';
 import type { Server } from 'node:http';
+
+// Passthrough spy on `readFile` so the indexing test below can count how many
+// times each lat.md file is read. Every other test sees the real implementation.
+const { readFileSpy } = vi.hoisted(() => ({ readFileSpy: vi.fn() }));
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  readFileSpy.mockImplementation(actual.readFile);
+  return { ...actual, readFile: readFileSpy };
+});
 
 // --- Unit tests: provider detection (now lives in @lat.md/embed) ---
 
@@ -242,5 +251,50 @@ describe.skipIf(!canRunHosted)('search (rag, hosted replay)', () => {
       embedder,
     );
     expect(results[0].id).toContain('Authentication');
+  });
+});
+
+// --- Indexing reads each file once ---
+//
+// Section text is sliced out of its file by line range. Reading the file per
+// section is O(sections x file size): a 3.5 MB tests.md holding 12k sections
+// was re-read 12k times on every search (~95 s before the query even ran).
+
+describe('search (rag, file reads)', () => {
+  let latDir: string;
+  let db: Client;
+  let embedder: Embedder;
+
+  beforeAll(async () => {
+    embedder = await createEmbedder({ model: minilm });
+    latDir = copyFixture();
+    db = openDb(latDir);
+    await ensureMeta(db);
+    await ensureSectionsSchema(db, embedder.dimensions);
+  });
+
+  afterAll(async () => {
+    if (db) await closeDb(db);
+    if (latDir) rmDirBestEffort(join(latDir, '..'));
+  });
+
+  // @lat: [[search#RAG Tests#Reads each file once when indexing]]
+  it('reads each file once when indexing', async () => {
+    readFileSpy.mockClear();
+    const stats = await indexSections(latDir, db, embedder);
+    expect(stats.added).toBe(9);
+
+    const readsPerFile = new Map<string, number>();
+    for (const [path] of readFileSpy.mock.calls) {
+      const file = String(path);
+      if (!file.endsWith('.md')) continue;
+      readsPerFile.set(file, (readsPerFile.get(file) ?? 0) + 1);
+    }
+    expect(readsPerFile.size).toBe(2);
+    // The parser reads each file once; slicing section text must reuse a
+    // single read per file, never one per section (5 and 4 in this fixture).
+    for (const [file, reads] of readsPerFile) {
+      expect(reads, `${file} read ${reads} times`).toBeLessThanOrEqual(2);
+    }
   });
 });


### PR DESCRIPTION
`lat search` slices each section's text out of its file by line range — and did so by re-reading and re-splitting the whole file once **per section**. That is O(sections × file size). On a real corpus (13k sections across 30 files, 12k of them in a 3.5 MB `tests.md`), every search spent ~94 s reading ~42 GB of strings before the query ran, while the embedding and `vector_top_k` lookup took 0.3 s.

Profile of one `lat search` on that corpus (0.12.2, local MiniLM, warm index, nothing changed):

| stage | time |
|---|---|
| `indexSections`: per-section `readFile` + `split` + hash | **94.4 s** |
| load stored hashes | 1.1 s |
| `loadAllSections` parse | 1.1 s |
| `vector_top_k` + join | 0.17 s |
| load model + embed query | 0.15 s |

This change reads each file once and slices all of its sections from that read. Same query, same corpus, same machine: **93.7 s → 3.7 s**, identical results in the same order.

A passthrough `readFile` spy in the RAG tests pins the file-once behaviour (it fails on the previous code with "`architecture.md` read 6 times"). `lat.md/cli.md` and `lat.md/tests/search.md` are updated to match.

Verified with `pnpm buildall && pnpm test && pnpm exec lat check` on macOS (arm64, Node 24, rustc 1.98).

Not included, for a possible follow-up: `runSearch` parses the corpus a second time in `resolveMatches` (~1 s of the remaining 3.7 s).
