### PR TITLE
Polish rendered link and TOC state styling

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -72,6 +72,8 @@ Markdown and source metadata rows align with the sidebar header, while source me
 
 Rendered sections use heading scale and whitespace without horizontal separators between headings.
 
+Rendered link text is always underlined. Segmented wiki and source links underline muted context and active targets separately so each line matches its text color; language badges, reference counts, and external-link icons remain undecorated.
+
 Document responses project every parsed heading and canonical GitHub slug into a local TOC. Its H1 entry stays bold at the base indentation, while subsection indentation remains relative to the first subsection level.
 
 TOC entries show an orange disc when their section contains a rendered Git change and a red disc when it owns validation errors. Git discs follow the Git visibility toggle; error discs remain visible.

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -684,6 +684,9 @@ describe('lat ui', () => {
     );
     expect(styles).toContain('.external-link-icon');
     expect(styles).toContain('-webkit-mask:');
+    expect(styles.match(/\.markdown a\s*\{([^}]*)\}/)?.[1]).toContain(
+      'text-decoration-line: underline;',
+    );
   });
 
   // @lat: [[lat.md/view/specs#View Tests#Shows a local table of contents]]
@@ -922,10 +925,18 @@ describe('lat ui', () => {
       join(import.meta.dirname, '..', 'view', 'src', 'styles.css'),
       'utf8',
     );
-    const leadingRule = styles.match(/\.code-link-leading\s*\{([^}]*)\}/)?.[1];
+    const leadingRule = styles.match(
+      /^\.code-link-leading\s*\{([^}]*)\}/m,
+    )?.[1];
     expect(leadingRule).toContain('display: inline-flex;');
     expect(leadingRule).toContain('align-items: baseline;');
     expect(leadingRule).toContain('white-space: nowrap;');
+    expect(styles).toContain(
+      'a.wiki-link-segmented .wiki-link-context,\na.wiki-link-segmented .wiki-link-leaf,',
+    );
+    expect(styles).toContain(
+      'a.wiki-link-code:not(.wiki-link-segmented) .code-link-leading',
+    );
 
     for (const referenceCount of [0, 1]) {
       const sparseReferences = await renderMarkdown(

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -864,6 +864,9 @@ describe('lat ui', () => {
       /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?\.document-toc \{[^}]*position: relative;[^}]*top: 0;/,
     );
     expect(styles).toMatch(
+      /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?\.document-toc-states \{[^}]*padding-right: 14px;/,
+    );
+    expect(styles).toMatch(
       /@media \(width < 64rem\)[\s\S]*?\.document-toc-toggle \{[\s\S]*?border-top: 0;/,
     );
   });

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -1898,6 +1898,10 @@ a.wiki-link-active {
     left: 0;
   }
 
+  .document-toc-states {
+    padding-right: 14px;
+  }
+
   .markdown {
     grid-area: document;
     min-width: 0;

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -1091,6 +1091,7 @@ a {
 
 .markdown a {
   overflow-wrap: anywhere;
+  text-decoration-line: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
 }
@@ -1200,8 +1201,9 @@ a.wiki-link-segmented {
   text-decoration: none;
 }
 
-a.wiki-link-segmented > .wiki-link-context,
-a.wiki-link-segmented > .wiki-link-leaf {
+a.wiki-link-segmented .wiki-link-context,
+a.wiki-link-segmented .wiki-link-leaf,
+a.wiki-link-code:not(.wiki-link-segmented) .code-link-leading {
   text-decoration-line: underline;
   text-decoration-color: currentColor;
   text-decoration-thickness: 1px;


### PR DESCRIPTION
## Summary

- consistently underline rendered Markdown links
- give segmented wiki and source links matching gray and blue underlines while keeping badges, counts, and icons undecorated
- add safer right-side spacing for Git and error markers in the compact TOC overlay

## Test plan

- pnpm buildall
- pnpm test (218 tests)
- lat check
- visually verified representative ordinary, external, wiki, and source links in a production build