### PR TITLE
Add Java source support

### DIFF
--- a/lat.md/architecture-analysis.md
+++ b/lat.md/architecture-analysis.md
@@ -22,7 +22,7 @@ Each resolver loads provider content and analyzes a complete external file once 
 
 ## Source analysis
 
-A source analysis is the serializable symbol table extracted from one supported JavaScript, TypeScript, Python, Dart, Rust, Go, or C file.
+A source analysis is the serializable symbol table extracted from one supported JavaScript, TypeScript, Python, Dart, Java, Rust, Go, or C file.
 
 It records symbol names, kinds, parents, source ranges, and signatures. Tree-sitter syntax trees and grammar instances remain private parser state and are never serialized.
 

--- a/lat.md/external-sources.md
+++ b/lat.md/external-sources.md
@@ -105,7 +105,7 @@ The supported fields are:
 - `repo` — required canonical HTTPS Git repository URL.
 - `commit` — required immutable full commit SHA.
 - `prefix` — optional `/`-separated POSIX directory prepended to every authored external path; Windows path syntax is not accepted.
-- `default-file-extension` — optional extension appended when an authored path has none. Values omit the leading dot and are limited to `md`, `rst`, `adoc`, `asciidoc`, `ts`, `tsx`, `js`, `jsx`, `py`, `dart`, `rs`, `go`, `c`, or `h`.
+- `default-file-extension` — optional extension appended when an authored path has none. Values omit the leading dot and are limited to `md`, `rst`, `adoc`, `asciidoc`, `ts`, `tsx`, `js`, `jsx`, `py`, `dart`, `java`, `rs`, `go`, `c`, or `h`.
 - `strategy` — required retrieval strategy, either `fetch` or `checkout`.
 - `fetch-url` — optional raw-file HTTP URL template for the `fetch` strategy.
 

--- a/lat.md/markdown.md
+++ b/lat.md/markdown.md
@@ -102,22 +102,25 @@ Resolution is handled by [[src/lattice-model.ts#resolveRef]]. See [[parser#Short
 
 ### Source Code Links
 
-Wiki links can reference symbols in TypeScript, JavaScript, Python, Dart, Rust, Go, and C source files:
+Wiki links can reference symbols in TypeScript, JavaScript, Python, Dart, Java, Rust, Go, and C source files:
 
 - **`[[src/config.ts#getConfigDir]]`** — the `getConfigDir` function in `src/config.ts`
 - **`[[src/server.ts#App#listen]]`** — the `listen` method on class `App` in `src/server.ts`
 - **`[[lib/service.dart#Greeter#greet]]`** — the `greet` method on class `Greeter` in Dart
+- **`[[src/Greeter.java#Greeter#greet]]`** — the `greet` method on class `Greeter` in Java
 - **`[[src/lib.rs#Greeter#greet]]`** — the `greet` method on struct `Greeter` in Rust
 - **`[[src/app.go#Greeter#Greet]]`** — the `Greet` method on type `Greeter` in Go
 - **`[[src/app.h#Greeter]]`** — the `Greeter` struct in a C header
 - **`[[src/app.h#Greeter#prefix]]`** — the `prefix` field of struct `Greeter` in C
 - **`[[src/config.ts]]`** — link to the file itself (no symbol)
 
-Supported extensions: `.c`, `.dart`, `.go`, `.h`, `.js`, `.jsx`, `.py`, `.rs`, `.ts`, `.tsx`. The typed [[src/source-formats.ts#SOURCE_FILE_EXTENSIONS]] registry governs source-link parsing, external source validation, and `@lat:` code-mention scanning.
+Supported extensions: `.c`, `.dart`, `.go`, `.h`, `.java`, `.js`, `.jsx`, `.py`, `.rs`, `.ts`, `.tsx`. The typed [[src/source-formats.ts#SOURCE_FILE_EXTENSIONS]] registry governs source-link parsing, external source validation, and `@lat:` code-mention scanning.
 
 Python symbols: functions, classes, methods, module-level variables. Decorated definitions (`@decorator`) are unwrapped transparently — `[[file.py#my_func]]` resolves whether or not `my_func` has decorators, and `# @lat:` comments placed between decorators and the `def`/`class` line are scanned normally.
 
 Dart symbols: functions, getters, setters, classes, constructors, fields, mixins, named extensions, enums and values, extension types, type aliases, and top-level variables. Nested members use `[[file.dart#Type#member]]`; named constructors use their suffix (`#Type#named`), while unnamed constructors use the class name (`#Type#Type`). Operators retain Dart spelling, such as `[[file.dart#Greeter#operator ==]]`. Annotations are included in definition ranges, and `// @lat:` comments are scanned like other C-style source comments.
+
+Java symbols: classes, interfaces, enums, records, annotation types, constructors, methods, fields, constants, enum values, record components, and annotation elements. Nested types resolve standalone and as `[[file.java#Outer#Inner]]`; their members use the standalone type, such as `[[file.java#Inner#method]]`, because source paths support two symbol levels. Ordinary and compact constructors use the enclosing type name. Annotations are included in source ranges, and overloads resolve by name like other languages.
 
 Rust symbols: functions, structs, enums, traits, impl methods, consts, statics, type aliases. Methods are resolved via `impl` blocks — `[[file.rs#Type#method]]` matches any `impl Type { fn method() }` or `impl Trait for Type { fn method() }`.
 

--- a/lat.md/tests/check-md.md
+++ b/lat.md/tests/check-md.md
@@ -30,3 +30,7 @@ Given links to Dart declarations and nested members, [[cli#check#md]] resolves f
 ### Accepts Dart dot shorthand
 
 The bundled Dart grammar parses Dart 3.7 dot shorthand such as `.red` without syntax errors while Lat resolves the containing definitions normally.
+
+### Passes with Java source symbol links
+
+Given links to Java types and members, [[cli#check#md]] resolves classes, interfaces, enums, records, annotation types, nested types, fields, constants, methods, record components, and ordinary or compact constructors with complete source ranges.

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -195,7 +195,7 @@ Focused source views place reference context before the highlighted definition, 
 
 ## Highlights source syntax safely
 
-Supported languages, including Dart, become structured line trees without HTML serialization. HTML-like source remains inert text and multiline tokens retain their styling across every line.
+Supported languages, including Dart and Java, become structured line trees without HTML serialization. HTML-like source remains inert text and multiline tokens retain their styling across every line.
 
 ## Builds a nested file tree
 

--- a/src/source-formats.ts
+++ b/src/source-formats.ts
@@ -6,6 +6,7 @@ export const SOURCE_FILE_EXTENSIONS = [
   '.dart',
   '.go',
   '.h',
+  '.java',
   '.js',
   '.jsx',
   '.py',

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -99,6 +99,7 @@ const grammarMap = {
   '.dart': 'tree-sitter-dart.wasm',
   '.go': 'tree-sitter-go.wasm',
   '.h': 'tree-sitter-c.wasm',
+  '.java': 'tree-sitter-java.wasm',
   '.js': 'tree-sitter-javascript.wasm',
   '.jsx': 'tree-sitter-javascript.wasm',
   '.py': 'tree-sitter-python.wasm',
@@ -623,6 +624,134 @@ function extractDartSymbols(tree: Tree): SourceSymbol[] {
     }
   }
 
+  return symbols;
+}
+
+const javaTypeKinds: Record<string, SourceSymbol['kind']> = {
+  annotation_type_declaration: 'interface',
+  class_declaration: 'class',
+  enum_declaration: 'class',
+  interface_declaration: 'interface',
+  record_declaration: 'class',
+};
+
+function javaSignature(
+  sourceLines: readonly string[],
+  node: SyntaxNode,
+): string {
+  const declarator = node.namedChildren.find(
+    (child) => child.type === 'variable_declarator',
+  );
+  const name =
+    node.childForFieldName('name') ?? declarator?.childForFieldName('name');
+  return sourceLines[(name ?? node).startPosition.row]?.trim() ?? '';
+}
+
+function pushJavaSymbol(
+  sourceLines: readonly string[],
+  symbols: SourceSymbol[],
+  name: string,
+  kind: SourceSymbol['kind'],
+  node: SyntaxNode,
+  parent?: string,
+): SourceSymbol {
+  const symbol: SourceSymbol = {
+    name,
+    kind,
+    ...(parent ? { parent } : {}),
+    startLine: node.startPosition.row + 1,
+    endLine: node.endPosition.row + 1,
+    signature: javaSignature(sourceLines, node),
+  };
+  symbols.push(symbol);
+  return symbol;
+}
+
+function extractJavaVariables(
+  sourceLines: readonly string[],
+  symbols: SourceSymbol[],
+  node: SyntaxNode,
+  parent: string,
+): void {
+  const kind = node.type === 'constant_declaration' ? 'const' : 'variable';
+  for (const declarator of node.namedChildren) {
+    if (declarator.type !== 'variable_declarator') continue;
+    const name = extractName(declarator);
+    if (name) {
+      pushJavaSymbol(sourceLines, symbols, name, kind, node, parent);
+    }
+  }
+}
+
+function collectJavaScope(
+  sourceLines: readonly string[],
+  scope: SyntaxNode,
+  parent: string | undefined,
+  symbols: SourceSymbol[],
+): void {
+  for (const node of scope.namedChildren) {
+    const typeKind = javaTypeKinds[node.type];
+    if (typeKind) {
+      const name = extractName(node);
+      if (!name) continue;
+
+      const symbol = pushJavaSymbol(sourceLines, symbols, name, typeKind, node);
+      if (parent) symbols.push({ ...symbol, parent });
+
+      if (node.type === 'record_declaration') {
+        const parameters = node.childForFieldName('parameters');
+        for (const parameter of parameters?.namedChildren ?? []) {
+          const component = extractName(parameter);
+          if (component) {
+            pushJavaSymbol(
+              sourceLines,
+              symbols,
+              component,
+              'variable',
+              parameter,
+              name,
+            );
+          }
+        }
+      }
+
+      const body = node.childForFieldName('body');
+      if (body) collectJavaScope(sourceLines, body, name, symbols);
+      continue;
+    }
+
+    if (!parent) continue;
+
+    if (
+      node.type === 'method_declaration' ||
+      node.type === 'constructor_declaration' ||
+      node.type === 'compact_constructor_declaration' ||
+      node.type === 'annotation_type_element_declaration'
+    ) {
+      const name = extractName(node);
+      if (name) {
+        pushJavaSymbol(sourceLines, symbols, name, 'method', node, parent);
+      }
+    } else if (
+      node.type === 'field_declaration' ||
+      node.type === 'constant_declaration'
+    ) {
+      extractJavaVariables(sourceLines, symbols, node, parent);
+    } else if (node.type === 'enum_constant') {
+      const name = extractName(node);
+      if (name) {
+        pushJavaSymbol(sourceLines, symbols, name, 'const', node, parent);
+      }
+    } else if (node.type === 'enum_body_declarations') {
+      collectJavaScope(sourceLines, node, parent, symbols);
+    }
+  }
+}
+
+function extractJavaSymbols(tree: Tree): SourceSymbol[] {
+  const symbols: SourceSymbol[] = [];
+  const sourceLines = tree.rootNode.text.split('\n');
+  collectJavaScope(sourceLines, tree.rootNode, undefined, symbols);
   return symbols;
 }
 
@@ -1168,6 +1297,7 @@ const symbolExtractors = {
   '.dart': extractDartSymbols,
   '.go': extractGoSymbols,
   '.h': extractCSymbols,
+  '.java': extractJavaSymbols,
   '.js': extractTsSymbols,
   '.jsx': extractTsSymbols,
   '.py': extractPySymbols,

--- a/src/view/highlight.ts
+++ b/src/view/highlight.ts
@@ -7,6 +7,7 @@ import css from 'highlight.js/lib/languages/css';
 import dart from 'highlight.js/lib/languages/dart';
 import diff from 'highlight.js/lib/languages/diff';
 import go from 'highlight.js/lib/languages/go';
+import java from 'highlight.js/lib/languages/java';
 import javascript from 'highlight.js/lib/languages/javascript';
 import json from 'highlight.js/lib/languages/json';
 import markdown from 'highlight.js/lib/languages/markdown';
@@ -26,6 +27,7 @@ const lowlight = createLowlight({
   dart,
   diff,
   go,
+  java,
   javascript,
   json,
   markdown,
@@ -46,6 +48,7 @@ const languageAliases: Record<string, string> = {
   go: 'go',
   h: 'c',
   html: 'xml',
+  java: 'java',
   js: 'javascript',
   javascript: 'javascript',
   json: 'json',
@@ -74,6 +77,7 @@ const languageByExtension: Record<string, string> = {
   '.dart': 'dart',
   '.go': 'go',
   '.h': 'c',
+  '.java': 'java',
   '.js': 'javascript',
   '.jsx': 'javascript',
   '.py': 'python',

--- a/src/view/markdown.ts
+++ b/src/view/markdown.ts
@@ -64,6 +64,7 @@ const CODE_LINK_CLASSES = [
   'code-language-go',
   'code-language-c',
   'code-language-dart',
+  'code-language-java',
 ];
 
 const ERROR_CLASS = 'markdown-error';
@@ -404,6 +405,8 @@ function codeLanguage(target: string): {
       return { className: 'code-language-c', label: 'C' };
     case '.dart':
       return { className: 'code-language-dart', label: 'DART' };
+    case '.java':
+      return { className: 'code-language-java', label: 'JAVA' };
     default:
       return null;
   }

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -1308,6 +1308,14 @@ describe('source-ref-dart-valid', () => {
   });
 });
 
+describe('source-ref-java-valid', () => {
+  // @lat: [[tests/check-md#Passes with valid links#Passes with Java source symbol links]]
+  it('resolves Java types and nested members without errors', async () => {
+    const { errors } = await checkMd(latDir('source-ref-java-valid'));
+    expect(errors).toHaveLength(0);
+  });
+});
+
 describe('error-source-ref-rs-missing', () => {
   it('check md reports all missing Rust symbols', async () => {
     const { errors } = await checkMd(latDir('error-source-ref-rs-missing'));
@@ -1379,6 +1387,27 @@ describe('error-source-ref-dart-missing', () => {
     );
     expect(
       byTarget.get('src/app.dart#Greeter#missingMethod')?.message,
+    ).toContain('symbol "Greeter#missingMethod" not found');
+  });
+});
+
+describe('error-source-ref-java-missing', () => {
+  it('check md reports all missing Java symbols', async () => {
+    const { errors } = await checkMd(latDir('error-source-ref-java-missing'));
+    expect(errors).toHaveLength(4);
+
+    const byTarget = new Map(errors.map((error) => [error.target, error]));
+    expect(byTarget.get('src/Greeter.java#nonexistent')?.message).toContain(
+      'symbol "nonexistent" not found',
+    );
+    expect(byTarget.get('src/Greeter.java#MissingClass')?.message).toContain(
+      'symbol "MissingClass" not found',
+    );
+    expect(byTarget.get('src/Greeter.java#MISSING_CONST')?.message).toContain(
+      'symbol "MISSING_CONST" not found',
+    );
+    expect(
+      byTarget.get('src/Greeter.java#Greeter#missingMethod')?.message,
     ).toContain('symbol "Greeter#missingMethod" not found');
   });
 });
@@ -1781,6 +1810,34 @@ describe('getSection', () => {
     expect(ref('src/app.dart#UserId#format')).toMatchObject({
       line: 44,
       endLine: 44,
+    });
+  });
+
+  it('Java: outgoingSourceRefs include annotated types and member ranges', async () => {
+    const ctx = testCtx('source-ref-java-valid');
+    const result = await getSection(ctx, 'lat.md/docs#Docs');
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') return;
+    const ref = (target: string) =>
+      result.outgoingSourceRefs.find(
+        (reference) => reference.target === target,
+      );
+
+    expect(ref('src/Greeter.java#Greeter')).toMatchObject({
+      line: 3,
+      endLine: 25,
+    });
+    expect(ref('src/Greeter.java#Greeter#greet')).toMatchObject({
+      line: 13,
+      endLine: 16,
+    });
+    expect(ref('src/Greeter.java#Point#Point')).toMatchObject({
+      line: 53,
+      endLine: 55,
+    });
+    expect(ref('src/Greeter.java#Marker#value')).toMatchObject({
+      line: 63,
+      endLine: 63,
     });
   });
 

--- a/tests/cases/error-source-ref-java-missing/lat.md/docs.md
+++ b/tests/cases/error-source-ref-java-missing/lat.md/docs.md
@@ -1,0 +1,11 @@
+# Docs
+
+These deliberately missing Java targets exercise source-link diagnostics.
+
+Missing method: [[src/Greeter.java#nonexistent]].
+
+Missing class: [[src/Greeter.java#MissingClass]].
+
+Missing constant: [[src/Greeter.java#MISSING_CONST]].
+
+Missing class method: [[src/Greeter.java#Greeter#missingMethod]].

--- a/tests/cases/error-source-ref-java-missing/src/Greeter.java
+++ b/tests/cases/error-source-ref-java-missing/src/Greeter.java
@@ -1,0 +1,7 @@
+package app;
+
+public class Greeter {
+  public String greet() {
+    return "hello";
+  }
+}

--- a/tests/cases/source-ref-java-valid/lat.md/docs.md
+++ b/tests/cases/source-ref-java-valid/lat.md/docs.md
@@ -1,0 +1,17 @@
+# Docs
+
+Java source links cover each supported declaration form and member relationship.
+
+Use [[src/Greeter.java#Greeter]], its [[src/Greeter.java#Greeter#Greeter]] constructor, [[src/Greeter.java#Greeter#greet]] method, and [[src/Greeter.java#Greeter#of]] factory.
+
+The class exposes [[src/Greeter.java#Greeter#DEFAULT_NAME]], [[src/Greeter.java#Greeter#name]], [[src/Greeter.java#Greeter#first]], and [[src/Greeter.java#Greeter#second]].
+
+The nested type resolves as [[src/Greeter.java#Inner]] and [[src/Greeter.java#Greeter#Inner]], while [[src/Greeter.java#Inner#innerMethod]] resolves through its standalone type.
+
+The [[src/Greeter.java#Greeting]] interface contains [[src/Greeter.java#Greeting#NAME_CONST]], [[src/Greeter.java#Greeting#hello]], and [[src/Greeter.java#Greeting#bye]].
+
+The [[src/Greeter.java#Color]] enum contains [[src/Greeter.java#Color#RED]], [[src/Greeter.java#Color#GREEN]], [[src/Greeter.java#Color#code]], [[src/Greeter.java#Color#Color]], and [[src/Greeter.java#Color#label]].
+
+The [[src/Greeter.java#Point]] record exposes [[src/Greeter.java#Point#x]], [[src/Greeter.java#Point#y]], its [[src/Greeter.java#Point#Point]] compact constructor, and [[src/Greeter.java#Point#sum]].
+
+The [[src/Greeter.java#Marker]] annotation type exposes [[src/Greeter.java#Marker#value]].

--- a/tests/cases/source-ref-java-valid/src/Greeter.java
+++ b/tests/cases/source-ref-java-valid/src/Greeter.java
@@ -1,0 +1,64 @@
+package app;
+
+@Deprecated
+public class Greeter<T> implements Greeting {
+  public static final String DEFAULT_NAME = "World";
+  private String name;
+  private int first = 1, second;
+
+  public Greeter(String name) {
+    this.name = name;
+  }
+
+  @Deprecated
+  public String greet() {
+    return "Hi, " + name;
+  }
+
+  public static Greeter of(String name) {
+    return new Greeter(name);
+  }
+
+  static class Inner {
+    void innerMethod() {}
+  }
+}
+
+interface Greeting {
+  String NAME_CONST = "greeting";
+
+  String hello();
+
+  default String bye() {
+    return "bye";
+  }
+}
+
+enum Color {
+  RED,
+  GREEN(2);
+
+  private final int code;
+
+  Color(int code) {
+    this.code = code;
+  }
+
+  String label() {
+    return name();
+  }
+}
+
+record Point(int x, int y) {
+  Point {
+    if (x < 0) throw new IllegalArgumentException();
+  }
+
+  int sum() {
+    return x + y;
+  }
+}
+
+@interface Marker {
+  String value() default "";
+}

--- a/tests/external-sources/core.test.ts
+++ b/tests/external-sources/core.test.ts
@@ -264,6 +264,17 @@ describe.sequential('external source core', () => {
     });
     expect(dartSource.content).toContain("return 'first';");
 
+    const javaSource = await fetchResolver.resolve(
+      'upstream:Widget.java#Widget#widget',
+    );
+    expect(javaSource).toMatchObject({
+      kind: 'source',
+      startLine: 2,
+      endLine: 4,
+      signature: 'String widget() {',
+    });
+    expect(javaSource.content).toContain('return "first";');
+
     const defaultRst = createExternalProject(fixture, {
       strategy: 'fetch',
       commit: fixture.commit1,

--- a/tests/external-sources/support.ts
+++ b/tests/external-sources/support.ts
@@ -109,6 +109,10 @@ export async function createExternalGitFixture(): Promise<ExternalGitFixture> {
     join(checkout, 'docs', 'widget.dart'),
     "String widget() {\n  return 'first';\n}\n",
   );
+  writeFileSync(
+    join(checkout, 'docs', 'Widget.java'),
+    'class Widget {\n  String widget() {\n    return "first";\n  }\n}\n',
+  );
   await git(['add', '.'], checkout);
   await git(['commit', '-m', 'first'], checkout);
   const commit1 = await git(['rev-parse', 'HEAD'], checkout);
@@ -131,6 +135,10 @@ export async function createExternalGitFixture(): Promise<ExternalGitFixture> {
   writeFileSync(
     join(checkout, 'docs', 'widget.dart'),
     "String widget() {\n  return 'second';\n}\n",
+  );
+  writeFileSync(
+    join(checkout, 'docs', 'Widget.java'),
+    'class Widget {\n  String widget() {\n    return "second";\n  }\n}\n',
   );
   await git(['add', '.'], checkout);
   await git(['commit', '-m', 'second'], checkout);

--- a/tests/highlight.test.ts
+++ b/tests/highlight.test.ts
@@ -58,6 +58,13 @@ describe('source highlighting', () => {
     expect(treeClasses(dart[0])).toContain('hljs-class');
     expect(treeText(dart[0])).toContain('Greeter');
 
+    const java = highlightSource(
+      'src/Greeter.java',
+      'class Greeter { String greet() { return "hello"; } }',
+    );
+    expect(treeClasses(java[0])).toContain('hljs-title');
+    expect(treeText(java[0])).toContain('Greeter');
+
     expect(highlightSource('notes.txt', '<safe>\n& literal')).toEqual([
       {
         version: 1,

--- a/tests/source-parser-cache.test.ts
+++ b/tests/source-parser-cache.test.ts
@@ -21,6 +21,7 @@ const SOURCE_CACHE_FIXTURES = {
   '.dart': { content: 'int cached() => 1;\n', symbol: 'cached' },
   '.go': { content: 'package cache\nfunc Cached() {}\n', symbol: 'Cached' },
   '.h': { content: 'int cached(void);\n', symbol: 'cached' },
+  '.java': { content: 'class Cached {}\n', symbol: 'Cached' },
   '.js': { content: 'export function cached() {}\n', symbol: 'cached' },
   '.jsx': {
     content: 'export function cached() { return <div /> }\n',

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -1320,6 +1320,19 @@ describe('lat ui', () => {
     );
     expect(dartLink.html).toContain('>DART</span>');
 
+    const javaLink = await renderMarkdown(
+      '[[src/Greeter.java#Greeter#greet]]',
+      'lat.md',
+      async () => ({
+        href: '/code/src/Greeter.java?symbol=Greeter%23greet',
+        referenceCount: 0,
+      }),
+    );
+    expect(javaLink.html).toContain(
+      'class="code-link-language code-language-java"',
+    );
+    expect(javaLink.html).toContain('>JAVA</span>');
+
     for (const referenceCount of [0, 1]) {
       const sparseReferences = await renderMarkdown(
         '[[orphan]]',

--- a/view/src/MarkdownContent.tsx
+++ b/view/src/MarkdownContent.tsx
@@ -133,6 +133,8 @@ function CodeReference({ reference }: { reference: ViewCodeBackReference }) {
     ['.go', ['code-language-go', 'GO']],
     ['.c', ['code-language-c', 'C']],
     ['.h', ['code-language-c', 'C']],
+    ['.dart', ['code-language-dart', 'DART']],
+    ['.java', ['code-language-java', 'JAVA']],
   ]).get(extension.toLowerCase()) ?? ['', '</>'];
   return (
     <div className="section-back-reference-item section-back-reference-code">


### PR DESCRIPTION
## Stack

1. #107 — avoid parser imports on warm checks
2. #109 — add Dart source support
3. **This PR** — add Java source support

## Summary

- register `.java` in the typed source-format registry used by source links, external sources, code-reference discovery, and persistent parser caching
- parse Java classes, interfaces, enums, records, annotation types, nested types, fields, constants, methods, record components, and ordinary or compact constructors
- preserve annotation-inclusive source ranges while presenting declaration signatures
- render Java source links, code back-references, and source views with Java badges and syntax highlighting
- cover valid and missing symbols, warm parser caches, external resolution, source ranges, highlighting, and UI behavior

## Attribution

Reimplements the Java support proposed by @isalvadori in #80 on the current parser infrastructure.

## Validation

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test` — 279 tests passed
- `pnpm build`
- `lat check`
