### PR TITLE
Render Markdown reference definitions

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -68,6 +68,8 @@ Whenever cached changes exist, the toggle keeps an orange notification dot wheth
 
 [[src/view/markdown.ts#renderMarkdown]] produces safe HTML with ordinary Markdown links, resolved wiki links, heading fragments, and `require-code-mention` metadata.
 
+Reference-link definitions remain in the syntax tree for resolving reference-style links and are also projected into muted two-column tables. Labels become monospace row headers, while rows retain authored validation and Git annotations.
+
 Markdown and source metadata rows align with the sidebar header, while source metadata retains clear space before the code panel.
 
 Rendered sections use heading scale and whitespace without horizontal separators between headings.

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -37,6 +37,10 @@ Website deployments compile the current Lat UI against pinned npm releases of th
 
 Markdown becomes safe HTML with GitHub-style heading ids while ordinary relative links retain their destinations and fragments. HTTP(S) and protocol-relative links append a decorative external-site icon in documents and rendered reference contexts.
 
+## Renders Markdown reference definitions
+
+Reference-link definitions remain visible as muted tables while continuing to resolve reference-style links. Labels are monospace row headers; URLs, titles, validation markers, and Git changes remain visible.
+
 ## Shows a local table of contents
 
 Markdown documents expose their H1 plus nested subsection headings in a sticky right rail on wide screens. The root entry stays bold without shifting subsection indentation; every entry links to its canonical fragment.

--- a/src/view/markdown.ts
+++ b/src/view/markdown.ts
@@ -1,5 +1,13 @@
 import { basename, extname } from 'node:path';
-import type { Link, PhrasingContent, Root, RootContent } from 'mdast';
+import type {
+  Blockquote,
+  Definition,
+  Link,
+  Parent,
+  PhrasingContent,
+  Root,
+  RootContent,
+} from 'mdast';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import type { Options as SanitizeSchema } from 'rehype-sanitize';
 import rehypeSlug from 'rehype-slug';
@@ -52,9 +60,12 @@ const ERROR_CLASS = 'markdown-error';
 const EXTERNAL_LINK_CLASS = 'external-link';
 const EXTERNAL_LINK_ICON_CLASS = 'external-link-icon';
 const GIT_CLASSES = ['git-added', 'git-removed'];
+const REFERENCE_DEFINITION_LABEL_CLASS = 'markdown-reference-label';
+const REFERENCE_DEFINITION_TABLE_CLASS = 'markdown-reference-definitions';
 
 function classAttributes(
   tag: string,
+  classes: string[] = [],
 ): NonNullable<SanitizeSchema['attributes']>[string] {
   const attributes = defaultSchema.attributes?.[tag] ?? [];
   const allowedClasses = attributes.flatMap((attribute) =>
@@ -67,7 +78,7 @@ function classAttributes(
       (attribute) =>
         !(Array.isArray(attribute) && attribute[0] === 'className'),
     ),
-    ['className', ...allowedClasses, ERROR_CLASS, ...GIT_CLASSES],
+    ['className', ...allowedClasses, ERROR_CLASS, ...GIT_CLASSES, ...classes],
   ];
 }
 
@@ -123,6 +134,9 @@ const sanitizeSchema: SanitizeSchema = {
         ...GIT_CLASSES,
       ],
     ],
+    table: classAttributes('table', [REFERENCE_DEFINITION_TABLE_CLASS]),
+    th: classAttributes('th', [REFERENCE_DEFINITION_LABEL_CLASS]),
+    tr: classAttributes('tr'),
     ul: classAttributes('ul'),
   },
 };
@@ -132,6 +146,101 @@ const htmlProcessor = unified()
   .use(rehypeSanitize, sanitizeSchema)
   .use(rehypeSlug)
   .use(rehypeStringify);
+
+function referenceDefinitionTable(definitions: Definition[]): Blockquote {
+  const firstPosition = definitions[0]?.position?.start;
+  const lastPosition = definitions.at(-1)?.position?.end;
+
+  return {
+    type: 'blockquote',
+    data: {
+      hName: 'table',
+      hProperties: { className: [REFERENCE_DEFINITION_TABLE_CLASS] },
+    },
+    ...(firstPosition && lastPosition
+      ? { position: { start: firstPosition, end: lastPosition } }
+      : {}),
+    children: [
+      {
+        type: 'blockquote',
+        data: { hName: 'tbody' },
+        children: definitions.map((definition) => ({
+          type: 'blockquote',
+          data: {
+            ...(definition.data ? structuredClone(definition.data) : undefined),
+            hName: 'tr',
+          },
+          position: definition.position,
+          children: [
+            {
+              type: 'paragraph',
+              data: {
+                hName: 'th',
+                hProperties: {
+                  scope: 'row',
+                  className: [REFERENCE_DEFINITION_LABEL_CLASS],
+                },
+              },
+              position: definition.position,
+              children: [
+                {
+                  type: 'text',
+                  value: `[${definition.label ?? definition.identifier}]`,
+                },
+              ],
+            },
+            {
+              type: 'paragraph',
+              data: { hName: 'td' },
+              position: definition.position,
+              children: [
+                {
+                  type: 'link',
+                  url: definition.url,
+                  title: definition.title,
+                  children: [{ type: 'text', value: definition.url }],
+                },
+                ...(definition.title
+                  ? [
+                      {
+                        type: 'text' as const,
+                        value: ` "${definition.title}"`,
+                      },
+                    ]
+                  : []),
+              ],
+            },
+          ],
+        })),
+      },
+    ],
+  };
+}
+
+function exposeReferenceDefinitions(parent: Parent): void {
+  const children: RootContent[] = [];
+  let definitions: Definition[] = [];
+
+  const flushDefinitions = () => {
+    if (definitions.length === 0) return;
+    children.push(referenceDefinitionTable(definitions));
+    definitions = [];
+  };
+
+  for (const child of parent.children) {
+    if (child.type === 'definition') {
+      children.push(child);
+      definitions.push(child);
+      continue;
+    }
+
+    flushDefinitions();
+    if ('children' in child) exposeReferenceDefinitions(child as Parent);
+    children.push(child);
+  }
+  flushDefinitions();
+  parent.children = children;
+}
 
 function nodeText(node: { value?: unknown; children?: unknown }): string {
   if (typeof node.value === 'string') return node.value;
@@ -376,6 +485,7 @@ export async function renderMarkdown(
   const tree = parsedTree ? structuredClone(parsedTree) : parse(markdown);
   tree.children = tree.children.filter((node) => node.type !== 'yaml');
   if (options.errors) markMarkdownErrors(tree, options.errors);
+  exposeReferenceDefinitions(tree);
 
   visit(tree, 'link', (node: Link) => {
     const authoredUrl = node.url;

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -689,6 +689,62 @@ describe('lat ui', () => {
     );
   });
 
+  // @lat: [[lat.md/view/specs#View Tests#Renders Markdown reference definitions]]
+  it('renders Markdown reference-link definitions', async () => {
+    const markdown = [
+      'See [the pull request][pr56275].',
+      '',
+      '[pr56275]: https://github.com/nodejs/node/pull/56275',
+      '[perf180]: https://github.com/nodejs/performance/issues/180 "Performance issue"',
+      '',
+    ].join('\n');
+    const rendered = await renderMarkdown(markdown, 'lat.md');
+
+    expect(rendered.html).toContain(
+      '<a href="https://github.com/nodejs/node/pull/56275">the pull request</a>',
+    );
+    expect(rendered.html).toContain(
+      '<table class="markdown-reference-definitions">\n<tbody>',
+    );
+    expect(rendered.html).toContain(
+      '<th scope="row" class="markdown-reference-label">[pr56275]</th>\n<td><a href="https://github.com/nodejs/node/pull/56275" class="external-link">https://github.com/nodejs/node/pull/56275',
+    );
+    expect(rendered.html).toContain(
+      '<th scope="row" class="markdown-reference-label">[perf180]</th>\n<td><a href="https://github.com/nodejs/performance/issues/180" title="Performance issue" class="external-link">https://github.com/nodejs/performance/issues/180',
+    );
+    expect(rendered.html).toContain(' "Performance issue"</td>');
+    expect(rendered.html.match(/class="external-link-icon"/g)).toHaveLength(2);
+
+    const styles = readFileSync(
+      join(import.meta.dirname, '..', 'view', 'src', 'styles.css'),
+      'utf8',
+    );
+    expect(
+      styles.match(
+        /\.markdown table\.markdown-reference-definitions\s*\{([^}]*)\}/,
+      )?.[1],
+    ).toContain('background: var(--code);');
+    expect(
+      styles.match(
+        /\.markdown-reference-definitions \.markdown-reference-label\s*\{([^}]*)\}/,
+      )?.[1],
+    ).toContain('background: var(--inline-code);');
+
+    const diff = await renderMarkdown(
+      markdown,
+      'lat.md',
+      undefined,
+      {},
+      buildGitDiffTree('', markdown),
+    );
+    expect(diff.html).toContain(
+      '<tr class="git-added">\n<th scope="row" class="markdown-reference-label">[pr56275]</th>',
+    );
+    expect(diff.html).toContain(
+      '<tr class="git-added">\n<th scope="row" class="markdown-reference-label">[perf180]</th>',
+    );
+  });
+
   // @lat: [[lat.md/view/specs#View Tests#Shows a local table of contents]]
   it('builds nested document navigation and tracks the active heading', async () => {
     const content =

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -1089,6 +1089,64 @@ a {
   margin-top: 0.35em;
 }
 
+.markdown table.markdown-reference-definitions {
+  width: 100%;
+  margin: 0 0 1.25em;
+  overflow: hidden;
+  border-spacing: 0;
+  background: var(--code);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+}
+
+.markdown-reference-definitions th,
+.markdown-reference-definitions td {
+  padding: 9px 12px;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.markdown-reference-definitions tr:last-child > * {
+  border-bottom: 0;
+}
+
+.markdown-reference-definitions .markdown-reference-label {
+  width: 1%;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.9em;
+  font-weight: 650;
+  white-space: nowrap;
+  background: var(--inline-code);
+  border-right: 1px solid var(--panel-border);
+}
+
+.markdown-reference-definitions td {
+  overflow-wrap: anywhere;
+}
+
+.markdown-reference-definitions tr.markdown-error > * {
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger-soft) 42%, transparent);
+}
+
+.markdown-reference-definitions tr.git-added > * {
+  color: var(--success);
+  background: color-mix(in srgb, var(--success-soft) 55%, transparent);
+}
+
+.markdown-reference-definitions tr.git-removed > * {
+  color: var(--danger);
+  text-decoration: line-through;
+  background: color-mix(in srgb, var(--danger-soft) 55%, transparent);
+}
+
+.markdown-reference-definitions tr.markdown-error > :first-child,
+.markdown-reference-definitions tr.git-added > :first-child,
+.markdown-reference-definitions tr.git-removed > :first-child {
+  box-shadow: inset 3px 0 0 currentColor;
+}
+
 .markdown a {
   overflow-wrap: anywhere;
   text-decoration-line: underline;


### PR DESCRIPTION
Stacked on #101.

## Summary
- render consecutive Markdown reference definitions as accessible two-column tables while preserving reference resolution
- present labels as monospace row headers and destinations as clickable, wrapping values on a muted surface
- retain external-link decoration, optional titles, validation markers, and Git diff state

## Testing
- `pnpm buildall`
- `pnpm test` (226 tests)
- `lat check`