### PR TITLE
Improve section reference output

### DIFF
--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -37,6 +37,8 @@ Output:
 
 Reference paragraphs rely on the 250-character section-summary invariant. As a fallback for documents that currently fail validation, output truncates them after 300 characters.
 
+Source snippet lines in outgoing-reference and code-backlink blocks use Markdown inline-code delimiters. Lines containing backticks receive a longer delimiter so template literals remain valid Markdown.
+
 Usage: `lat section <query>`
 
 Core logic in [[src/cli/section.ts#getSection]] (returns structured result), used by both the CLI command and [[cli#mcp]] `lat_section` tool.

--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -30,10 +30,12 @@ Output:
 
 1. Section header with id and file location
 2. Section content blockquoted (`>`) from `startLine` through the end of the last descendant subsection
-3. **This section references** — all wiki link targets found within the section, including both lat.md section refs (with body descriptions) and source code refs (with file path and line range, e.g. `file.ts:10-25`, plus a 5-line snippet centered on the symbol)
-4. **Referenced by** — other sections in `lat.md/` that contain wiki links pointing to this section
-5. **Referenced by code** — source files containing `@lat:` comments that reference this section, each shown with file path, line number, and a 5-line snippet centered on the reference
+3. **This section references** — all wiki link targets found within the section or its descendants, including lat.md section refs with complete leading paragraphs, source code refs with line ranges and snippets, and external refs
+4. **Referenced by** — other sections in `lat.md/` that contain wiki links pointing to this section, shown with their complete leading paragraphs
+5. **Referenced by code** — source files containing `@lat:` comments that reference this section or any descendant, each shown with file path, line number, and a 5-line snippet centered on the reference
 6. **Navigation hints** — same footer as [[cli#search]], suggesting `lat section` and `lat search` as next steps
+
+Reference paragraphs rely on the 250-character section-summary invariant. As a fallback for documents that currently fail validation, output truncates them after 300 characters.
 
 Usage: `lat section <query>`
 

--- a/lat.md/tests/section.md
+++ b/lat.md/tests/section.md
@@ -55,6 +55,10 @@ Outgoing and incoming section lists render complete valid leading paragraphs rat
 
 `formatSectionOutput` renders source code references with `file:startLine-endLine` when the symbol spans multiple lines, showing the full extent of the definition.
 
+## formatSectionOutput marks source snippets as inline code
+
+Outgoing source and code-backlink snippet lines use Markdown inline-code delimiters, including valid longer delimiters around source that contains backticks.
+
 ## formatSectionOutput includes all parts
 
 `formatSectionOutput` produces styled output containing section id, location, raw content, "This section references" with outgoing refs, "Referenced by" with incoming refs, and "Referenced by code" with `@lat:` back-references.

--- a/lat.md/tests/section.md
+++ b/lat.md/tests/section.md
@@ -39,6 +39,14 @@ A section that is referenced by wiki links from other sections returns those ref
 
 Verifies that `formatSectionOutput` correctly renders the "Referenced by" block when a section has incoming references.
 
+## Parent section aggregates descendant references
+
+Requesting a parent section recursively includes outgoing references owned by descendant sections, plus code backlinks targeting any descendant.
+
+## Reference summaries preserve leading paragraphs
+
+Outgoing and incoming section lists render complete valid leading paragraphs rather than short previews, with a 300-character safety cap for invalid documents.
+
 ## Source refs include line range
 
 `getSection` populates `outgoingSourceRefs` with `line` and `endLine` from the resolved symbol, so callers can display the full extent of a function or class.

--- a/src/cli/section.ts
+++ b/src/cli/section.ts
@@ -2,10 +2,12 @@ import { readFile } from 'node:fs/promises';
 import { extname, join, relative } from 'node:path';
 import {
   findSections,
+  flattenSections,
   resolveRef,
   type Section,
   type SectionMatch,
 } from '../lattice.js';
+import { MAX_SECTION_SUMMARY_LENGTH } from '../markdown-validation.js';
 import { SOURCE_EXTENSIONS, resolveSourceSymbol } from '../source-parser.js';
 import type { CmdContext, CmdResult } from '../context.js';
 import {
@@ -93,7 +95,14 @@ export async function getSection(
   const sectionIds = new Set(project.sectionIds);
   const { fileIndex, slugIndex } = project;
   const sectionId = section.id.toLowerCase();
-  const sectionRefs = project.outgoingRefsBySection.get(sectionId) ?? [];
+  const subtreeSections = flattenSections([section]);
+  const subtreeSectionIds = new Set(
+    subtreeSections.map((subtreeSection) => subtreeSection.id.toLowerCase()),
+  );
+  const sectionRefs = subtreeSections.flatMap(
+    (subtreeSection) =>
+      project.outgoingRefsBySection.get(subtreeSection.id.toLowerCase()) ?? [],
+  );
 
   const outgoingRefs: { target: string; resolved: Section }[] = [];
   const outgoingSourceRefs: SourceRef[] = [];
@@ -101,7 +110,7 @@ export async function getSection(
   const external = await commandProjectSession(ctx).external();
   const seen = new Set<string>();
   for (const ref of sectionRefs) {
-    if (ref.fromSection.toLowerCase() !== sectionId) continue;
+    if (!subtreeSectionIds.has(ref.fromSection.toLowerCase())) continue;
     if (external.parse(ref.target)) {
       if (!seen.has(ref.target)) {
         seen.add(ref.target);
@@ -206,7 +215,7 @@ export async function getSection(
       fileIndex,
       slugIndex,
     );
-    if (codeResolved.toLowerCase() === sectionId) {
+    if (subtreeSectionIds.has(codeResolved.toLowerCase())) {
       const absFile = join(ctx.projectRoot, ref.file);
       let snippet = '';
       try {
@@ -241,6 +250,12 @@ function fullEndLine(section: Section): number {
 
 function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max) + '...' : s;
+}
+
+const SECTION_SUMMARY_SAFETY_LIMIT = MAX_SECTION_SUMMARY_LENGTH + 50;
+
+function sectionSummary(section: Section): string {
+  return truncate(section.firstParagraph, SECTION_SUMMARY_SAFETY_LIMIT);
 }
 
 /**
@@ -285,7 +300,7 @@ export function formatSectionOutput(
     parts.push('', '## This section references:', '');
     for (const ref of outgoingRefs) {
       const body = ref.resolved.firstParagraph
-        ? ` ${s.dim('—')} ${truncate(ref.resolved.firstParagraph, 120)}`
+        ? ` ${s.dim('—')} ${sectionSummary(ref.resolved)}`
         : '';
       parts.push(
         `${s.dim('*')} [[${formatSectionId(ref.resolved.id, s)}]]${body}`,
@@ -319,7 +334,7 @@ export function formatSectionOutput(
     parts.push('', '## Referenced by:', '');
     for (const ref of incomingRefs) {
       const body = ref.section.firstParagraph
-        ? ` ${s.dim('—')} ${truncate(ref.section.firstParagraph, 120)}`
+        ? ` ${s.dim('—')} ${sectionSummary(ref.section)}`
         : '';
       parts.push(
         `${s.dim('*')} [[${formatSectionId(ref.section.id, s)}]]${body}`,

--- a/src/cli/section.ts
+++ b/src/cli/section.ts
@@ -258,6 +258,18 @@ function sectionSummary(section: Section): string {
   return truncate(section.firstParagraph, SECTION_SUMMARY_SAFETY_LIMIT);
 }
 
+function markdownInlineCode(value: string): string {
+  const content = value || ' ';
+  const longestBacktickRun = Math.max(
+    0,
+    ...(content.match(/`+/g) ?? []).map((run) => run.length),
+  );
+  const delimiter = '`'.repeat(longestBacktickRun + 1);
+  const padded =
+    content.startsWith('`') || content.endsWith('`') ? ` ${content} ` : content;
+  return `${delimiter}${padded}${delimiter}`;
+}
+
 /**
  * Format a successful section result with styling.
  */
@@ -316,7 +328,7 @@ export function formatSectionOutput(
       if (ref.snippet) {
         const snippetLines = ref.snippet.split('\n');
         for (const line of snippetLines) {
-          parts.push(`  ${s.dim('|')} ${line}`);
+          parts.push(`  ${s.dim('|')} ${markdownInlineCode(line)}`);
         }
       }
     }
@@ -325,7 +337,9 @@ export function formatSectionOutput(
         `${s.dim('*')} [[${s.cyan(ref.target.identity)}]]${s.dim(` (${ref.target.repositoryPath}:${ref.startLine}-${ref.endLine}, ${ref.provider})`)}`,
       );
       for (const line of ref.content.split('\n').slice(0, 5)) {
-        parts.push(`  ${s.dim('|')} ${line}`);
+        parts.push(
+          `  ${s.dim('|')} ${ref.kind === 'source' ? markdownInlineCode(line) : line}`,
+        );
       }
     }
   }
@@ -355,7 +369,7 @@ export function formatSectionOutput(
       if (ref.snippet) {
         const snippetLines = ref.snippet.split('\n');
         for (const line of snippetLines) {
-          parts.push(`  ${s.dim('|')} ${line}`);
+          parts.push(`  ${s.dim('|')} ${markdownInlineCode(line)}`);
         }
       }
     }

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -1652,6 +1652,31 @@ describe('getSection', () => {
     expect(output).toContain('src/app.ts:18-21');
   });
 
+  // @lat: [[tests/section#formatSectionOutput marks source snippets as inline code]]
+  it('formatSectionOutput marks source snippets as robust Markdown inline code', async () => {
+    const sourceCtx = testCtx('source-ref-ts-valid');
+    const sourceResult = await getSection(sourceCtx, 'lat.md/docs#Docs');
+    expect(sourceResult.kind).toBe('found');
+    if (sourceResult.kind !== 'found') return;
+    const sourceOutput = stripAnsi(
+      formatSectionOutput(sourceCtx, sourceResult),
+    );
+    expect(sourceOutput).toContain(
+      '| `export function greet(name: string): string {`',
+    );
+    expect(sourceOutput).toContain('| ``  return `Hello, ${name}!`;``');
+
+    const backlinkCtx = testCtx('section-nested');
+    const backlinkResult = await getSection(backlinkCtx, 'guide#Guide');
+    expect(backlinkResult.kind).toBe('found');
+    if (backlinkResult.kind !== 'found') return;
+    const backlinkOutput = stripAnsi(
+      formatSectionOutput(backlinkCtx, backlinkResult),
+    );
+    const backlinkAnnotation = '// @' + 'lat: [[guide#Guide#Child]]';
+    expect(backlinkOutput).toContain(`| \`${backlinkAnnotation}\``);
+  });
+
   // @lat: [[tests/section#formatSectionOutput includes all parts]]
   it('formatSectionOutput includes content and refs', async () => {
     const ctx = testCtx('basic-project');

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -1479,6 +1479,46 @@ describe('getSection', () => {
     expect(output).toContain('lat.md/links#Links');
   });
 
+  // @lat: [[tests/section#Parent section aggregates descendant references]]
+  it('aggregates outgoing refs and code backlinks from descendants', async () => {
+    const ctx = testCtx('section-nested');
+    const result = await getSection(ctx, 'guide#Guide');
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') return;
+
+    expect(result.outgoingRefs.map((ref) => ref.resolved.id)).toEqual([
+      'lat.md/target#Target',
+    ]);
+    expect(result.outgoingSourceRefs.map((ref) => ref.target)).toEqual([
+      'src/example.ts#child',
+    ]);
+    expect(result.codeRefs.map((ref) => ref.line)).toEqual([1, 4]);
+
+    const output = stripAnsi(formatSectionOutput(ctx, result));
+    expect(output).toContain('This section references:');
+    expect(output).toContain('Referenced by code:');
+    expect(output).toContain('@lat: [[guide#Guide#Child]]');
+    expect(output).toContain('@lat: [[guide#Guide#Child#Grandchild]]');
+  });
+
+  // @lat: [[tests/section#Reference summaries preserve leading paragraphs]]
+  it('renders full reference summaries with a malformed-content safety cap', async () => {
+    const ctx = testCtx('section-nested');
+    const result = await getSection(ctx, 'guide#Guide');
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') return;
+
+    const completeOutput = stripAnsi(formatSectionOutput(ctx, result));
+    expect(completeOutput).toContain('outgoing summary ending.');
+    expect(completeOutput).toContain('incoming summary ending.');
+
+    result.outgoingRefs[0].resolved.firstParagraph =
+      'x'.repeat(300) + 'content beyond the safety limit';
+    const cappedOutput = stripAnsi(formatSectionOutput(ctx, result));
+    expect(cappedOutput).toContain('x'.repeat(300) + '...');
+    expect(cappedOutput).not.toContain('content beyond the safety limit');
+  });
+
   // @lat: [[tests/section#Source refs include line range]]
   it('TS: outgoingSourceRefs include endLine for function, class, type, interface', async () => {
     const ctx = testCtx('source-ref-ts-valid');

--- a/tests/cases/section-nested/lat.md/guide.md
+++ b/tests/cases/section-nested/lat.md/guide.md
@@ -1,0 +1,13 @@
+# Guide
+
+The guide groups related instructions into a nested section tree.
+
+## Child
+
+The child introduces the detailed procedure.
+
+### Grandchild
+
+The grandchild owns references that should remain visible from the guide output.
+
+Follow [[target#Target]] and [[src/example.ts#child]] for the shared implementation details.

--- a/tests/cases/section-nested/lat.md/referrer.md
+++ b/tests/cases/section-nested/lat.md/referrer.md
@@ -1,0 +1,5 @@
+# Referrer
+
+This complete incoming reference paragraph deliberately continues beyond the old short preview boundary so the final identifying words remain visible in section output: incoming summary ending.
+
+See [[guide#Guide]] for the grouped instructions.

--- a/tests/cases/section-nested/lat.md/target.md
+++ b/tests/cases/section-nested/lat.md/target.md
@@ -1,0 +1,3 @@
+# Target
+
+This complete outgoing reference paragraph deliberately continues beyond the old short preview boundary so the final identifying words remain visible in section output: outgoing summary ending.

--- a/tests/cases/section-nested/src/example.ts
+++ b/tests/cases/section-nested/src/example.ts
@@ -1,0 +1,5 @@
+// @lat: [[guide#Guide#Child]]
+export const child = true;
+
+// @lat: [[guide#Guide#Child#Grandchild]]
+export const grandchild = true;

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -1459,7 +1459,19 @@ describe('lat ui', () => {
       'utf8',
     );
     expect(styles).toMatch(
-      /\.section-back-reference-toggle:hover \{\s*background: var\(--reference-control-hover\);/,
+      /--section-menu-control: color-mix\([\s\S]*?var\(--reference-control\) 70%,[\s\S]*?var\(--background\)[\s\S]*?\);/,
+    );
+    expect(styles).toMatch(
+      /\.section-back-reference-toggle \{[^}]*background: var\(--section-menu-control\);/,
+    );
+    expect(styles).toMatch(
+      /\.section-back-reference-toggle:hover \{\s*background: var\(--section-menu-control-hover\);/,
+    );
+    expect(styles).toMatch(
+      /\.section-back-reference-toggle svg \{[^}]*opacity: 0\.7;/,
+    );
+    expect(styles).toMatch(
+      /\.section-back-reference-toggle:hover svg \{\s*opacity: 0\.82;/,
     );
     expect(styles).toMatch(
       /\.section-back-reference-actions \{\s*display: grid;/,

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -1563,6 +1563,23 @@ describe('lat ui', () => {
       '<h2 id="unreferenced">Unreferenced</h2>',
     );
 
+    const referencedSectionOutputResponse = await fetch(
+      new URL(sectionOutputRequestUrl('lat.md/guide#Guide#Details'), view.url),
+    );
+    const referencedSectionOutput =
+      (await referencedSectionOutputResponse.json()) as ViewSectionCommandOutput;
+    expect(referencedSectionOutput.output).toContain(
+      '| `export function run(): string {`',
+    );
+    const referencedSectionHtml = documentTreeToHtml(
+      referencedSectionOutput.tree,
+    );
+    expect(referencedSectionHtml).toContain(
+      '<code>export function run(): string {</code>',
+    );
+    const codeReference = '// @' + 'lat: [[guide#Details]]';
+    expect(referencedSectionHtml).toContain(`<code>${codeReference}</code>`);
+
     const sourceResponse = await fetch(
       new URL('/api/source?path=src/app.ts&at=5', view.url),
     );

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -36,6 +36,16 @@
   --inline-code: #ededed;
   --reference-control: #e5e5e5;
   --reference-control-hover: #ededed;
+  --section-menu-control: color-mix(
+    in srgb,
+    var(--reference-control) 70%,
+    var(--background)
+  );
+  --section-menu-control-hover: color-mix(
+    in srgb,
+    var(--reference-control-hover) 70%,
+    var(--background)
+  );
   --graph-document: #0070f3;
   --graph-code: #d97706;
   --map-control-filter: none;
@@ -1039,7 +1049,7 @@ a {
   letter-spacing: 0.01em;
   vertical-align: middle;
   cursor: pointer;
-  background: var(--reference-control);
+  background: var(--section-menu-control);
   border: 0;
   border-radius: 5px;
 }
@@ -1048,13 +1058,18 @@ a {
   width: 14px;
   height: 14px;
   fill: none;
+  opacity: 0.7;
   stroke: currentColor;
   stroke-linecap: round;
   stroke-width: 1.5;
 }
 
 .section-back-reference-toggle:hover {
-  background: var(--reference-control-hover);
+  background: var(--section-menu-control-hover);
+}
+
+.section-back-reference-toggle:hover svg {
+  opacity: 0.82;
 }
 
 .section-back-reference-count {


### PR DESCRIPTION
## Summary

- Aggregate outgoing references and code backlinks across nested sections, while preserving complete reference summaries with a safety cap.
- Render source snippet lines as Markdown inline code, including robust delimiters for template literals.
- Make section burger controls quieter in both themes with subdued rest and hover states.

## Validation

- pnpm format
- pnpm buildall
- pnpm test (254 tests)
- lat check