### PR TITLE
Stop external previews from restarting on cache writes

### DIFF
--- a/lat.md/tests/external-tests.md
+++ b/lat.md/tests/external-tests.md
@@ -73,6 +73,10 @@ Across Markdown, reStructuredText, and AsciiDoc, relative links to explicitly re
 
 A watched local checkout rebuilds the view generation after a referenced file changes, and the next external document request returns the dirty working-tree content.
 
+### Cache writes stay internal
+
+Fetching and parsing an external file may update disposable caches, but those writes never publish a project generation or restart the browser's in-flight preview request.
+
 ### Unused source omission
 
 Configured external sources with no references remain absent from the browser index so navigation reflects only content the project actually uses.

--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -66,7 +66,7 @@ A server-lifetime [[src/view/store.ts#createViewStore|ViewStore]] keeps document
 
 At startup the store reads each Markdown file once through the shared [[architecture-analysis#File analysis|file analyzer]], scans code references once, and obtains the explicit supported-source inventory from [[src/code-refs.ts#createCodeReferenceDiscovery]] for its watch scope. It then resolves the cached AST-free facts into an immutable reverse-reference snapshot.
 
-The store watches the project with a short debounce and serializes updates. Existing Markdown and code files are reread individually; file additions trigger a lightweight scope refresh, and deletions remove their cached contributions.
+The store watches the project with a short debounce and serializes updates. Existing Markdown and code files are reread individually; file additions trigger a lightweight scope refresh, and deletions remove their cached contributions. Disposable `lat.md/.cache` writes are ignored at the watcher boundary.
 
 Every update atomically replaces the snapshot. Section identity changes rebuild the global resolution maps and re-resolve cached occurrences from memory, but never force unchanged files to be reread or reparsed.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -157,6 +157,8 @@ Changing, adding, or deleting project files updates cached documents, navigation
 
 Browser clients receive a change event and refresh the current route while keeping its URL and viewport stable.
 
+Internal parser, search, and external-source cache writes do not publish project generations or restart in-flight document requests.
+
 ### Accepts restarted server generations
 
 Each event stream identifies its server lifetime, so reconnecting after a restart accepts reset generations and invalidates document and graph data from the prior process.

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -167,6 +167,10 @@ Each event stream identifies its server lifetime, so reconnecting after a restar
 
 A document request that never settles becomes a visible error with a retry action instead of leaving the route on an indefinite loading state.
 
+### Recovers interrupted document requests
+
+A transport-interrupted document request retries once. A repeated interruption becomes a visible retryable error, while navigation cancellations remain silent and never overwrite the next route.
+
 ## Refreshes search after Markdown changes
 
 The first search indexes lazily, while a later Markdown generation triggers exactly one shared incremental indexing pass before new queries run.

--- a/src/view/store.ts
+++ b/src/view/store.ts
@@ -103,6 +103,11 @@ function projectPath(projectRoot: string, path: string): string {
   return toPosix(normalized).replace(/^\.\//, '');
 }
 
+function isInternalLatCachePath(path: string, latPath: string): boolean {
+  const cachePath = latPath ? `${latPath}/.cache` : '.cache';
+  return path === cachePath || path.startsWith(`${cachePath}/`);
+}
+
 function excludedCodePath(
   projectRoot: string,
   path: string,
@@ -551,9 +556,13 @@ export class ViewStore {
 
   refresh(paths: string[]): Promise<void> {
     if (this.closed) return Promise.resolve();
-    const normalized = paths.map((path) =>
-      path ? projectPath(this.projectRoot, path) : '',
-    );
+    const latPath = projectPath(this.projectRoot, this.latDir);
+    const normalized = paths
+      .map((path) => (path ? projectPath(this.projectRoot, path) : ''))
+      .filter((path) => !isInternalLatCachePath(path, latPath));
+    if (paths.length > 0 && normalized.length === 0) {
+      return Promise.resolve();
+    }
     return this.queueRefresh(normalized, false);
   }
 
@@ -581,13 +590,15 @@ export class ViewStore {
 
   private scheduleRefresh(path: string): void {
     if (this.closed) return;
-    this.pendingPaths.add(
+    const normalizedPath =
       path === EXTERNAL_REFRESH_PATH
         ? path
         : path
           ? projectPath(this.projectRoot, path)
-          : '',
-    );
+          : '';
+    const latPath = projectPath(this.projectRoot, this.latDir);
+    if (isInternalLatCachePath(normalizedPath, latPath)) return;
+    this.pendingPaths.add(normalizedPath);
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null;

--- a/tests/data-source.test.ts
+++ b/tests/data-source.test.ts
@@ -34,4 +34,49 @@ describe('view data source', () => {
     await vi.advanceTimersByTimeAsync(VIEW_REQUEST_TIMEOUT_MS);
     await rejected;
   });
+
+  // @lat: [[lat.md/view/specs#View Tests#Updates long-running views incrementally#Recovers interrupted document requests]]
+  it('recovers interrupted requests without retrying navigation cancellations', async () => {
+    const recoveredFetch = vi
+      .fn()
+      .mockRejectedValueOnce(new DOMException('Aborted', 'AbortError'))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', recoveredFetch);
+
+    await expect(
+      fetchViewJson<{ ok: boolean }>('/api/external'),
+    ).resolves.toEqual({ ok: true });
+    expect(recoveredFetch).toHaveBeenCalledTimes(2);
+
+    const interruptedFetch = vi
+      .fn()
+      .mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+    vi.stubGlobal('fetch', interruptedFetch);
+
+    await expect(fetchViewJson('/api/external')).rejects.toMatchObject({
+      name: 'NetworkError',
+      message: 'The server connection was interrupted. Try again.',
+    });
+    expect(interruptedFetch).toHaveBeenCalledTimes(2);
+
+    const cancelledFetch = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'));
+        });
+      });
+    });
+    vi.stubGlobal('fetch', cancelledFetch);
+    const controller = new AbortController();
+
+    const request = fetchViewJson('/api/external', controller.signal);
+    controller.abort();
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+    expect(cancelledFetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/external-sources/view.test.ts
+++ b/tests/external-sources/view.test.ts
@@ -264,6 +264,9 @@ describe.sequential('external source view', () => {
       externalCa: fixture.ca,
     });
     try {
+      // Give the recursive watcher a turn to become observable before the
+      // fixture writes immediately after server startup under parallel load.
+      await new Promise((resolveReady) => setTimeout(resolveReady, 100));
       const generation = server.store.snapshot.generation;
 
       const changed = new Promise<void>((resolveChange, reject) => {
@@ -293,6 +296,34 @@ describe.sequential('external source view', () => {
     } finally {
       await server.close();
       writeFileSync(guidePath, originalGuide);
+    }
+  });
+
+  // @lat: [[tests/external-tests#External Sources#Browser and static export#Cache writes stay internal]]
+  it('does not publish project changes for external cache activity', async () => {
+    const project = createExternalProject(fixture, {
+      strategy: 'fetch',
+      commit: fixture.commit1,
+      defaultFileExtension: 'md',
+      body: 'Read [[upstream:guide#Navigation]].',
+    });
+    roots.push(project.root);
+    const server = await startViewServer(commandContext(project), {
+      git: false,
+      port: 0,
+      externalCa: fixture.ca,
+    });
+    try {
+      const generation = server.store.snapshot.generation;
+      const external = await json<ViewExternalDocument>(
+        `${server.url}api/external?target=${encodeURIComponent('upstream:guide')}`,
+      );
+      expect(external.kind).toBe('markdown');
+
+      await new Promise((resolveWait) => setTimeout(resolveWait, 200));
+      expect(server.store.snapshot.generation).toBe(generation);
+    } finally {
+      await server.close();
     }
   });
 

--- a/view/src/App.tsx
+++ b/view/src/App.tsx
@@ -266,10 +266,6 @@ function currentLocation(): string {
   return `${window.location.pathname}${window.location.search}${window.location.hash}`;
 }
 
-function isAbortError(reason: unknown): boolean {
-  return reason instanceof Error && reason.name === 'AbortError';
-}
-
 function errorMessage(reason: unknown): string {
   return reason instanceof Error ? reason.message : String(reason);
 }
@@ -524,7 +520,7 @@ export function App() {
         setIndexError('');
       })
       .catch((reason: unknown) => {
-        if (!isAbortError(reason)) setIndexError(errorMessage(reason));
+        if (!controller.signal.aborted) setIndexError(errorMessage(reason));
       });
     return () => controller.abort();
   }, [connectionRevision, projectChange.generation]);
@@ -578,7 +574,7 @@ export function App() {
         setError('');
       })
       .catch((reason: unknown) => {
-        if (requestId === pageRequestId.current && !isAbortError(reason)) {
+        if (requestId === pageRequestId.current && !controller.signal.aborted) {
           setPage(null);
           setHistoryScroll(null);
           setError(errorMessage(reason));

--- a/view/src/GraphView.tsx
+++ b/view/src/GraphView.tsx
@@ -504,7 +504,7 @@ function GraphInspector({
             controller.signal,
           ).then((source) => setContent({ kind: 'source', source }));
     request.catch((reason: Error) => {
-      if (reason.name !== 'AbortError') setError(reason.message);
+      if (!controller.signal.aborted) setError(reason.message);
     });
     return () => controller.abort();
   }, [contentTarget, graph.generation, node]);
@@ -716,7 +716,7 @@ export default function GraphView({
           });
         })
         .catch((reason: Error) => {
-          if (reason.name !== 'AbortError') setSearchError(reason.message);
+          if (!controller.signal.aborted) setSearchError(reason.message);
         })
         .finally(() => {
           if (!controller.signal.aborted) setSearching(false);

--- a/view/src/SearchPage.tsx
+++ b/view/src/SearchPage.tsx
@@ -115,7 +115,7 @@ export function SearchPage({
           setSearched(true);
         })
         .catch((reason: Error) => {
-          if (reason.name !== 'AbortError') setError(reason.message);
+          if (!controller.signal.aborted) setError(reason.message);
         })
         .finally(() => {
           if (!controller.signal.aborted) setLoading(false);

--- a/view/src/SectionOutputDialog.tsx
+++ b/view/src/SectionOutputDialog.tsx
@@ -33,7 +33,7 @@ export function SectionOutputDialog({
     )
       .then(setResult)
       .catch((reason: Error) => {
-        if (reason.name !== 'AbortError') setError(reason.message);
+        if (!controller.signal.aborted) setError(reason.message);
       });
     return () => controller.abort();
   }, [sectionId]);

--- a/view/src/data-source.ts
+++ b/view/src/data-source.ts
@@ -22,6 +22,20 @@ export class ViewRequestTimeoutError extends Error {
   override name = 'TimeoutError';
 }
 
+export class ViewRequestConnectionError extends Error {
+  override name = 'NetworkError';
+}
+
+function isTransientRequestError(reason: unknown): boolean {
+  return (
+    reason instanceof TypeError ||
+    (typeof reason === 'object' &&
+      reason !== null &&
+      'name' in reason &&
+      reason.name === 'AbortError')
+  );
+}
+
 async function fetchJsonFile<T>(url: string, signal?: AbortSignal): Promise<T> {
   const controller = new AbortController();
   let timedOut = false;
@@ -33,23 +47,35 @@ async function fetchJsonFile<T>(url: string, signal?: AbortSignal): Promise<T> {
     controller.abort();
   }, VIEW_REQUEST_TIMEOUT_MS);
   try {
-    const response = await fetch(url, { signal: controller.signal });
-    const value = (await response.json()) as T | ViewError;
-    if (!response.ok) {
-      throw new Error(
-        value && typeof value === 'object' && 'error' in value
-          ? value.error
-          : 'Request failed',
-      );
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const response = await fetch(url, { signal: controller.signal });
+        const value = (await response.json()) as T | ViewError;
+        if (!response.ok) {
+          throw new Error(
+            value && typeof value === 'object' && 'error' in value
+              ? value.error
+              : 'Request failed',
+          );
+        }
+        return value as T;
+      } catch (reason) {
+        if (timedOut) {
+          throw new ViewRequestTimeoutError(
+            'The server did not respond in time. Try again.',
+          );
+        }
+        if (controller.signal.aborted) throw reason;
+        if (!isTransientRequestError(reason)) throw reason;
+        if (attempt === 0) continue;
+        throw new ViewRequestConnectionError(
+          'The server connection was interrupted. Try again.',
+        );
+      }
     }
-    return value as T;
-  } catch (reason) {
-    if (timedOut) {
-      throw new ViewRequestTimeoutError(
-        'The server did not respond in time. Try again.',
-      );
-    }
-    throw reason;
+    throw new ViewRequestConnectionError(
+      'The server connection was interrupted. Try again.',
+    );
   } finally {
     globalThis.clearTimeout(timeout);
     signal?.removeEventListener('abort', abort);


### PR DESCRIPTION
## Summary

- ignore disposable lat.md/.cache activity at the live view watcher boundary
- prevent external cache locks and parser-cache writes from publishing project generations
- add regression coverage for first-load external previews

## Cause

Opening an external file creates a short-lived cache lock. The project watcher treated that lock as linked-resource activity, published a new generation, and made the browser abort and restart the same preview request indefinitely.

## Verification

- pnpm build
- pnpm test (282 tests)
- pnpm exec vitest run tests/external-sources/view.test.ts
- lat check
- reproduced against test-lat in headless Chrome: repeated API requests became one request and the preview rendered without reload