### PR TITLE
Add search score debugging and relevance thresholds

### DIFF
--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -340,9 +340,13 @@ Implementation: [[src/mcp/server.ts]]
 Semantic search across `lat.md` sections using vector embeddings. Works **offline by default** — no
 API key required.
 
-Usage: `lat search [query] [--limit=5]`
+Usage: `lat search [query] [--limit=5] [--threshold=0.35] [--debug]`
 
 Query is optional — `lat search` with no query just builds the index on first use. `lat search` only reads; rebuilding is [[cli#reindex]]. Results include a navigation hint footer suggesting `lat locate`, `lat refs`, and `lat search` for further exploration — this makes the tools self-documenting so agents discover them organically.
+
+`--debug` appends each result's cosine-similarity score, rounded to six decimal places. Scores stay hidden by default, including in the MCP `lat_search` output.
+
+Search returns only results whose cosine-similarity score is at least `--threshold` (`0.35` by default). The accepted range is `-1` to `1`; lower the threshold to favor recall or raise it to favor precision. MCP `lat_search` uses the same default and accepts the same optional threshold.
 
 Core search logic in [[src/cli/search.ts#runSearch]] (returns matched sections), used by both the CLI command and [[cli#mcp]] `lat_search` tool. Indexing/storage internals are in `src/search/`; all embedding generation lives in the `@lat.md/embed` package (see [[cli#search#Embeddings]]).
 

--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -346,7 +346,7 @@ Query is optional — `lat search` with no query just builds the index on first 
 
 `--debug` appends each result's cosine-similarity score, rounded to six decimal places. Scores stay hidden by default, including in the MCP `lat_search` output.
 
-Search returns only results whose cosine-similarity score is at least `--threshold` (`0.35` by default). The accepted range is `-1` to `1`; lower the threshold to favor recall or raise it to favor precision. MCP `lat_search` uses the same default and accepts the same optional threshold.
+Search returns only results whose cosine-similarity score is at least `--threshold` (`0.35` by default). The accepted range is `0` to `1`; lower the threshold to favor recall or raise it to favor precision. MCP `lat_search` uses the same default and accepts the same optional threshold. All search paths discard negative similarities, including UI and prompt-hook retrieval, because they indicate semantic opposition rather than relevance.
 
 Core search logic in [[src/cli/search.ts#runSearch]] (returns matched sections), used by both the CLI command and [[cli#mcp]] `lat_search` tool. Indexing/storage internals are in `src/search/`; all embedding generation lives in the `@lat.md/embed` package (see [[cli#search#Embeddings]]).
 

--- a/lat.md/tests/search.md
+++ b/lat.md/tests/search.md
@@ -34,10 +34,20 @@ Index the RAG fixture (9 sections across 2 files), verify counts.
 Search for "how do we handle user login and security?" and verify the Authentication section ranks
 first.
 
+### Filters results below the similarity threshold
+
+Semantic search returns only candidates at or above the requested cosine-similarity threshold so
+callers can trade recall for less low-relevance noise.
+
 ### Finds performance section for latency query
 
 Search for "what tools do we use to measure response times?" and verify the Performance Tests
 section ranks first.
+
+### Debug output includes similarity scores
+
+Search result formatting includes each cosine-similarity score when debug output is requested and
+keeps scores out of the normal output.
 
 ### Deterministic embeddings
 

--- a/lat.md/tests/search.md
+++ b/lat.md/tests/search.md
@@ -39,6 +39,11 @@ first.
 Semantic search returns only candidates at or above the requested cosine-similarity threshold so
 callers can trade recall for less low-relevance noise.
 
+### Discards negative similarity scores
+
+Every semantic-search path applies a zero score floor even without an explicit relevance threshold,
+so results pointing away from the query in embedding space are never returned.
+
 ### Finds performance section for latency query
 
 Search for "what tools do we use to measure response times?" and verify the Performance Tests

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,8 +30,8 @@ function parsePort(value: string): number {
 
 function parseSimilarityThreshold(value: string): number {
   const threshold = Number(value);
-  if (!Number.isFinite(threshold) || threshold < -1 || threshold > 1) {
-    throw new InvalidArgumentError('threshold must be a number from -1 to 1');
+  if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+    throw new InvalidArgumentError('threshold must be a number from 0 to 1');
   }
   return threshold;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,6 +28,14 @@ function parsePort(value: string): number {
   return port;
 }
 
+function parseSimilarityThreshold(value: string): number {
+  const threshold = Number(value);
+  if (!Number.isFinite(threshold) || threshold < -1 || threshold > 1) {
+    throw new InvalidArgumentError('threshold must be a number from -1 to 1');
+  }
+  return threshold;
+}
+
 /** Reserve `-- <directory>` for an explicit check target. */
 function splitCheckTarget(args: string[]): CheckTargetArgs {
   let commandIndex = -1;
@@ -335,18 +343,33 @@ program
   .description('Semantic search across lat.md sections')
   .argument('[query]', 'search query in plain English')
   .option('--limit <n>', 'max results', '5')
-  .action(async (query: string | undefined, opts: { limit: string }) => {
-    const ctx = resolveContext(program.opts());
-    const { searchCommand, cliProgress } = await import('./search.js');
-    const progress = cliProgress(ctx.styler);
-    const result = await searchCommand(
-      ctx,
-      query,
-      { limit: parseInt(opts.limit) },
-      progress,
-    );
-    handleResult(result);
-  });
+  .option('--debug', 'show result similarity scores')
+  .option(
+    '--threshold <score>',
+    'minimum cosine similarity score (default: 0.35)',
+    parseSimilarityThreshold,
+  )
+  .action(
+    async (
+      query: string | undefined,
+      opts: { limit: string; debug?: boolean; threshold?: number },
+    ) => {
+      const ctx = resolveContext(program.opts());
+      const { searchCommand, cliProgress } = await import('./search.js');
+      const progress = cliProgress(ctx.styler);
+      const result = await searchCommand(
+        ctx,
+        query,
+        {
+          limit: parseInt(opts.limit),
+          debug: opts.debug,
+          threshold: opts.threshold,
+        },
+        progress,
+      );
+      handleResult(result);
+    },
+  );
 
 program
   .command('reindex')

--- a/src/cli/search.ts
+++ b/src/cli/search.ts
@@ -18,7 +18,7 @@ import {
   type Embedder,
 } from '../search/embedder.js';
 import { indexSections, type IndexStats } from '../search/index.js';
-import { searchSections } from '../search/search.js';
+import { DEFAULT_SEARCH_THRESHOLD, searchSections } from '../search/search.js';
 import type { SectionMatch } from '../lattice-model.js';
 import {
   analyzeMarkdownProject,
@@ -147,7 +147,11 @@ export async function runSearch(
   query: string,
   limit: number,
   progress?: IndexProgress,
-  opts?: { buildIndex?: boolean; project?: MarkdownProjectAnalysis },
+  opts?: {
+    buildIndex?: boolean;
+    project?: MarkdownProjectAnalysis;
+    threshold?: number;
+  },
 ): Promise<SearchResult> {
   if (opts?.buildIndex === false) {
     const db = openDb(latDir);
@@ -159,7 +163,13 @@ export async function runSearch(
       if (stored === null) return { query, matches: [] };
       const embedder = await embedderForIndex(stored, latDir);
       await ensureSectionsSchema(db, embedder.dimensions);
-      const results = await searchSections(db, query, embedder, limit);
+      const results = await searchSections(
+        db,
+        query,
+        embedder,
+        limit,
+        opts.threshold,
+      );
       const project =
         opts.project ??
         (await analyzeMarkdownProject(latDir, dirname(latDir), {
@@ -177,7 +187,13 @@ export async function runSearch(
       executor: 'auto',
     }));
   return withDb(latDir, progress, project, async (db, embedder, analyzed) => {
-    const results = await searchSections(db, query, embedder, limit);
+    const results = await searchSections(
+      db,
+      query,
+      embedder,
+      limit,
+      opts?.threshold,
+    );
     return { query, matches: await resolveMatches(analyzed, results) };
   });
 }
@@ -227,7 +243,7 @@ export function cliProgress(s: Styler): IndexProgress {
 export async function searchCommand(
   ctx: CmdContext,
   query: string | undefined,
-  opts: { limit: number },
+  opts: { limit: number; debug?: boolean; threshold?: number },
   progress?: IndexProgress,
 ): Promise<CmdResult> {
   const s = ctx.styler;
@@ -240,6 +256,7 @@ export async function searchCommand(
     const project = await commandProjectAnalysis(ctx);
     const result = await runSearch(ctx.latDir, query, opts.limit, progress, {
       project,
+      threshold: opts.threshold ?? DEFAULT_SEARCH_THRESHOLD,
     });
 
     if (result.matches.length === 0) {
@@ -252,6 +269,7 @@ export async function searchCommand(
           ctx,
           `Search results for "${query}":`,
           result.matches,
+          { showScores: opts.debug },
         ) + formatNavHints(ctx),
     };
   } catch (err) {

--- a/src/format.ts
+++ b/src/format.ts
@@ -13,7 +13,7 @@ export function formatSectionId(id: string, s: Styler): string {
 export function formatSectionPreview(
   ctx: CmdContext,
   section: Section,
-  opts?: { reason?: string },
+  opts?: { reason?: string; score?: number },
 ): string {
   const s = ctx.styler;
   const relPath = relative(
@@ -22,9 +22,14 @@ export function formatSectionPreview(
   );
 
   const kind = section.id.includes('#') ? 'Section' : 'File';
-  const reasonSuffix = opts?.reason ? ' ' + s.dim(`(${opts.reason})`) : '';
+  const details = [
+    opts?.reason,
+    opts?.score === undefined ? undefined : `score: ${opts.score.toFixed(6)}`,
+  ].filter((detail): detail is string => detail !== undefined);
+  const detailsSuffix =
+    details.length > 0 ? ' ' + s.dim(`(${details.join(', ')})`) : '';
   const lines: string[] = [
-    `${s.dim('*')} ${s.dim(kind + ':')} [[${formatSectionId(section.id, s)}]]${reasonSuffix}`,
+    `${s.dim('*')} ${s.dim(kind + ':')} [[${formatSectionId(section.id, s)}]]${detailsSuffix}`,
     `  ${s.dim('Defined in')} ${s.cyan(relPath)}${s.dim(`:${section.startLine}-${section.endLine}`)}`,
   ];
 
@@ -39,6 +44,7 @@ export function formatResultList(
   ctx: CmdContext,
   header: string,
   matches: SectionMatch[],
+  opts?: { showScores?: boolean },
 ): string {
   const lines: string[] = ['', `## ${header}`, ''];
 
@@ -47,6 +53,7 @@ export function formatResultList(
     lines.push(
       formatSectionPreview(ctx, matches[i].section, {
         reason: matches[i].reason,
+        score: opts?.showScores ? matches[i].score : undefined,
       }),
     );
   }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -68,7 +68,7 @@ export async function startMcpServer(): Promise<void> {
         .describe('Max results (default 5)'),
       threshold: z
         .number()
-        .min(-1)
+        .min(0)
         .max(1)
         .optional()
         .default(DEFAULT_SEARCH_THRESHOLD)

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,6 +7,7 @@ import { plainStyler, type CmdContext, type CmdResult } from '../context.js';
 import { locateCommand } from '../cli/locate.js';
 import { sectionCommand } from '../cli/section.js';
 import { searchCommand } from '../cli/search.js';
+import { DEFAULT_SEARCH_THRESHOLD } from '../search/search.js';
 import { expandCommand } from '../cli/expand.js';
 import { checkAllCommand } from '../cli/check.js';
 import { refsCommand, type Scope } from '../cli/refs.js';
@@ -65,9 +66,16 @@ export async function startMcpServer(): Promise<void> {
         .optional()
         .default(5)
         .describe('Max results (default 5)'),
+      threshold: z
+        .number()
+        .min(-1)
+        .max(1)
+        .optional()
+        .default(DEFAULT_SEARCH_THRESHOLD)
+        .describe('Minimum cosine similarity score (default 0.35)'),
     },
-    async ({ query, limit }) =>
-      toMcp(await searchCommand(requestContext(), query, { limit })),
+    async ({ query, limit, threshold }) =>
+      toMcp(await searchCommand(requestContext(), query, { limit, threshold })),
   );
 
   server.tool(

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -1,6 +1,8 @@
 import type { Client } from '@libsql/client';
 import type { Embedder } from './embedder.js';
 
+export const DEFAULT_SEARCH_THRESHOLD = 0.35;
+
 export type SearchResult = {
   id: string;
   file: string;
@@ -14,6 +16,7 @@ export async function searchSections(
   query: string,
   embedder: Embedder,
   limit = 5,
+  threshold?: number,
 ): Promise<SearchResult[]> {
   const [queryVec] = await embedder.embed([query]);
   const vecJson = JSON.stringify(queryVec);
@@ -27,7 +30,7 @@ export async function searchSections(
     args: [vecJson, vecJson, limit],
   });
 
-  return rows.rows.map((row) => {
+  const results = rows.rows.map((row) => {
     const score = Number(row.score);
     return {
       id: row.id as string,
@@ -37,4 +40,8 @@ export async function searchSections(
       score: Number.isFinite(score) ? score : 0,
     };
   });
+
+  return threshold === undefined
+    ? results
+    : results.filter((result) => result.score >= threshold);
 }

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -16,7 +16,7 @@ export async function searchSections(
   query: string,
   embedder: Embedder,
   limit = 5,
-  threshold?: number,
+  threshold = 0,
 ): Promise<SearchResult[]> {
   const [queryVec] = await embedder.embed([query]);
   const vecJson = JSON.stringify(queryVec);
@@ -41,7 +41,5 @@ export async function searchSections(
     };
   });
 
-  return threshold === undefined
-    ? results
-    : results.filter((result) => result.score >= threshold);
+  return results.filter((result) => result.score >= threshold);
 }

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -128,16 +128,18 @@ describe('cli command surface', () => {
     expect(search.stdout).toContain('--threshold <score>');
     expect(search.stdout).toContain('default: 0.35');
 
-    const invalidThreshold = runCli('basic-project', [
-      'search',
-      'query',
-      '--threshold',
-      '1.1',
-    ]);
-    expect(invalidThreshold.exitCode).toBe(1);
-    expect(invalidThreshold.stderr).toContain(
-      'threshold must be a number from -1 to 1',
-    );
+    for (const threshold of ['-0.1', '1.1']) {
+      const invalidThreshold = runCli('basic-project', [
+        'search',
+        'query',
+        '--threshold',
+        threshold,
+      ]);
+      expect(invalidThreshold.exitCode).toBe(1);
+      expect(invalidThreshold.stderr).toContain(
+        'threshold must be a number from 0 to 1',
+      );
+    }
   });
 });
 

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -119,6 +119,26 @@ describe('cli command surface', () => {
     expect(view.exitCode).toBe(1);
     expect(view.stderr).toContain("unknown command 'view'");
   });
+
+  it('exposes search score controls', () => {
+    const search = runCli('basic-project', ['search', '--help']);
+    expect(search.exitCode).toBe(0);
+    expect(search.stdout).toContain('--debug');
+    expect(search.stdout).toContain('show result similarity scores');
+    expect(search.stdout).toContain('--threshold <score>');
+    expect(search.stdout).toContain('default: 0.35');
+
+    const invalidThreshold = runCli('basic-project', [
+      'search',
+      'query',
+      '--threshold',
+      '1.1',
+    ]);
+    expect(invalidThreshold.exitCode).toBe(1);
+    expect(invalidThreshold.stderr).toContain(
+      'threshold must be a number from -1 to 1',
+    );
+  });
 });
 
 // --- basic-project ---

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -208,7 +208,7 @@ describe.skipIf(!canRunSearch)('mcp search (rag)', () => {
 
     const result = await client2.callTool({
       name: 'lat_search',
-      arguments: { query: 'how do we handle user login and security?' },
+      arguments: { query: 'How are users authenticated with JWT tokens?' },
     });
     const text = (result.content as { type: string; text: string }[])[0].text;
     expect(result.isError).toBeFalsy();

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -14,6 +14,9 @@ import {
 import { indexSections } from '../src/search/index.js';
 import { searchSections } from '../src/search/search.js';
 import { runSearch } from '../src/cli/search.js';
+import { formatResultList } from '../src/format.js';
+import { plainStyler, type CmdContext } from '../src/context.js';
+import type { Section } from '../src/lattice-model.js';
 import { startReplayServer, hasReplayData } from './rag-replay-server.js';
 import type { Client } from '@libsql/client';
 import type { Server } from 'node:http';
@@ -99,6 +102,17 @@ describe('search (rag, local)', () => {
     expect(results[0].score).toBeGreaterThanOrEqual(results.at(-1)!.score);
   });
 
+  // @lat: [[search#RAG Tests#Filters results below the similarity threshold]]
+  it('filters results below the similarity threshold', async () => {
+    const query = 'how do we handle user login and security?';
+    const results = await searchSections(db, query, embedder);
+    const threshold = (results[0].score + results[1].score) / 2;
+    const filtered = await searchSections(db, query, embedder, 5, threshold);
+
+    expect(filtered.map((result) => result.id)).toEqual([results[0].id]);
+    expect(filtered[0].score).toBeGreaterThanOrEqual(threshold);
+  });
+
   // @lat: [[search#RAG Tests#Finds performance section for latency query]]
   it('finds performance section for latency query', async () => {
     const results = await searchSections(
@@ -132,6 +146,39 @@ describe('search (rag, local)', () => {
     const stats = await indexSections(latDir, db, embedder);
     expect(stats.removed).toBe(4); // testing + unit + integration + performance
     expect(stats.unchanged).toBe(5); // architecture sections remain
+  });
+});
+
+describe('search result formatting', () => {
+  const ctx: CmdContext = {
+    latDir: '/project/lat.md',
+    projectRoot: '/project',
+    styler: plainStyler,
+    mode: 'cli',
+  };
+  const section: Section = {
+    id: 'lat.md/architecture#Authentication',
+    heading: 'Authentication',
+    depth: 2,
+    file: 'lat.md/architecture',
+    filePath: 'lat.md/architecture.md',
+    children: [],
+    startLine: 3,
+    endLine: 8,
+    firstParagraph: 'Authentication uses signed sessions.',
+  };
+  const matches = [{ section, reason: 'semantic match', score: 0.8123456789 }];
+
+  // @lat: [[search#RAG Tests#Debug output includes similarity scores]]
+  it('shows scores only when debug output is requested', () => {
+    const normal = formatResultList(ctx, 'Results:', matches);
+    const debug = formatResultList(ctx, 'Results:', matches, {
+      showScores: true,
+    });
+
+    expect(normal).toContain('(semantic match)');
+    expect(normal).not.toContain('score:');
+    expect(debug).toContain('(semantic match, score: 0.812346)');
   });
 });
 

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -182,6 +182,41 @@ describe('search result formatting', () => {
   });
 });
 
+describe('search score floor', () => {
+  // @lat: [[search#RAG Tests#Discards negative similarity scores]]
+  it('discards negative cosine similarities without an explicit threshold', async () => {
+    const db = {
+      execute: vi.fn().mockResolvedValue({
+        rows: [
+          {
+            id: 'negative',
+            file: 'negative.md',
+            heading: 'Negative',
+            content: 'Negative match',
+            score: -0.1,
+          },
+          {
+            id: 'zero',
+            file: 'zero.md',
+            heading: 'Zero',
+            content: 'Zero match',
+            score: 0,
+          },
+        ],
+      }),
+    } as unknown as Client;
+    const embedder: Embedder = {
+      name: 'test',
+      dimensions: 1,
+      embed: vi.fn().mockResolvedValue([[1]]),
+    };
+
+    const results = await searchSections(db, 'query', embedder);
+
+    expect(results.map((result) => result.id)).toEqual(['zero']);
+  });
+});
+
 // --- Legacy cache upgrade: rebuild a pre-versioning index ---
 //
 // A `.cache` built by a version that never recorded `meta.embedding_model` has


### PR DESCRIPTION
## Summary

- add a --debug flag to lat search that includes each result's cosine-similarity score
- add an overridable --threshold option with a shared CLI/MCP default of 0.35
- restrict threshold overrides to the meaningful 0-to-1 range
- apply a universal zero score floor so CLI, MCP, UI, and prompt-hook search never return negative-similarity candidates
- document and test score formatting, filtering, CLI validation, and local/hosted search paths

## Validation

- pnpm build
- pnpm typecheck
- pnpm format:check
- pnpm test (285 tests)
- lat check