### PR TITLE
Render external documents from native ASTs

### DIFF
--- a/lat.md/external-sources.md
+++ b/lat.md/external-sources.md
@@ -324,6 +324,8 @@ The `.json` suffix cannot collide with a source directory because dots are forbi
 }
 ```
 
+Generation updates use adjacent filesystem lock directories with recorded process owners. Concurrent live commands wait for the owner; interrupted owners are reclaimed immediately, and ownerless partial locks receive a short creation grace period before recovery.
+
 The metadata `ver` is [[src/external-sources.ts#EXTERNAL_SOURCES_SCHEMA_VER]], which covers both the JSON contract and strategy-specific on-disk layouts. `strategy` is `fetch`, `checkout`, or the internal value `local`. `source` is the effective fetch URL, configured checkout repository, or configured local path respectively. It is stored and compared exactly, without path or URL equivalence normalization. `commit` is always the effective commit, including a local override.
 
 ### Cache Invalidation
@@ -472,6 +474,8 @@ Agents may use the checkout suggestions from `lat external show` when they need 
 Lat retrieves exact files reached through configured external references rather than crawling or mirroring complete repositories.
 
 Fetch providers download referenced files individually. Managed checkouts use partial Git storage and lazy blob retrieval, keeping work proportional to the external content the project actually references.
+
+Repository-relative hyperlinks inside external documents become navigable only when their target file is already in that explicit reference set. Other destinations stay visible as unavailable, non-interactive text and never expand retrieval transitively.
 
 ### Stable Fragments
 

--- a/lat.md/tests/external-tests.md
+++ b/lat.md/tests/external-tests.md
@@ -39,6 +39,10 @@ Cache tests verify schema-version, exact provider-source, commit, and strategy g
 
 Missing or mismatched schema-version metadata forces complete regeneration of that source's cached files before resolution continues.
 
+### Interrupted owner recovery
+
+Filesystem cache locks record their process owner. A later command immediately reclaims a lock whose owner exited, while incomplete owner metadata receives a short creation grace period and live owners retain mutual exclusion.
+
 ## Commands and MCP
 
 Functional tests cover add, show, list, section, expand, refs, check, initialization, and the read-only external MCP tools.
@@ -60,6 +64,8 @@ View tests verify external previews share the versioned document tree with local
 The live server renders each supported external document kind and exposes its backlinks and graph relationships without relying on browser-side repository access.
 
 External source-code previews persist their AST-free symbol tables under a handle-scoped parser-cache identity.
+
+Across Markdown, reStructuredText, and AsciiDoc, relative links to explicitly referenced sibling files use canonical Lat routes. Links to other upstream files render as unavailable text and do not add live or static retrieval work.
 
 ### Local watcher refresh
 

--- a/lat.md/tests/external-tests.md
+++ b/lat.md/tests/external-tests.md
@@ -25,6 +25,10 @@ Format tests verify Markdown, reStructuredText, and AsciiDoc expose complete tit
 
 AsciiDoc coverage includes explicit document-title IDs and sections after legacy source blocks whose opening and closing delimiter lengths differ.
 
+### Native document tree projection
+
+reStructuredText and AsciiDoc parse nodes project directly into safe canonical trees. External links share document icons, labeled supported source blocks highlight, unlabeled literals stay plain, and raw pass-through markup remains inert.
+
 ## Persistent document analysis cache
 
 External Markdown, reStructuredText, and AsciiDoc analyses use validated versioned cache entries, invalidate changed content, recover from malformed payloads, and share one provider load and parse across every fragment of a file.

--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -26,13 +26,13 @@ Document APIs carry one versioned, parser-neutral presentation tree so the brows
 
 [[src/view/markdown.ts#renderMarkdown]] resolves Markdown semantics and converts mdast through the sanitizer, KaTeX, slug, and highlighting pipeline, then [[src/view/document-tree.ts#toViewDocumentTree]] retains only JSON-safe `root`, `element`, and `text` nodes. Parser positions, plugin objects, and executable properties never cross the boundary.
 
-reStructuredText and AsciiDoc use their native processors, then [[src/view/markdown.ts#externalHtmlToDocumentTree]] reflects the sanitized format output into the same tree. The browser therefore receives one rendering contract for local Markdown, external documents, Git projections, section output, and reference excerpts.
+[[src/view/external-document-tree.ts#renderExternalDocumentTree]] projects reStructuredText nodes and Asciidoctor block and inline nodes directly into the same tree. Native renderers never serialize external documents to HTML for the server to parse again.
 
 [[view/src/MarkdownContent.tsx#MarkdownContent]] recursively creates the React element tree, filters executable properties and unsafe URL protocols again, and mounts section menus and rich fences as stateful React components. It never uses `innerHTML` or `dangerouslySetInnerHTML`.
 
 Rich fences remain `pre` and `code` elements with inert text children in the contract. [[view/src/MarkdownRichFence.tsx#MarkdownRichFence]] recognizes those nodes while reflecting the tree, owns every renderer resource through React effects, and restores the same source fallback on failure or unmount.
 
-Source and fenced-code highlighting starts as Lowlight HAST and becomes document-tree nodes without HTML serialization. Multiline tokens are split structurally into independently renderable lines. Only native reStructuredText or AsciiDoc HTML remains a sanitized server-side adapter input.
+Source and fenced-code highlighting starts as Lowlight HAST and becomes document-tree nodes without HTML serialization. Multiline tokens are split structurally into independently renderable lines. Raw reStructuredText and AsciiDoc pass-through content remains inert text.
 
 Static export traverses tree properties to discover linked source and external targets and to rewrite route URLs. It does not parse or edit serialized markup.
 
@@ -98,7 +98,7 @@ Markdown and source metadata rows align with the sidebar header, while source me
 
 Rendered sections use heading scale and whitespace without horizontal separators between headings.
 
-Rendered link text is always underlined. Segmented wiki and source links underline muted context and active targets separately so each line matches its text color; language badges, reference counts, and external-link icons remain undecorated.
+Rendered link text is always underlined. A [[src/view/document-tree.ts#decorateExternalSiteLinks|parser-neutral tree pass]] adds external-link icons across Markdown, reStructuredText, and AsciiDoc; language badges, reference counts, and those icons remain undecorated.
 
 Document responses project every parsed heading and canonical GitHub slug into a local TOC. Its H1 entry stays bold at the base indentation, while subsection indentation remains relative to the first subsection level.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -43,7 +43,7 @@ Website deployments compile the current Lat UI against pinned npm releases of th
 
 Document, Git, section-output, reference, and highlighted-source APIs expose versioned JSON trees of safe root, element, and text nodes without legacy HTML fields.
 
-Markdown, reStructuredText, and AsciiDoc normalize into the same protocol. The client recursively reflects it into React elements, rejects executable properties and unsafe URL protocols, and owns interactive section menus without `innerHTML`.
+Markdown, reStructuredText, and AsciiDoc normalize into the same protocol. Native external parse trees project directly without an HTML round trip; shared tree decoration marks external links, and the client rejects executable properties and unsafe URL protocols.
 
 Static export discovers and rewrites links by traversing node properties while retaining the same document-tree payload as the live server.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -45,6 +45,8 @@ Document, Git, section-output, reference, and highlighted-source APIs expose ver
 
 Markdown, reStructuredText, and AsciiDoc normalize into the same protocol. Native external parse trees project directly without an HTML round trip; shared tree decoration marks external links, and the client rejects executable properties and unsafe URL protocols.
 
+External-document repository links resolve against the document's source path. Files present in the project's explicit external set receive canonical routes; unavailable relative targets become visibly muted, non-interactive nodes.
+
 Static export discovers and rewrites links by traversing node properties while retaining the same document-tree payload as the live server.
 
 ## Renders Markdown with navigable local links

--- a/src/external-documents.ts
+++ b/src/external-documents.ts
@@ -177,7 +177,7 @@ async function restructuredTextAnalysis(
 }
 
 /** Accept legacy AsciiDoc source listings whose delimiter lengths do not match. */
-function asciidocCompatibleContent(content: string): string {
+export function asciidocCompatibleContent(content: string): string {
   const lines = content.split('\n');
   for (let index = 0; index + 1 < lines.length; index++) {
     if (!/^\[(?:source|listing)(?:,|\])/i.test(lines[index].trim())) continue;
@@ -496,30 +496,4 @@ export function addExternalDocumentAliasAnchors(
     insert(tree.children);
   }
   return tree;
-}
-
-/** Render a non-Markdown external document with its native processor. */
-export async function renderExternalDocument(
-  format: Exclude<DocumentFormat, 'markdown'>,
-  content: string,
-): Promise<string> {
-  if (format === 'restructuredtext') {
-    const { RstToHtmlCompiler } = await import('rst-compiler');
-    const compiler = new RstToHtmlCompiler();
-    return compiler.compile(
-      content,
-      { disableErrors: true, disableWarnings: true },
-      { disableErrors: true, disableWarnings: true },
-    ).body;
-  }
-  const { load } = await import('@asciidoctor/core');
-  const document = await load(asciidocCompatibleContent(content), {
-    safe: 'secure',
-    attributes: { showtitle: true },
-  });
-  const html = await document.convert({ standalone: false });
-  if (typeof html !== 'string') {
-    throw new Error('AsciiDoc renderer did not return HTML');
-  }
-  return html;
 }

--- a/src/external-sources.ts
+++ b/src/external-sources.ts
@@ -677,6 +677,55 @@ const sourceLocks = new Map<string, Promise<void>>();
 const LOCK_RETRY_MS = 25;
 const LOCK_TIMEOUT_MS = 30_000;
 const LOCK_STALE_MS = 10 * 60_000;
+const LOCK_OWNER_GRACE_MS = 1_000;
+
+type FilesystemLockOwner = {
+  owner: string;
+  pid: number;
+  startedAt: number;
+};
+
+async function filesystemLockOwner(
+  path: string,
+): Promise<FilesystemLockOwner | null> {
+  try {
+    const value = JSON.parse(
+      await readFile(join(path, 'owner.json'), 'utf8'),
+    ) as Partial<FilesystemLockOwner> | null;
+    if (
+      !value ||
+      typeof value.owner !== 'string' ||
+      !Number.isInteger(value.pid) ||
+      value.pid! <= 0 ||
+      !Number.isFinite(value.startedAt)
+    ) {
+      return null;
+    }
+    return value as FilesystemLockOwner;
+  } catch {
+    return null;
+  }
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+async function discardFilesystemLock(path: string): Promise<void> {
+  const discarded = `${path}.stale-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  try {
+    await rename(path, discarded);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+  await rm(discarded, { recursive: true, force: true });
+}
 
 async function acquireFilesystemLock(
   key: string,
@@ -708,8 +757,13 @@ async function acquireFilesystemLock(
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
       try {
         const age = Date.now() - statSync(path).mtimeMs;
-        if (age > LOCK_STALE_MS) {
-          await rm(path, { recursive: true, force: true });
+        const currentOwner = await filesystemLockOwner(path);
+        if (
+          age > LOCK_STALE_MS ||
+          (currentOwner && !processIsAlive(currentOwner.pid)) ||
+          (!currentOwner && age > LOCK_OWNER_GRACE_MS)
+        ) {
+          await discardFilesystemLock(path);
           continue;
         }
       } catch (statError) {

--- a/src/view/document-tree.ts
+++ b/src/view/document-tree.ts
@@ -94,6 +94,53 @@ export function visitDocumentElements(
   for (const child of tree.children) visit(child);
 }
 
+function classNames(value: ViewDocumentProperty | undefined): string[] {
+  if (Array.isArray(value)) return value.map(String);
+  return typeof value === 'string' ? value.split(/\s+/).filter(Boolean) : [];
+}
+
+function isExternalSiteUrl(value: string): boolean {
+  return /^(?:https?:)?\/\//i.test(value);
+}
+
+/** Apply parser-neutral presentation to links that leave the current site. */
+export function decorateExternalSiteLinks(
+  tree: ViewDocumentTree,
+): ViewDocumentTree {
+  visitDocumentElements(tree, (element) => {
+    const href = element.properties.href;
+    if (
+      element.tagName !== 'a' ||
+      typeof href !== 'string' ||
+      !isExternalSiteUrl(href)
+    ) {
+      return;
+    }
+
+    const classes = classNames(element.properties.className);
+    if (!classes.includes('external-link')) classes.push('external-link');
+    element.properties.className = classes;
+    const alreadyDecorated = element.children.some(
+      (child) =>
+        child.type === 'element' &&
+        child.tagName === 'span' &&
+        classNames(child.properties.className).includes('external-link-icon'),
+    );
+    if (!alreadyDecorated) {
+      element.children.push({
+        type: 'element',
+        tagName: 'span',
+        properties: {
+          ariaHidden: 'true',
+          className: ['external-link-icon'],
+        },
+        children: [],
+      });
+    }
+  });
+  return tree;
+}
+
 /** Clone a document tree while structurally rewriting navigable URLs. */
 export function rewriteDocumentTreeUrls(
   tree: ViewDocumentTree,

--- a/src/view/external-document-tree.ts
+++ b/src/view/external-document-tree.ts
@@ -1,0 +1,945 @@
+import type { AbstractBlock, Inline } from '@asciidoctor/core';
+import type { RstNode } from 'rst-compiler';
+import { asciidocCompatibleContent } from '../external-documents.js';
+import {
+  decorateExternalSiteLinks,
+  toViewDocumentTree,
+} from './document-tree.js';
+import { highlightCode } from './highlight.js';
+import type {
+  ViewDocumentElement,
+  ViewDocumentNode,
+  ViewDocumentProperty,
+  ViewDocumentTree,
+} from './protocol.js';
+
+type Properties = Record<string, ViewDocumentProperty>;
+
+function text(value: string): ViewDocumentNode {
+  return { type: 'text', value };
+}
+
+function element(
+  tagName: string,
+  children: ViewDocumentNode[] = [],
+  properties: Properties = {},
+): ViewDocumentElement {
+  return { type: 'element', tagName, properties, children };
+}
+
+function safeUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const url = value.trim();
+  if (!url || /^\s*(?:data|javascript|vbscript):/i.test(url)) return null;
+  return url;
+}
+
+function codeBlock(source: string, language?: string | null): ViewDocumentNode {
+  const normalizedLanguage = language?.trim().toLowerCase() || null;
+  const highlighted = normalizedLanguage
+    ? highlightCode(normalizedLanguage, source)
+    : null;
+  const children = highlighted
+    ? toViewDocumentTree(highlighted).children
+    : [text(source ? `${source}\n` : '')];
+  const className = [
+    ...(normalizedLanguage ? [`language-${normalizedLanguage}`] : []),
+    ...(highlighted ? ['hljs'] : []),
+  ];
+  return element('pre', [
+    element(
+      'code',
+      highlighted ? [...children, text('\n')] : children,
+      className.length > 0 ? { className } : {},
+    ),
+  ]);
+}
+
+type RstData = Record<string, unknown>;
+
+function rstData(node: RstNode): RstData {
+  const value = node.toObject().data;
+  return value && typeof value === 'object' ? (value as RstData) : {};
+}
+
+function rstInlineChildren(
+  nodes: readonly RstNode[],
+  render: (node: RstNode) => ViewDocumentNode[],
+): ViewDocumentNode[] {
+  return nodes.flatMap(render);
+}
+
+function normalizeRstName(value: string): string {
+  return value
+    .normalize('NFD')
+    .replaceAll(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9\-_.:+<>]/g, '-')
+    .replaceAll(/-{2,}/g, '-')
+    .replace(/^[-]*/, '')
+    .replace(/[-]*$/, '');
+}
+
+async function restructuredTextTree(
+  content: string,
+): Promise<ViewDocumentTree> {
+  const { RstToHtmlCompiler } = await import('rst-compiler');
+  const parsed = new RstToHtmlCompiler().parse(content, {
+    disableErrors: true,
+    disableWarnings: true,
+  });
+
+  const properties = (node: RstNode): Properties => {
+    const id = parsed.htmlAttrResolver.getNodeHtmlId(node);
+    const className = parsed.htmlAttrResolver.getNodeHtmlClasses(node);
+    return {
+      ...(id ? { id } : {}),
+      ...(className.length > 0 ? { className } : {}),
+    };
+  };
+  const linkableNodes = new Map<string, RstNode>(
+    parsed.simpleNameResolver.nodesLinkableFromOutside,
+  );
+  for (const node of parsed.root.findAllChildren('HyperlinkTarget')) {
+    const label = (node as RstNode & { label?: string }).label;
+    if (label) linkableNodes.set(normalizeRstName(label), node);
+  }
+
+  const linkedNodeUrl = (
+    node: RstNode,
+    visited = new Set<RstNode>(),
+  ): string | null => {
+    if (visited.has(node)) return null;
+    visited.add(node);
+    if (node.nodeType === 'HyperlinkTarget') {
+      const target = (node as RstNode & { target?: string }).target ?? '';
+      const alias = (node as RstNode & { isAlias?: boolean }).isAlias;
+      if (alias) {
+        const linked = linkableNodes.get(
+          normalizeRstName(target.replace(/_$/, '')),
+        );
+        return linked ? linkedNodeUrl(linked, visited) : null;
+      }
+      if (target) return safeUrl(target);
+    }
+    const id = parsed.htmlAttrResolver.getNodeHtmlId(node);
+    return id ? `#${id}` : null;
+  };
+
+  const hyperlinkUrl = (node: RstNode): string | null => {
+    const link = node as RstNode & {
+      isAlias?: boolean;
+      isAnonymous?: boolean;
+      isEmbeded?: boolean;
+      target?: string;
+    };
+    if (link.isAnonymous && !link.isEmbeded) {
+      const target =
+        parsed.simpleNameResolver.anonymousHyperlinkRefToTarget.get(
+          node as never,
+        );
+      return target ? linkedNodeUrl(target) : null;
+    }
+    const rawTarget = link.target ?? '';
+    const targetName = link.isAlias ? rawTarget.replace(/_$/, '') : rawTarget;
+    const linked = linkableNodes.get(normalizeRstName(targetName));
+    return linked ? linkedNodeUrl(linked) : safeUrl(rawTarget);
+  };
+
+  const render = (node: RstNode): ViewDocumentNode[] => {
+    const data = rstData(node);
+    const children = () => rstInlineChildren(node.children, render);
+    switch (node.nodeType) {
+      case 'Document':
+        return children();
+      case 'Section': {
+        const level = Number(data.level ?? 1);
+        return [
+          element(
+            `h${Math.max(1, Math.min(6, level))}`,
+            children(),
+            properties(node),
+          ),
+        ];
+      }
+      case 'Paragraph':
+        return [element('p', children(), properties(node))];
+      case 'Text':
+        return [text(node.textContent)];
+      case 'Emphasis':
+        return [element('em', [text(node.textContent)], properties(node))];
+      case 'StrongEmphasis':
+        return [element('strong', [text(node.textContent)], properties(node))];
+      case 'InlineLiteral':
+      case 'InterpretedText':
+        return [element('code', [text(node.textContent)], properties(node))];
+      case 'HyperlinkRef': {
+        const href = hyperlinkUrl(node);
+        if (!href) return [text(node.textContent)];
+        return [
+          element('a', [text(node.textContent)], {
+            ...properties(node),
+            href,
+          }),
+        ];
+      }
+      case 'InlineInternalTarget':
+        return [element('span', [text(node.textContent)], properties(node))];
+      case 'LiteralBlock':
+      case 'DoctestBlock':
+        return [codeBlock(node.rawTextContent || node.textContent)];
+      case 'Blockquote':
+        return [element('blockquote', children(), properties(node))];
+      case 'BlockquoteAttribution':
+        return [element('footer', children(), properties(node))];
+      case 'Transition':
+        return [element('hr', [], properties(node))];
+      case 'LineBlock':
+        return [element('p', children(), properties(node))];
+      case 'LineBlockLine':
+        return [...children(), element('br')];
+      case 'BulletList':
+        return [element('ul', children(), properties(node))];
+      case 'EnumeratedList':
+        return [element('ol', children(), properties(node))];
+      case 'BulletListItem':
+        return [element('li', children(), properties(node))];
+      case 'DefinitionList':
+      case 'FieldList':
+      case 'OptionList':
+        return [element('dl', children(), properties(node))];
+      case 'DefinitionListItem': {
+        const item = node as RstNode & {
+          term: readonly RstNode[];
+          classifiers: readonly (readonly RstNode[])[];
+          definition: readonly RstNode[];
+        };
+        const term = item.term.flatMap(render);
+        const classifiers = item.classifiers.map((classifier) =>
+          classifier.flatMap(render),
+        );
+        const definition = item.definition.flatMap(render);
+        return [
+          element('dt', [
+            ...term,
+            ...classifiers.flatMap((classifier) => [
+              text(' : '),
+              ...classifier,
+            ]),
+          ]),
+          element('dd', definition),
+        ];
+      }
+      case 'FieldListItem': {
+        const item = node as RstNode & {
+          name: readonly RstNode[];
+          body: readonly RstNode[];
+        };
+        return [
+          element('dt', item.name.flatMap(render)),
+          element('dd', item.body.flatMap(render)),
+        ];
+      }
+      case 'OptionListItem': {
+        const options = (
+          node as RstNode & {
+            options: readonly {
+              name: string;
+              delimiter?: string;
+              rawArgName?: string;
+            }[];
+          }
+        ).options;
+        return [
+          element('dt', [
+            text(
+              options
+                .map(
+                  (option) =>
+                    `${option.name}${option.delimiter ?? ''}${option.rawArgName ?? ''}`,
+                )
+                .join(', '),
+            ),
+          ]),
+          element('dd', children()),
+        ];
+      }
+      case 'Table': {
+        const headRows = (node as RstNode & { headRows?: readonly RstNode[] })
+          .headRows;
+        const bodyRows = (node as RstNode & { bodyRows?: readonly RstNode[] })
+          .bodyRows;
+        return [
+          element('table', [
+            ...(headRows?.length
+              ? [element('thead', headRows.flatMap(render))]
+              : []),
+            element('tbody', (bodyRows ?? node.children).flatMap(render)),
+          ]),
+        ];
+      }
+      case 'TableRow':
+        return [element('tr', children())];
+      case 'TableCell': {
+        const cell = node as RstNode & { colSpan?: number; rowSpan?: number };
+        const parent = node.parent;
+        const tagName =
+          parent?.nodeType === 'TableRow' &&
+          (parent as RstNode & { isHeadRow?: boolean }).isHeadRow
+            ? 'th'
+            : 'td';
+        return [
+          element(tagName, children(), {
+            ...(cell.colSpan && cell.colSpan > 1
+              ? { colSpan: cell.colSpan }
+              : {}),
+            ...(cell.rowSpan && cell.rowSpan > 1
+              ? { rowSpan: cell.rowSpan }
+              : {}),
+          }),
+        ];
+      }
+      case 'Directive': {
+        const directive = String(data.directive ?? '').toLowerCase();
+        const rawBody =
+          typeof data.rawBodyText === 'string' ? data.rawBodyText : '';
+        if (['code', 'code-block', 'sourcecode'].includes(directive)) {
+          const language = (
+            node as RstNode & { initContentText?: string }
+          ).initContentText
+            ?.trim()
+            .split(/\s+/, 1)[0];
+          return [codeBlock(rawBody || node.textContent, language)];
+        }
+        if (directive === 'image' || directive === 'figure') {
+          const src = safeUrl(
+            (node as RstNode & { initContentText?: string }).initContentText,
+          );
+          return src
+            ? [element('img', [], { src, alt: String(data.alt ?? '') })]
+            : [];
+        }
+        if (
+          [
+            'attention',
+            'caution',
+            'danger',
+            'error',
+            'hint',
+            'important',
+            'note',
+            'tip',
+            'warning',
+          ].includes(directive)
+        ) {
+          return [
+            element(
+              'div',
+              [
+                element(
+                  'p',
+                  [text(directive[0].toUpperCase() + directive.slice(1))],
+                  {
+                    className: ['markdown-alert-title'],
+                  },
+                ),
+                ...children(),
+              ],
+              {
+                className: [
+                  'markdown-alert',
+                  `markdown-alert-${directive === 'hint' ? 'tip' : directive}`,
+                ],
+              },
+            ),
+          ];
+        }
+        if (directive === 'raw') {
+          return rawBody ? [codeBlock(rawBody)] : [];
+        }
+        return children();
+      }
+      case 'FootnoteRef':
+      case 'CitationRef':
+        return [element('sup', [text(node.textContent)], properties(node))];
+      case 'FootnoteDef':
+      case 'CitationDef':
+        return [element('div', children(), properties(node))];
+      case 'Comment':
+      case 'HyperlinkTarget':
+      case 'SubstitutionDef':
+        return [];
+      default:
+        return node.children.length > 0 ? children() : [text(node.textContent)];
+    }
+  };
+
+  return { version: 1, type: 'root', children: render(parsed.root) };
+}
+
+type AsciiBlock = AbstractBlock & {
+  _text?: string;
+  getItems?: () => unknown[];
+  getSource?: () => string;
+  rows?: {
+    toObject: () => { head: unknown[][]; body: unknown[][]; foot: unknown[][] };
+  };
+};
+
+type AsciiCell = {
+  _text?: string;
+  colspan?: number;
+  rowspan?: number;
+};
+
+type AsciiInlineOwner = {
+  applySubs: (
+    value: string,
+    substitutions?: string[],
+  ) => Promise<string | string[]>;
+  subs?: string[];
+};
+
+const ASCIIDOC_NORMAL_SUBSTITUTIONS = [
+  'specialcharacters',
+  'quotes',
+  'attributes',
+  'replacements',
+  'macros',
+  'post_replacements',
+];
+
+function decodeAsciiEntities(value: string): string {
+  return value.replace(
+    /&(?:#(\d+)|#x([\da-f]+)|(amp|apos|gt|lt|quot));/gi,
+    (match, decimal: string, hex: string, named: string) => {
+      if (decimal) return String.fromCodePoint(Number(decimal));
+      if (hex) return String.fromCodePoint(Number.parseInt(hex, 16));
+      return (
+        {
+          amp: '&',
+          apos: "'",
+          gt: '>',
+          lt: '<',
+          quot: '"',
+        }[named.toLowerCase()] ?? match
+      );
+    },
+  );
+}
+
+/** Convert Asciidoctor's native inline nodes into document-tree tokens. */
+class AsciiInlineProjector {
+  private readonly tokens: ViewDocumentNode[][] = [];
+
+  private token(nodes: ViewDocumentNode | ViewDocumentNode[]): string {
+    const index = this.tokens.push(Array.isArray(nodes) ? nodes : [nodes]) - 1;
+    return `\u{e000}${index}\u{e001}`;
+  }
+
+  private properties(node: Inline): Properties {
+    const id = node.getId();
+    const className = node.getRoles();
+    return {
+      ...(id ? { id } : {}),
+      ...(className.length > 0 ? { className } : {}),
+    };
+  }
+
+  decode(value: string): ViewDocumentNode[] {
+    const nodes: ViewDocumentNode[] = [];
+    let cursor = 0;
+    for (const match of value.matchAll(/\u{e000}(\d+)\u{e001}/gu)) {
+      const index = match.index ?? 0;
+      if (index > cursor) {
+        nodes.push(text(decodeAsciiEntities(value.slice(cursor, index))));
+      }
+      nodes.push(...(this.tokens[Number(match[1])] ?? []));
+      cursor = index + match[0].length;
+    }
+    if (cursor < value.length) {
+      nodes.push(text(decodeAsciiEntities(value.slice(cursor))));
+    }
+    return nodes;
+  }
+
+  async project(
+    owner: AsciiInlineOwner,
+    value: string,
+  ): Promise<ViewDocumentNode[]> {
+    const substitutions =
+      owner.subs && owner.subs.length > 0
+        ? owner.subs
+        : ASCIIDOC_NORMAL_SUBSTITUTIONS;
+    const converted = await owner.applySubs(value, substitutions);
+    return this.decode(
+      Array.isArray(converted) ? converted.join('\n') : converted,
+    );
+  }
+
+  convert(node: Inline): string {
+    const content = this.decode(node.getText() ?? '');
+    const properties = this.properties(node);
+    switch (node.getContext()) {
+      case 'quoted': {
+        const tagName =
+          {
+            emphasis: 'em',
+            mark: 'mark',
+            monospaced: 'code',
+            strong: 'strong',
+            subscript: 'sub',
+            superscript: 'sup',
+            unquoted: 'span',
+          }[node.getType() ?? ''] ?? 'span';
+        if (node.getType() === 'double') {
+          return this.token([text('“'), ...content, text('”')]);
+        }
+        if (node.getType() === 'single') {
+          return this.token([text('‘'), ...content, text('’')]);
+        }
+        return this.token(element(tagName, content, properties));
+      }
+      case 'anchor': {
+        if (node.getType() === 'ref' || node.getType() === 'bibref') {
+          return this.token(
+            element('span', content, {
+              ...properties,
+              ...(node.getId() ? { id: node.getId() as string } : {}),
+            }),
+          );
+        }
+        const href = safeUrl(node.getTarget());
+        return this.token(
+          href
+            ? element('a', content.length > 0 ? content : [text(href)], {
+                ...properties,
+                href,
+              })
+            : content,
+        );
+      }
+      case 'image': {
+        const src = safeUrl(node.getTarget());
+        return this.token(
+          src
+            ? element('img', [], {
+                ...properties,
+                src,
+                alt: node.getAlt(),
+              })
+            : content,
+        );
+      }
+      case 'break':
+        return this.token([...content, element('br')]);
+      case 'button':
+        return this.token(element('b', content, { className: ['button'] }));
+      case 'callout':
+        return this.token(
+          element('b', [text(`(${node.getText() ?? ''})`)], {
+            className: ['conum'],
+          }),
+        );
+      case 'footnote':
+        return this.token(
+          element(
+            'sup',
+            [text(String(node.getAttribute('index') ?? node.getText() ?? ''))],
+            { className: ['footnote'] },
+          ),
+        );
+      case 'indexterm':
+        return node.getType() === 'visible' ? this.token(content) : '';
+      case 'kbd': {
+        const keys = node.getAttribute('keys');
+        const values = Array.isArray(keys) ? keys.map(String) : [];
+        return this.token(
+          values.flatMap((key, index) => [
+            ...(index > 0 ? [text('+')] : []),
+            element('kbd', [text(key)]),
+          ]),
+        );
+      }
+      case 'menu': {
+        const values = [
+          node.getAttribute('menu'),
+          ...(Array.isArray(node.getAttribute('submenus'))
+            ? (node.getAttribute('submenus') as unknown[])
+            : []),
+          node.getAttribute('menuitem'),
+        ].filter((value) => value != null && value !== '');
+        return this.token(
+          element('span', [text(values.map(String).join(' › '))], {
+            className: ['menuseq'],
+          }),
+        );
+      }
+      default:
+        return this.token(content);
+    }
+  }
+}
+
+function asciiSource(node: AsciiBlock): string {
+  return node.getSource?.() ?? '';
+}
+
+function asciiNodeProperties(node: AsciiBlock): Properties {
+  const id = node.getId();
+  const className = node.getRoles();
+  return {
+    ...(id ? { id } : {}),
+    ...(className.length > 0 ? { className } : {}),
+  };
+}
+
+function asciiRawText(value: unknown): string {
+  return value && typeof value === 'object' && '_text' in value
+    ? String((value as { _text?: unknown })._text ?? '')
+    : '';
+}
+
+async function asciiTable(
+  node: AsciiBlock,
+  projector: AsciiInlineProjector,
+): Promise<ViewDocumentNode> {
+  const rows = node.rows?.toObject() ?? { head: [], body: [], foot: [] };
+  const renderRows = async (source: unknown[][], header: boolean) => {
+    const result: ViewDocumentNode[] = [];
+    for (const row of source) {
+      const cells: ViewDocumentNode[] = [];
+      for (const rawCell of row) {
+        const cell = rawCell as AsciiCell;
+        cells.push(
+          element(
+            header ? 'th' : 'td',
+            await projector.project(
+              cell as unknown as AsciiInlineOwner,
+              asciiRawText(cell),
+            ),
+            {
+              ...(cell.colspan && cell.colspan > 1
+                ? { colSpan: cell.colspan }
+                : {}),
+              ...(cell.rowspan && cell.rowspan > 1
+                ? { rowSpan: cell.rowspan }
+                : {}),
+            },
+          ),
+        );
+      }
+      result.push(element('tr', cells));
+    }
+    return result;
+  };
+  return element('table', [
+    ...(rows.head.length
+      ? [element('thead', await renderRows(rows.head, true))]
+      : []),
+    element('tbody', await renderRows(rows.body, false)),
+    ...(rows.foot.length
+      ? [element('tfoot', await renderRows(rows.foot, false))]
+      : []),
+  ]);
+}
+
+async function asciidocTree(content: string): Promise<ViewDocumentTree> {
+  const { load } = await import('@asciidoctor/core');
+  const document = await load(asciidocCompatibleContent(content), {
+    safe: 'secure',
+    sourcemap: true,
+    attributes: { showtitle: true },
+  });
+  const lines = content.split('\n');
+  const documentTitle = document.getAttribute('doctitle');
+  const rawDocumentTitle =
+    typeof documentTitle === 'string' ? documentTitle : null;
+  const projector = new AsciiInlineProjector();
+  const originalConverter = document.getConverter();
+  document.setConverter(projector);
+  const sectionOffset = rawDocumentTitle ? 1 : 0;
+
+  const sectionTitle = (node: AsciiBlock): string => {
+    const line = node.getLineNumber();
+    const raw = line ? lines[line - 1] : undefined;
+    const match = raw ? /^={1,6}\s+(.+)$/.exec(raw) : null;
+    return match?.[1] ?? String(node.getTitle() ?? '');
+  };
+
+  let render: (sourceNode: AbstractBlock) => Promise<ViewDocumentNode[]>;
+  const renderMany = async (
+    sourceNodes: readonly AbstractBlock[],
+  ): Promise<ViewDocumentNode[]> => {
+    const result: ViewDocumentNode[] = [];
+    for (const sourceNode of sourceNodes)
+      result.push(...(await render(sourceNode)));
+    return result;
+  };
+
+  const renderListItem = async (raw: unknown): Promise<ViewDocumentNode> => {
+    const item = raw as AsciiBlock;
+    return element('li', [
+      ...(await projector.project(
+        item as unknown as AsciiInlineOwner,
+        asciiRawText(item),
+      )),
+      ...(await renderMany(item.getBlocks())),
+    ]);
+  };
+
+  render = async (sourceNode: AbstractBlock): Promise<ViewDocumentNode[]> => {
+    const node = sourceNode as AsciiBlock;
+    const context = node.getContext();
+    const childNodes = () => renderMany(node.getBlocks());
+    switch (context) {
+      case 'preamble':
+      case 'document':
+        return await childNodes();
+      case 'section': {
+        const level = Math.max(
+          1,
+          Math.min(6, (node.getLevel() ?? node.level ?? 1) + sectionOffset),
+        );
+        return [
+          element(
+            `h${level}`,
+            await projector.project(
+              node as unknown as AsciiInlineOwner,
+              sectionTitle(node),
+            ),
+            asciiNodeProperties(node),
+          ),
+          ...(await childNodes()),
+        ];
+      }
+      case 'paragraph':
+        return [
+          element(
+            'p',
+            await projector.project(
+              node as unknown as AsciiInlineOwner,
+              asciiSource(node),
+            ),
+            asciiNodeProperties(node),
+          ),
+        ];
+      case 'ulist':
+      case 'olist':
+      case 'colist': {
+        const tagName = context === 'ulist' ? 'ul' : 'ol';
+        return [
+          element(
+            tagName,
+            await Promise.all((node.getItems?.() ?? []).map(renderListItem)),
+            asciiNodeProperties(node),
+          ),
+        ];
+      }
+      case 'dlist': {
+        const entries = node.getItems?.() ?? [];
+        const descriptionNodes: ViewDocumentNode[] = [];
+        for (const entry of entries) {
+          if (!Array.isArray(entry)) continue;
+          const terms = Array.isArray(entry[0]) ? entry[0] : [];
+          const description = entry[1] as AsciiBlock | null;
+          for (const term of terms) {
+            descriptionNodes.push(
+              element(
+                'dt',
+                await projector.project(
+                  term as unknown as AsciiInlineOwner,
+                  asciiRawText(term),
+                ),
+              ),
+            );
+          }
+          descriptionNodes.push(
+            element('dd', [
+              ...(description
+                ? await projector.project(
+                    description as unknown as AsciiInlineOwner,
+                    asciiRawText(description),
+                  )
+                : []),
+              ...(description ? await renderMany(description.getBlocks()) : []),
+            ]),
+          );
+        }
+        return [element('dl', descriptionNodes, asciiNodeProperties(node))];
+      }
+      case 'listing':
+      case 'literal': {
+        const language =
+          context === 'listing' && node.getStyle() === 'source'
+            ? String(node.getAttribute('language') ?? '')
+            : null;
+        return [codeBlock(asciiSource(node), language)];
+      }
+      case 'stem':
+        return [codeBlock(asciiSource(node), 'text')];
+      case 'quote':
+      case 'verse': {
+        const contents = await childNodes();
+        return [
+          element(
+            'blockquote',
+            contents.length > 0
+              ? contents
+              : [
+                  element(
+                    'p',
+                    await projector.project(
+                      node as unknown as AsciiInlineOwner,
+                      asciiSource(node),
+                    ),
+                  ),
+                ],
+            asciiNodeProperties(node),
+          ),
+        ];
+      }
+      case 'admonition': {
+        const kind = String(node.getStyle() ?? 'note').toLowerCase();
+        const body = await childNodes();
+        return [
+          element(
+            'div',
+            [
+              element('p', [text(kind[0].toUpperCase() + kind.slice(1))], {
+                className: ['markdown-alert-title'],
+              }),
+              ...(body.length > 0
+                ? body
+                : [
+                    element(
+                      'p',
+                      await projector.project(
+                        node as unknown as AsciiInlineOwner,
+                        asciiSource(node),
+                      ),
+                    ),
+                  ]),
+            ],
+            {
+              ...asciiNodeProperties(node),
+              className: [
+                'markdown-alert',
+                `markdown-alert-${kind === 'hint' ? 'tip' : kind}`,
+              ],
+            },
+          ),
+        ];
+      }
+      case 'image': {
+        const src = safeUrl(node.getAttribute('target'));
+        return src
+          ? [
+              element('img', [], {
+                ...asciiNodeProperties(node),
+                src,
+                alt: String(node.getAttribute('alt') ?? ''),
+              }),
+            ]
+          : [];
+      }
+      case 'table':
+        return [await asciiTable(node, projector)];
+      case 'thematic_break':
+      case 'page_break':
+        return [element('hr', [], asciiNodeProperties(node))];
+      case 'floating_title':
+      case 'discrete_heading': {
+        const level = Math.max(
+          1,
+          Math.min(6, (node.getLevel() ?? node.level ?? 1) + 1),
+        );
+        return [
+          element(
+            `h${level}`,
+            await projector.project(
+              node as unknown as AsciiInlineOwner,
+              sectionTitle(node),
+            ),
+            asciiNodeProperties(node),
+          ),
+        ];
+      }
+      case 'pass':
+        return asciiSource(node) ? [codeBlock(asciiSource(node))] : [];
+      case 'open':
+      case 'example':
+      case 'sidebar': {
+        const contents = await childNodes();
+        return [
+          element(
+            'div',
+            contents.length > 0
+              ? contents
+              : [
+                  element(
+                    'p',
+                    await projector.project(
+                      node as unknown as AsciiInlineOwner,
+                      asciiSource(node),
+                    ),
+                  ),
+                ],
+            {
+              ...asciiNodeProperties(node),
+              className: [`asciidoc-${context}`, ...node.getRoles()],
+            },
+          ),
+        ];
+      }
+      default: {
+        const contents = await childNodes();
+        if (contents.length > 0) return contents;
+        const source = asciiSource(node);
+        return source
+          ? [
+              element(
+                'p',
+                await projector.project(
+                  node as unknown as AsciiInlineOwner,
+                  source,
+                ),
+              ),
+            ]
+          : [];
+      }
+    }
+  };
+
+  try {
+    const children: ViewDocumentNode[] = [];
+    if (rawDocumentTitle) {
+      children.push(
+        element(
+          'h1',
+          await projector.project(
+            document as unknown as AsciiInlineOwner,
+            rawDocumentTitle,
+          ),
+          document.getId() ? { id: document.getId() as string } : {},
+        ),
+      );
+    }
+    children.push(...(await renderMany(document.getBlocks())));
+    return { version: 1, type: 'root', children };
+  } finally {
+    document.setConverter(originalConverter);
+  }
+}
+
+/** Reflect a native non-Markdown parser AST into the browser document tree. */
+export async function renderExternalDocumentTree(
+  format: 'asciidoc' | 'restructuredtext',
+  content: string,
+): Promise<ViewDocumentTree> {
+  const tree =
+    format === 'restructuredtext'
+      ? await restructuredTextTree(content)
+      : await asciidocTree(content);
+  return decorateExternalSiteLinks(tree);
+}

--- a/src/view/highlight.ts
+++ b/src/view/highlight.ts
@@ -10,6 +10,7 @@ import javascript from 'highlight.js/lib/languages/javascript';
 import json from 'highlight.js/lib/languages/json';
 import markdown from 'highlight.js/lib/languages/markdown';
 import python from 'highlight.js/lib/languages/python';
+import ruby from 'highlight.js/lib/languages/ruby';
 import rust from 'highlight.js/lib/languages/rust';
 import typescript from 'highlight.js/lib/languages/typescript';
 import xml from 'highlight.js/lib/languages/xml';
@@ -27,6 +28,7 @@ const lowlight = createLowlight({
   json,
   markdown,
   python,
+  ruby,
   rust,
   typescript,
   xml,
@@ -49,6 +51,8 @@ const languageAliases: Record<string, string> = {
   md: 'markdown',
   py: 'python',
   python: 'python',
+  rb: 'ruby',
+  ruby: 'ruby',
   rs: 'rust',
   rust: 'rust',
   sh: 'bash',

--- a/src/view/markdown.ts
+++ b/src/view/markdown.ts
@@ -20,7 +20,10 @@ import { visit } from 'unist-util-visit';
 import type { AlertMarker } from '../extensions/alert-marker.js';
 import type { WikiLink } from '../extensions/wiki-link/types.js';
 import { parse } from '../parser.js';
-import { toViewDocumentTree } from './document-tree.js';
+import {
+  decorateExternalSiteLinks,
+  toViewDocumentTree,
+} from './document-tree.js';
 import { highlightCode } from './highlight.js';
 import type { ViewDocumentTree } from './protocol.js';
 
@@ -63,8 +66,6 @@ const CODE_LINK_CLASSES = [
 ];
 
 const ERROR_CLASS = 'markdown-error';
-const EXTERNAL_LINK_CLASS = 'external-link';
-const EXTERNAL_LINK_ICON_CLASS = 'external-link-icon';
 const GIT_CLASSES = ['git-added', 'git-removed'];
 const GEOJSON_SOURCE_CLASS = 'markdown-geojson-source';
 const HIGHLIGHT_CLASS = 'hljs';
@@ -144,7 +145,6 @@ const sanitizeSchema: SanitizeSchema = {
         'wiki-link-segmented',
         'wiki-link-code',
         'wiki-link-active',
-        EXTERNAL_LINK_CLASS,
         ERROR_CLASS,
         ...GIT_CLASSES,
       ],
@@ -187,7 +187,6 @@ const sanitizeSchema: SanitizeSchema = {
         'wiki-link-context',
         'wiki-link-leaf',
         'wiki-link-ref-count',
-        EXTERNAL_LINK_ICON_CLASS,
         ...CODE_LINK_CLASSES.slice(2),
         /^hljs-./,
         ERROR_CLASS,
@@ -298,19 +297,6 @@ function transformCustomEmoji(tree: Root): void {
     parent.children.splice(index, 1, ...children);
     return index + children.length;
   });
-}
-
-const externalHtmlProcessor = unified()
-  .use(rehypeRaw)
-  .use(rehypeSanitize, { ...sanitizeSchema, clobberPrefix: '' });
-
-/** Normalize HTML emitted by a format-native parser into the document tree. */
-export function externalHtmlToDocumentTree(html: string): ViewDocumentTree {
-  const tree = {
-    type: 'root' as const,
-    children: [{ type: 'raw' as const, value: html }],
-  };
-  return toViewDocumentTree(externalHtmlProcessor.runSync(tree));
 }
 
 function nodeText(node: { value?: unknown; children?: unknown }): string {
@@ -468,24 +454,6 @@ function codeLinkContent(
   ];
 }
 
-function externalLinkIcon(): PhrasingContent {
-  return {
-    type: 'emphasis',
-    data: {
-      hName: 'span',
-      hProperties: {
-        ariaHidden: 'true',
-        className: [EXTERNAL_LINK_ICON_CLASS],
-      },
-    },
-    children: [],
-  } as PhrasingContent;
-}
-
-function isExternalSiteUrl(url: string): boolean {
-  return /^(?:https?:)?\/\//i.test(url);
-}
-
 function referenceCountBadge(count: number): RootContent {
   return {
     type: 'emphasis',
@@ -609,23 +577,6 @@ export async function renderMarkdown(
     if (options.rewriteMarkdownLink) {
       node.url = options.rewriteMarkdownLink(authoredUrl);
     }
-    if (!isExternalSiteUrl(node.url)) return;
-
-    const properties = node.data?.hProperties ?? {};
-    const currentClasses = properties.className;
-    const classes = Array.isArray(currentClasses)
-      ? currentClasses.map(String)
-      : currentClasses
-        ? [String(currentClasses)]
-        : [];
-    node.data = {
-      ...node.data,
-      hProperties: {
-        ...properties,
-        className: [...classes, EXTERNAL_LINK_CLASS],
-      },
-    };
-    node.children.push(externalLinkIcon());
   });
 
   const firstHeading = tree.children.find((node) => node.type === 'heading');
@@ -714,5 +665,8 @@ export async function renderMarkdown(
   });
 
   const hast = await documentTreeProcessor.run(tree);
-  return { tree: toViewDocumentTree(hast), title };
+  return {
+    tree: decorateExternalSiteLinks(toViewDocumentTree(hast)),
+    title,
+  };
 }

--- a/src/view/repository.ts
+++ b/src/view/repository.ts
@@ -22,7 +22,6 @@ import {
 import {
   addExternalDocumentAliasAnchors,
   externalDocumentSections,
-  renderExternalDocument,
 } from '../external-documents.js';
 import {
   resolveSourceSymbol,
@@ -31,9 +30,10 @@ import {
 } from '../source-parser.js';
 import { isSourceFileExtension } from '../source-formats.js';
 import { toPosix } from '../walk.js';
+import { renderExternalDocumentTree } from './external-document-tree.js';
 import type { ViewExternalDocument, ViewSourceDocument } from './protocol.js';
 import { highlightSource } from './highlight.js';
-import { externalHtmlToDocumentTree, renderMarkdown } from './markdown.js';
+import { renderMarkdown } from './markdown.js';
 import {
   renderExternalSectionBackReferences,
   renderExternalSourceReferences,
@@ -233,11 +233,9 @@ export async function getViewExternal(
           )
         : {
             title: analysis.title,
-            tree: externalHtmlToDocumentTree(
-              await renderExternalDocument(
-                analysis.format,
-                resolved.fullContent,
-              ),
+            tree: await renderExternalDocumentTree(
+              analysis.format,
+              resolved.fullContent,
             ),
           };
     const fragmentIndex = resolved.target.identity.indexOf('#');

--- a/src/view/repository.ts
+++ b/src/view/repository.ts
@@ -4,6 +4,7 @@ import {
   extname,
   isAbsolute,
   join,
+  posix,
   relative,
   resolve,
   sep,
@@ -23,6 +24,7 @@ import {
   addExternalDocumentAliasAnchors,
   externalDocumentSections,
 } from '../external-documents.js';
+import type { ExternalTarget } from '../external-sources.js';
 import {
   resolveSourceSymbol,
   SourceParserRuntime,
@@ -31,6 +33,7 @@ import {
 import { isSourceFileExtension } from '../source-formats.js';
 import { toPosix } from '../walk.js';
 import { renderExternalDocumentTree } from './external-document-tree.js';
+import { visitDocumentElements } from './document-tree.js';
 import type { ViewExternalDocument, ViewSourceDocument } from './protocol.js';
 import { highlightSource } from './highlight.js';
 import { renderMarkdown } from './markdown.js';
@@ -85,6 +88,145 @@ export function externalUrl(target: string): string {
   const fragment = hash === -1 ? '' : target.slice(hash + 1);
   const encodedPath = path.split('/').map(encodeURIComponent).join('/');
   return `/external/${encodeURIComponent(handle)}/${encodedPath}${fragment ? `#${encodeURIComponent(fragment)}` : ''}`;
+}
+
+function baseExternalTarget(identity: string): string {
+  const hash = identity.indexOf('#');
+  return hash === -1 ? identity : identity.slice(0, hash);
+}
+
+function externalFileKey(handle: string, path: string): string {
+  return `${handle}\0${path}`;
+}
+
+function availableExternalFiles(
+  external: ExternalResolver,
+  referenceIndex: ViewReferenceIndex,
+  current: ExternalTarget,
+): Map<string, string> {
+  const files = new Map<string, string>();
+  for (const target of referenceIndex.externalByTarget.keys()) {
+    try {
+      const parsed = external.parse(target);
+      if (!parsed) continue;
+      files.set(
+        externalFileKey(parsed.handle, parsed.resolvedPath),
+        baseExternalTarget(parsed.identity),
+      );
+    } catch {
+      // Invalid external references remain diagnostics and are not navigable.
+    }
+  }
+  files.set(
+    externalFileKey(current.handle, current.resolvedPath),
+    baseExternalTarget(current.identity),
+  );
+  return files;
+}
+
+function externalDocumentLink(
+  href: string,
+  current: ExternalTarget,
+  external: ExternalResolver,
+  available: ReadonlyMap<string, string>,
+): string | null | undefined {
+  if (
+    href.startsWith('#') ||
+    href.startsWith('?') ||
+    href.startsWith('//') ||
+    /^[a-z][a-z\d+.-]*:/i.test(href) ||
+    /^\/(?:code|docs|external)(?:\/|$)/.test(href)
+  ) {
+    return undefined;
+  }
+
+  let destination: URL;
+  try {
+    const encodedPath = current.resolvedPath
+      .split('/')
+      .map(encodeURIComponent)
+      .join('/');
+    destination = new URL(href, `http://lat.external/${encodedPath}`);
+  } catch {
+    return null;
+  }
+  if (destination.origin !== 'http://lat.external') return undefined;
+
+  let path: string;
+  let fragment: string;
+  try {
+    path = destination.pathname
+      .slice(1)
+      .split('/')
+      .map(decodeURIComponent)
+      .join('/');
+    fragment = decodeURIComponent(destination.hash.slice(1));
+  } catch {
+    return null;
+  }
+  path = posix.normalize(path);
+  if (!path || path === '.' || path === '..' || path.startsWith('../')) {
+    return null;
+  }
+
+  let parsed: ExternalTarget | null;
+  try {
+    parsed = external.parse(
+      `${current.handle}:${path}${fragment ? `#${fragment}` : ''}`,
+    );
+  } catch {
+    return null;
+  }
+  if (!parsed) return null;
+  const availableTarget = available.get(
+    externalFileKey(parsed.handle, parsed.resolvedPath),
+  );
+  if (!availableTarget) return null;
+
+  const route = externalUrl(
+    `${availableTarget}${fragment ? `#${fragment}` : ''}`,
+  );
+  if (!destination.search) return route;
+  const hash = route.indexOf('#');
+  return hash === -1
+    ? `${route}${destination.search}`
+    : `${route.slice(0, hash)}${destination.search}${route.slice(hash)}`;
+}
+
+/** Make repository-relative external-document links reflect pulled files. */
+export function resolveExternalDocumentLinks(
+  tree: Awaited<ReturnType<typeof renderExternalDocumentTree>>,
+  current: ExternalTarget,
+  external: ExternalResolver,
+  referenceIndex: ViewReferenceIndex,
+): typeof tree {
+  const available = availableExternalFiles(external, referenceIndex, current);
+  visitDocumentElements(tree, (element) => {
+    if (element.tagName !== 'a') return;
+    const href = element.properties.href;
+    if (typeof href !== 'string') return;
+    const resolved = externalDocumentLink(href, current, external, available);
+    if (resolved === undefined) return;
+    if (resolved !== null) {
+      element.properties.href = resolved;
+      return;
+    }
+
+    const currentClasses = element.properties.className;
+    const classes = Array.isArray(currentClasses)
+      ? currentClasses.map(String)
+      : typeof currentClasses === 'string'
+        ? currentClasses.split(/\s+/).filter(Boolean)
+        : [];
+    element.tagName = 'span';
+    element.properties = {
+      ...element.properties,
+      className: [...classes, 'external-source-link-unavailable'],
+      title: 'Linked file is not included in this Lat project',
+    };
+    delete element.properties.href;
+  });
+  return tree;
 }
 
 function matchingSymbol(
@@ -238,6 +380,12 @@ export async function getViewExternal(
               resolved.fullContent,
             ),
           };
+    resolveExternalDocumentLinks(
+      rendered.tree,
+      resolved.target,
+      external,
+      referenceIndex,
+    );
     const fragmentIndex = resolved.target.identity.indexOf('#');
     const baseTarget =
       fragmentIndex === -1

--- a/tests/external-documents.test.ts
+++ b/tests/external-documents.test.ts
@@ -9,9 +9,8 @@ import {
   analyzeExternalDocumentCached,
   externalDocumentAnalysisCachePath,
   findExternalDocumentSection,
-  renderExternalDocument,
 } from '../src/external-documents.js';
-import { externalHtmlToDocumentTree } from '../src/view/markdown.js';
+import { renderExternalDocumentTree } from '../src/view/external-document-tree.js';
 import { documentTreeToHtml } from './document-tree.js';
 import { PARSER_CACHE_VERSION } from '../src/parser-cache.js';
 import { rmDirBestEffort } from './util.js';
@@ -169,16 +168,12 @@ describe('external document formats', () => {
 
     const rstHtml = documentTreeToHtml(
       addExternalDocumentAliasAnchors(
-        externalHtmlToDocumentTree(
-          await renderExternalDocument('restructuredtext', rst),
-        ),
+        await renderExternalDocumentTree('restructuredtext', rst),
         rstAnalysis,
       ),
     );
     const asciidocHtml = documentTreeToHtml(
-      externalHtmlToDocumentTree(
-        await renderExternalDocument('asciidoc', asciidoc),
-      ),
+      await renderExternalDocumentTree('asciidoc', asciidoc),
     );
     expect(rstHtml).toContain('<h2 id="installation">');
     expect(rstHtml).toContain('<span id="install" aria-hidden="true"></span>');
@@ -187,14 +182,114 @@ describe('external document formats', () => {
     expect(asciidocHtml).toContain('<h2 id="install">Installation</h2>');
     expect(asciidocHtml).toContain('Nested details.');
     expect(asciidocHtml).toContain('<h2 id="Late_Section">Late Section</h2>');
+  });
 
-    const unsafe = documentTreeToHtml(
-      externalHtmlToDocumentTree(
-        '<h1 id="safe">Safe</h1><script>alert(1)</script>',
-      ),
+  // @lat: [[tests/external-tests#External Sources#Document formats#Native document tree projection]]
+  it('reflects native external-document ASTs without an HTML round trip', async () => {
+    const rst = [
+      'Guide',
+      '=====',
+      '',
+      'Use *emphasis*, **strength**, ``code``, `a link <https://example.com>`_, and named_.',
+      '',
+      '- first',
+      '- second',
+      '',
+      '.. note:: Structured warning.',
+      '',
+      '.. code-block:: python',
+      '',
+      '   enabled = True',
+      '',
+      'Plain literal::',
+      '',
+      '   command --without-language',
+      '',
+      '.. raw:: html',
+      '',
+      '   <script>alert("rst")</script>',
+      '',
+      '.. _named: https://example.org',
+    ].join('\n');
+    const asciidoc = [
+      '= Guide',
+      '',
+      ':source-language: ruby',
+      '',
+      'Use _emphasis_, *strength*, `code`, https://example.com[a link], <<target,jump>>, and link:javascript:alert(1)[bad].',
+      '',
+      'image:https://example.com/image.png[Example]',
+      '',
+      '* first',
+      '* second',
+      '',
+      'NOTE: Structured warning.',
+      '',
+      '[source]',
+      '----',
+      'puts "hello"',
+      '----',
+      '',
+      ' command --without-language',
+      '',
+      '[[target]]',
+      '== Target',
+      '',
+      '|===',
+      '|A |B',
+      '|C |D',
+      '|===',
+      '',
+      '++++',
+      '<script>alert("asciidoc")</script>',
+      '++++',
+    ].join('\n');
+
+    const rstTree = await renderExternalDocumentTree('restructuredtext', rst);
+    const asciidocTree = await renderExternalDocumentTree('asciidoc', asciidoc);
+    const rstHtml = documentTreeToHtml(rstTree);
+    const asciidocHtml = documentTreeToHtml(asciidocTree);
+
+    expect(rstTree).toMatchObject({ version: 1, type: 'root' });
+    expect(asciidocTree).toMatchObject({ version: 1, type: 'root' });
+    expect(rstHtml).toContain('<em>emphasis</em>');
+    expect(rstHtml).toContain('<strong>strength</strong>');
+    expect(rstHtml).toContain('<code>code</code>');
+    expect(rstHtml).toContain('<ul><li><p>first</p></li>');
+    expect(rstHtml).toContain(
+      'href="https://example.com" class="external-link"',
     );
-    expect(unsafe).toContain('<h1 id="safe">Safe</h1>');
-    expect(unsafe).not.toContain('<script');
+    expect(rstHtml).toContain(
+      'href="https://example.org" class="external-link"',
+    );
+    expect(rstHtml.match(/class="external-link-icon"/g)).toHaveLength(2);
+    expect(rstHtml).toContain('class="language-python hljs"');
+    expect(rstHtml).toContain('command --without-language');
+    expect(rstHtml).not.toContain('language-command');
+    expect(rstHtml).toContain('&#x3C;script>alert("rst")&#x3C;/script>');
+    expect(rstHtml).not.toContain('<script');
+
+    expect(asciidocHtml).toContain('<em>emphasis</em>');
+    expect(asciidocHtml).toContain('<strong>strength</strong>');
+    expect(asciidocHtml).toContain('<code>code</code>');
+    expect(asciidocHtml).toContain('<ul><li>first</li><li>second</li></ul>');
+    expect(asciidocHtml).toContain('<table>');
+    expect(asciidocHtml).toContain(
+      'href="https://example.com" class="external-link"',
+    );
+    expect(asciidocHtml.match(/class="external-link-icon"/g)).toHaveLength(1);
+    expect(asciidocHtml).toContain('href="#target"');
+    expect(asciidocHtml).toContain('class="language-ruby hljs"');
+    expect(asciidocHtml).toContain('command --without-language');
+    expect(asciidocHtml).not.toContain('language-command');
+    expect(asciidocHtml).toContain(
+      '<img src="https://example.com/image.png" alt="Example">',
+    );
+    expect(asciidocHtml).not.toContain('href="javascript:');
+    expect(asciidocHtml).toContain(
+      '&#x3C;script>alert("asciidoc")&#x3C;/script>',
+    );
+    expect(asciidocHtml).not.toContain('<script');
   });
 
   // @lat: [[tests/external-tests#External Sources#Persistent document analysis cache]]

--- a/tests/external-sources/core.test.ts
+++ b/tests/external-sources/core.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -445,6 +445,7 @@ describe.sequential('external source core', () => {
       strategy: 'fetch',
       commit: fixture.commit1,
     });
+
     projects.push(project.root);
     const target = 'upstream:guide.md#Navigation';
     await (
@@ -585,4 +586,36 @@ describe.sequential('external source core', () => {
     expect(existsSync(paths.directory)).toBe(false);
     expect(existsSync(paths.metadata)).toBe(false);
   }, 30_000);
+
+  // @lat: [[tests/external-tests#External Sources#Cache reconciliation#Interrupted owner recovery]]
+  it('reclaims an external cache lock after its owner exits', async () => {
+    const project = createExternalProject(fixture, {
+      strategy: 'fetch',
+      commit: fixture.commit1,
+    });
+    projects.push(project.root);
+    const paths = externalCachePaths(project.latDir, 'upstream');
+    const lockPath = `${paths.metadata}.lock`;
+    const exited = spawnSync(process.execPath, ['-e', '']);
+    expect(exited.status).toBe(0);
+    expect(exited.pid).toBeTypeOf('number');
+    mkdirSync(lockPath, { recursive: true });
+    writeFileSync(
+      join(lockPath, 'owner.json'),
+      `${JSON.stringify({
+        owner: 'interrupted-test-owner',
+        pid: exited.pid,
+        startedAt: Date.now(),
+      })}\n`,
+    );
+
+    const resolved = await (
+      await createExternalResolver(project.latDir, project.root, {
+        ca: fixture.ca,
+      })
+    ).resolve('upstream:guide.md#Navigation');
+
+    expect(resolved.content).toContain('First version navigation.');
+    expect(existsSync(lockPath)).toBe(false);
+  });
 });

--- a/tests/external-sources/support.ts
+++ b/tests/external-sources/support.ts
@@ -79,15 +79,27 @@ export async function createExternalGitFixture(): Promise<ExternalGitFixture> {
   mkdirSync(join(checkout, 'docs'), { recursive: true });
   writeFileSync(
     join(checkout, 'docs', 'guide.md'),
-    '# Guide\n\nPinned guide.\n\n## Navigation\n\nFirst version navigation.\n',
+    '# Guide\n\nPinned guide.\n\n## Navigation\n\nFirst version navigation.\n\nRead the [available reStructuredText guide](guide.rst#navigation) and the [omitted appendix](appendix.md).\n',
   );
   writeFileSync(
     join(checkout, 'docs', 'guide.rst'),
-    'Guide\n=====\n\nPinned guide.\n\n.. _navigation:\n\nNavigation\n----------\n\nFirst version reStructuredText navigation.\n',
+    'Guide\n=====\n\nPinned guide.\n\n.. _navigation:\n\nNavigation\n----------\n\nFirst version reStructuredText navigation.\n\nRead the `available AsciiDoc guide <guide.adoc#navigation>`_, the `omitted appendix <appendix.rst>`_, and the `translation’s repository <TRANSLATION_REPO_>`_.\n',
   );
   writeFileSync(
     join(checkout, 'docs', 'guide.adoc'),
-    '= Guide\n\nPinned guide.\n\n[#navigation]\n== Navigation\n\nFirst version AsciiDoc navigation.\n',
+    '= Guide\n\nPinned guide.\n\n[#navigation]\n== Navigation\n\nFirst version AsciiDoc navigation.\n\nRead the link:guide.md#navigation[available Markdown guide] and the link:appendix.adoc[omitted appendix].\n',
+  );
+  writeFileSync(
+    join(checkout, 'docs', 'appendix.md'),
+    '# Appendix\n\nThis file exists upstream but is not referenced by the Lat project.\n',
+  );
+  writeFileSync(
+    join(checkout, 'docs', 'appendix.rst'),
+    'Appendix\n========\n\nThis file exists upstream but is not referenced by the Lat project.\n',
+  );
+  writeFileSync(
+    join(checkout, 'docs', 'appendix.adoc'),
+    '= Appendix\n\nThis file exists upstream but is not referenced by the Lat project.\n',
   );
   writeFileSync(
     join(checkout, 'docs', 'widget.ts'),
@@ -98,15 +110,15 @@ export async function createExternalGitFixture(): Promise<ExternalGitFixture> {
   const commit1 = await git(['rev-parse', 'HEAD'], checkout);
   writeFileSync(
     join(checkout, 'docs', 'guide.md'),
-    '# Guide\n\nPinned guide.\n\n## Navigation\n\nSecond version navigation.\n',
+    '# Guide\n\nPinned guide.\n\n## Navigation\n\nSecond version navigation.\n\nRead the [available reStructuredText guide](guide.rst#navigation) and the [omitted appendix](appendix.md).\n',
   );
   writeFileSync(
     join(checkout, 'docs', 'guide.rst'),
-    'Guide\n=====\n\nPinned guide.\n\n.. _navigation:\n\nNavigation\n----------\n\nSecond version reStructuredText navigation.\n',
+    'Guide\n=====\n\nPinned guide.\n\n.. _navigation:\n\nNavigation\n----------\n\nSecond version reStructuredText navigation.\n\nRead the `available AsciiDoc guide <guide.adoc#navigation>`_, the `omitted appendix <appendix.rst>`_, and the `translation’s repository <TRANSLATION_REPO_>`_.\n',
   );
   writeFileSync(
     join(checkout, 'docs', 'guide.adoc'),
-    '= Guide\n\nPinned guide.\n\n[#navigation]\n== Navigation\n\nSecond version AsciiDoc navigation.\n',
+    '= Guide\n\nPinned guide.\n\n[#navigation]\n== Navigation\n\nSecond version AsciiDoc navigation.\n\nRead the link:guide.md#navigation[available Markdown guide] and the link:appendix.adoc[omitted appendix].\n',
   );
   writeFileSync(
     join(checkout, 'docs', 'widget.ts'),

--- a/tests/external-sources/view.test.ts
+++ b/tests/external-sources/view.test.ts
@@ -148,6 +148,15 @@ describe.sequential('external source view', () => {
         expect(html(externalDocument.document)).toContain(
           'Second version navigation.',
         );
+        expect(html(externalDocument.document)).toContain(
+          'href="/external/upstream/guide.rst#navigation"',
+        );
+        expect(html(externalDocument.document)).toContain(
+          '<span class="external-source-link-unavailable" title="Linked file is not included in this Lat project">omitted appendix</span>',
+        );
+        expect(html(externalDocument.document)).not.toContain(
+          'href="appendix.md"',
+        );
         expect(externalDocument.document.backReferences).toHaveLength(2);
         expect(
           externalDocument.document.backReferences.find(
@@ -171,7 +180,19 @@ describe.sequential('external source view', () => {
         );
         expect(externalDocument.kind).toBe('markdown');
         if (externalDocument.kind === 'markdown') {
-          expect(html(externalDocument.document)).toContain(text);
+          const rendered = html(externalDocument.document);
+          expect(rendered).toContain(text);
+          expect(rendered).toContain('external-source-link-unavailable');
+          expect(rendered).not.toMatch(/href="appendix\.(?:rst|adoc)"/);
+          if (target.includes('.rst')) {
+            expect(rendered).toContain(
+              '<span class="external-source-link-unavailable" title="Linked file is not included in this Lat project">translation’s repository</span>',
+            );
+            expect(rendered).not.toContain('href="TRANSLATION_REPO_"');
+          }
+          expect(rendered).toMatch(
+            /href="\/external\/upstream\/guide(?:\.adoc)?#navigation"/,
+          );
           expect(externalDocument.document.tableOfContents).toContainEqual(
             expect.objectContaining({ id: 'navigation', title: 'Navigation' }),
           );
@@ -338,6 +359,13 @@ describe.sequential('external source view', () => {
       'upstream:widget.ts#gadget',
       'upstream:widget.ts#widget',
     ]);
+    expect(Object.keys(manifest.externals)).not.toEqual(
+      expect.arrayContaining([
+        'upstream:appendix.md',
+        'upstream:appendix.rst',
+        'upstream:appendix.adoc',
+      ]),
+    );
     expect(manifest.index.externalFiles).toEqual([
       {
         handle: 'upstream',
@@ -382,8 +410,11 @@ describe.sequential('external source view', () => {
       ) as ViewExternalDocument;
       expect(payload.kind).toBe('markdown');
       if (payload.kind === 'markdown') {
-        expect(html(payload.document)).toContain('First version navigation.');
-        expect(html(payload.document)).not.toContain('Live dirty navigation.');
+        const rendered = html(payload.document);
+        expect(rendered).toContain('First version navigation.');
+        expect(rendered).not.toContain('Live dirty navigation.');
+        expect(rendered).toContain('external-source-link-unavailable');
+        expect(rendered).not.toContain('href="appendix.md"');
       }
     }
     for (const [target, text] of [
@@ -398,8 +429,11 @@ describe.sequential('external source view', () => {
         ) as ViewExternalDocument;
         expect(payload.kind).toBe('markdown');
         if (payload.kind === 'markdown') {
-          expect(html(payload.document)).toContain(text);
-          expect(html(payload.document)).not.toContain('Second version');
+          const rendered = html(payload.document);
+          expect(rendered).toContain(text);
+          expect(rendered).not.toContain('Second version');
+          expect(rendered).toContain('external-source-link-unavailable');
+          expect(rendered).not.toMatch(/href="appendix\.(?:rst|adoc)"/);
         }
       }
     }

--- a/tests/highlight.test.ts
+++ b/tests/highlight.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { toViewDocumentTree } from '../src/view/document-tree.js';
 import { highlightCode, highlightSource } from '../src/view/highlight.js';
 import type {
   ViewDocumentNode,
@@ -63,5 +64,9 @@ describe('source highlighting', () => {
       },
     ]);
     expect(highlightCode('unknown-language', '<safe>')).toBeNull();
+
+    const ruby = highlightCode('ruby', 'puts "hello"');
+    expect(ruby).not.toBeNull();
+    expect(treeClasses(toViewDocumentTree(ruby!))).toContain('hljs-string');
   });
 });

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -1015,6 +1015,7 @@ describe('lat ui', () => {
       'utf8',
     );
     expect(styles).toContain('.external-link-icon');
+    expect(styles).toContain('.external-source-link-unavailable');
     expect(styles).toContain('-webkit-mask:');
     expect(styles.match(/\.markdown a\s*\{([^}]*)\}/)?.[1]).toContain(
       'text-decoration-line: underline;',

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -1688,6 +1688,15 @@ a.wiki-link-code:not(.wiki-link-segmented) .code-link-leading {
     center / contain no-repeat;
 }
 
+.external-source-link-unavailable {
+  color: var(--muted);
+  text-decoration-line: underline;
+  text-decoration-style: dashed;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  cursor: not-allowed;
+}
+
 .code-link-language {
   display: inline-flex;
   width: 1.55em;


### PR DESCRIPTION
## Summary

- parse reStructuredText and AsciiDoc into the shared structured render tree and render them through React alongside Markdown
- preserve external-link treatment and source highlighting, while marking relative document links unavailable when their targets were not pulled into the Lat project
- recover dead external-source cache locks promptly without discarding cached content

## Validation

- `pnpm buildall`
- `pnpm test` — 269 tests passed
- `lat check`