### PR TITLE
Add CodeMirror editing for local Markdown

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -60,6 +60,22 @@ Builds reject any existing destination, including an empty directory or prior ex
 
 The generated marker makes later project-wide scans ignore the artifact instead of indexing rendered JSON or bundles as source. Any destination that could contain the project root is also rejected.
 
+## Live Markdown editing
+
+Live local documents can switch between the rendered tree and an editable Markdown source while static and external documents remain read-only.
+
+[[view/src/MarkdownEditor.tsx#MarkdownEditor]] and its CodeMirror dependencies load only after Edit is selected. The editor provides soft wrapping, line numbers, history, Markdown syntax highlighting, and keyboard indentation without increasing production dependency installs.
+
+CodeMirror incrementally compares the draft with the last loaded or saved source. A narrow gutter and subtle line tint distinguish added, modified, and deleted lines until a successful explicit save resets the baseline.
+
+The editor writes only through its Save button or the platform save shortcut. Later keystrokes made during a request remain a dirty draft for another explicit save instead of being silently queued.
+
+Switching to View, navigating to another document, or opening Graph asks before discarding a dirty draft. Browser reload and close use the native unsaved-changes prompt; same-document navigation preserves the mounted editor and its draft.
+
+Each request carries the source originally loaded or acknowledged plus the user's edited source. [[src/view/document-edit.ts#applyDocumentEdit]] creates a contextual patch and applies it to the latest disk content, preserving unrelated concurrent changes while rejecting overlapping edits without discarding the browser draft.
+
+The server serializes editor writes, verifies the target is a known real Markdown file inside the vault, replaces it atomically, and refreshes the live project snapshot before acknowledging the save.
+
 ## Live project index
 
 A server-lifetime [[src/view/store.ts#createViewStore|ViewStore]] keeps document navigation and reverse references current without rescanning the project for every request.

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -127,6 +127,22 @@ The URL preserves the latest query; Back restores it, and Escape clears the quer
 
 Documents expose [[markdown#Frontmatter#require-code-mention]] separately from the rendered document tree so the browser can badge files that require code references.
 
+## Edits local Markdown safely
+
+Live local documents expose a View/Edit split control that swaps rendered Markdown for a soft-wrapped, syntax-highlighted CodeMirror surface without exposing editing in static exports or external documents.
+
+The editor loads raw source on demand and writes only from its Save button or the platform save shortcut. Saving, saved, unsaved, and conflict states remain visible without blocking further typing.
+
+Added, modified, and deleted lines receive subdued gutter markers against the last loaded or saved source. Markers clear when edits are reverted or saved and reset when clean content reloads from disk.
+
+Leaving Edit, navigating away, or entering Graph requires confirmation while a draft is dirty. Reloading or closing the page requests the browser's native unsaved-changes confirmation, while canceled transitions keep the draft mounted.
+
+Each save applies the user's delta from the last loaded or acknowledged text to the latest file content on disk. Unrelated concurrent changes survive, overlapping changes fail visibly while retaining the draft, and successful writes immediately refresh the live project snapshot.
+
+### Does not replay uncertain writes
+
+An interrupted editor PATCH becomes a visible error without automatic replay because the first request may already have reached disk; safe read requests retain their one retry.
+
 ## Resolves Markdown and source wiki links
 
 Resolved Markdown sections and validated source definitions become client-side links, while unresolved wiki targets remain authored text.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,13 @@
     "cook-test-rag": "tsx scripts/cook-test-rag.ts"
   },
   "devDependencies": {
+    "@codemirror/commands": "^6.11.0",
+    "@codemirror/lang-markdown": "^6.5.2",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/merge": "^6.12.2",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.9",
+    "@lezer/highlight": "^1.2.3",
     "@types/geojson": "^7946.0.16",
     "@types/hast": "^3.0.5",
     "@types/mdast": "^4.0.4",
@@ -82,6 +89,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@repomix/tree-sitter-wasms": "^0.1.17",
     "commander": "^14.0.3",
+    "diff": "^8.0.4",
     "github-slugger": "^2.0.0",
     "ignore-walk": "^8.0.0",
     "mdast-util-gfm-autolink-literal": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      diff:
+        specifier: ^8.0.4
+        version: 8.0.4
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -120,6 +123,27 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@codemirror/commands':
+        specifier: ^6.11.0
+        version: 6.11.0
+      '@codemirror/lang-markdown':
+        specifier: ^6.5.2
+        version: 6.5.2
+      '@codemirror/language':
+        specifier: ^6.12.4
+        version: 6.12.4
+      '@codemirror/merge':
+        specifier: ^6.12.2
+        version: 6.12.2
+      '@codemirror/state':
+        specifier: ^6.7.1
+        version: 6.7.1
+      '@codemirror/view':
+        specifier: ^6.43.9
+        version: 6.43.9
+      '@lezer/highlight':
+        specifier: ^1.2.3
+        version: 1.2.3
       '@types/geojson':
         specifier: ^7946.0.16
         version: 7946.0.16
@@ -353,6 +377,39 @@ packages:
 
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/commands@6.11.0':
+    resolution: {integrity: sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.12':
+    resolution: {integrity: sha512-pw2ReWKUqSkbvh76RAT4NYxiogRu+PWkR2ukAwO9uOgrm8uipkzjtKKtNpyeAQwHOqxEeSvAXZ6vr3AfyB9y/w==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-markdown@6.5.2':
+    resolution: {integrity: sha512-AwBOdkWYuA//WcM0xO5PfHPUcmz/O2i5o0Nsg1U69SII/loCJlFI1Romd9xp2HYb1kYJRGZotyqRghuHH5n8Kw==}
+
+  '@codemirror/language@6.12.4':
+    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+
+  '@codemirror/lint@6.9.7':
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/merge@6.12.2':
+    resolution: {integrity: sha512-V8JvyAPjHbPupqP7BeMcsdsYCbyPij74jxIbaIJDORI+VZzW44zFmon8bF+oxGWvOKhcRmkiUMXd8MxHr3YA2w==}
+
+  '@codemirror/state@6.7.1':
+    resolution: {integrity: sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==}
+
+  '@codemirror/view@6.43.9':
+    resolution: {integrity: sha512-sTuUzTpPMFebRhg6dawChoKKgndIwfjmJgKVxBefPElcU2NwQ6AFroupk0SFqEerQyZOGRfDNnSN8Dw/lMAsXw==}
 
   '@csstools/color-helpers@6.1.1':
     resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
@@ -751,6 +808,27 @@ packages:
   '@lat.md/embed@0.2.0':
     resolution: {integrity: sha512-Q5M8w0jBQTXY/iQ6+iV1fb8UCByr5xoqtP+G6R844OTyze0Joe19AhHtz8i/Ei8hfHwS2EhBd1Mdjw7L1vnyVw==}
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.6':
+    resolution: {integrity: sha512-YJE78Wcg+zX8f10hiHWQ4Az48Qr/c13eId0VtRQYLBpxHDmDeSrXIlkbl+fJGW42rWC/uoUco9mhBZeVWP/A1g==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/markdown@1.7.2':
+    resolution: {integrity: sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ==}
+
   '@libsql/client@0.17.0':
     resolution: {integrity: sha512-TLjSU9Otdpq0SpKHl1tD1Nc9MKhrsZbCFGot3EbCxRa8m1E5R1mMwoOjKMMM31IyF7fr+hPNHLpYfwbMKNusmg==}
 
@@ -843,6 +921,9 @@ packages:
 
   '@maplibre/vt-pbf@4.3.2':
     resolution: {integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==}
+
+  '@marijn/find-cluster-break@1.0.4':
+    resolution: {integrity: sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==}
 
   '@mermaid-js/parser@1.2.1':
     resolution: {integrity: sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==}
@@ -1458,6 +1539,9 @@ packages:
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
+
   cross-fetch@4.1.0:
     resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
 
@@ -1679,6 +1763,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
 
   dompurify@3.4.14:
     resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
@@ -2653,6 +2741,9 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -2898,6 +2989,9 @@ packages:
       jsdom:
         optional: true
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -3132,6 +3226,94 @@ snapshots:
       css-tree: 3.2.1
 
   '@chevrotain/types@11.1.2': {}
+
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.9
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.11.0':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.9
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.6
+
+  '@codemirror/lang-html@6.4.12':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.9
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.6
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.9
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-markdown@6.5.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.12
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.9
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.7.2
+
+  '@codemirror/language@6.12.4':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.9
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.9
+      crelt: 1.0.7
+
+  '@codemirror/merge@6.12.2':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.9
+      '@lezer/highlight': 1.2.3
+      style-mod: 4.1.3
+
+  '@codemirror/state@6.7.1':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.4
+
+  '@codemirror/view@6.43.9':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      crelt: 1.0.7
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   '@csstools/color-helpers@6.1.1': {}
 
@@ -3384,6 +3566,39 @@ snapshots:
 
   '@lat.md/embed@0.2.0': {}
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.7.2':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+
   '@libsql/client@0.17.0':
     dependencies:
       '@libsql/core': 0.17.0
@@ -3486,6 +3701,8 @@ snapshots:
       '@mapbox/point-geometry': 1.1.0
       '@types/geojson': 7946.0.16
       pbf: 5.1.2
+
+  '@marijn/find-cluster-break@1.0.4': {}
 
   '@mermaid-js/parser@1.2.1':
     dependencies:
@@ -4074,6 +4291,8 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
+  crelt@1.0.7: {}
+
   cross-fetch@4.1.0:
     dependencies:
       node-fetch: 2.7.0
@@ -4316,6 +4535,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@8.0.4: {}
 
   dompurify@3.4.14:
     optionalDependencies:
@@ -5691,6 +5912,8 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  style-mod@4.1.3: {}
+
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
@@ -5925,6 +6148,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/src/view/document-edit.ts
+++ b/src/view/document-edit.ts
@@ -1,0 +1,46 @@
+import { applyPatch, createPatch } from 'diff';
+
+const PATCH_CONTEXT_LINES = 3;
+const PATCH_FUZZ_LINES = 2;
+
+export class ViewDocumentConflictError extends Error {}
+
+export type AppliedDocumentEdit = {
+  content: string;
+  merged: boolean;
+};
+
+/** Apply the user's base-to-edited patch to the latest content on disk. */
+export function applyDocumentEdit(
+  baseContent: string,
+  editedContent: string,
+  currentContent: string,
+): AppliedDocumentEdit {
+  if (baseContent === editedContent) {
+    return { content: currentContent, merged: currentContent !== baseContent };
+  }
+  if (currentContent === editedContent) {
+    return { content: currentContent, merged: currentContent !== baseContent };
+  }
+  if (currentContent === baseContent) {
+    return { content: editedContent, merged: false };
+  }
+
+  const patch = createPatch(
+    'document.md',
+    baseContent,
+    editedContent,
+    undefined,
+    undefined,
+    { context: PATCH_CONTEXT_LINES },
+  );
+  const content = applyPatch(currentContent, patch, {
+    fuzzFactor: PATCH_FUZZ_LINES,
+  });
+  if (content === false) {
+    throw new ViewDocumentConflictError(
+      'Could not save because this file changed in the same area. Your edits are still in the editor.',
+    );
+  }
+  return { content, merged: true };
+}

--- a/src/view/protocol.ts
+++ b/src/view/protocol.ts
@@ -146,6 +146,20 @@ export type ViewDocument = {
   };
 };
 
+export type ViewDocumentSource = {
+  path: string;
+  content: string;
+};
+
+export type ViewDocumentEditRequest = {
+  baseContent: string;
+  content: string;
+};
+
+export type ViewDocumentEditResponse = ViewDocumentSource & {
+  merged: boolean;
+};
+
 export type ViewMarkdownBackReference = {
   kind: 'markdown';
   sectionId: string;

--- a/src/view/server.ts
+++ b/src/view/server.ts
@@ -1,16 +1,23 @@
 import { readFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
-import { createServer, type Server, type ServerResponse } from 'node:http';
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
 import { dirname, extname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { plainStyler, type CmdContext } from '../context.js';
 import { sectionCommand } from '../cli/section.js';
 import {
   DEFAULT_VIEW_LOGO_TEXT,
+  type ViewDocumentEditRequest,
   type ViewError,
   type ViewProjectGeneration,
   type ViewSectionCommandOutput,
 } from './protocol.js';
+import { ViewDocumentConflictError } from './document-edit.js';
 import {
   ViewExternalNotFoundError,
   ViewDocumentNotFoundError,
@@ -22,6 +29,8 @@ import { rewriteClientAssetUrls } from './client-shell.js';
 
 const DEFAULT_HOST = '127.0.0.1';
 export const DEFAULT_VIEW_PORT = 4242;
+const MAX_DOCUMENT_EDIT_BODY_BYTES = 16 * 1024 * 1024;
+const MAX_DOCUMENT_CONTENT_LENGTH = 8 * 1024 * 1024;
 const defaultClientDir = fileURLToPath(new URL('./client/', import.meta.url));
 
 export type ViewServer = {
@@ -83,6 +92,24 @@ function sendJson(
     JSON.stringify(value),
     headOnly,
   );
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const value of req) {
+    const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+    size += chunk.byteLength;
+    if (size > MAX_DOCUMENT_EDIT_BODY_BYTES) {
+      throw new RangeError('Document edit is too large');
+    }
+    chunks.push(chunk);
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+  } catch {
+    throw new SyntaxError('Document edit must be valid JSON');
+  }
 }
 
 function contentType(path: string): string {
@@ -167,7 +194,7 @@ function listen(server: Server, host: string, port: number): Promise<void> {
   });
 }
 
-/** Start the read-only loopback server used by `lat ui`. */
+/** Start the loopback server used by `lat ui`. */
 export async function startViewServer(
   ctx: CmdContext,
   options: ViewServerOptions = {},
@@ -201,13 +228,15 @@ export async function startViewServer(
       setSecurityHeaders(res);
       const method = req.method ?? 'GET';
       const headOnly = method === 'HEAD';
-      if (method !== 'GET' && !headOnly) {
+      const url = new URL(req.url ?? '/', `http://${host}`);
+      const documentEdit =
+        method === 'PATCH' && url.pathname === '/api/document';
+      if (method !== 'GET' && !headOnly && !documentEdit) {
         res.setHeader('Allow', 'GET, HEAD');
         send(res, 405, 'text/plain; charset=utf-8', 'Method not allowed');
         return;
       }
 
-      const url = new URL(req.url ?? '/', `http://${host}`);
       if (url.pathname === '/') {
         const entry = store.getIndex().entry;
         if (!entry) {
@@ -255,8 +284,95 @@ export async function startViewServer(
 
       if (url.pathname === '/api/document') {
         const path = url.searchParams.get('path') ?? '';
+        if (documentEdit) {
+          let body: unknown;
+          try {
+            body = await readJsonBody(req);
+          } catch (error) {
+            sendJson(
+              res,
+              error instanceof RangeError ? 413 : 400,
+              { error: (error as Error).message } satisfies ViewError,
+              false,
+            );
+            return;
+          }
+          if (
+            !body ||
+            typeof body !== 'object' ||
+            typeof (body as Partial<ViewDocumentEditRequest>).baseContent !==
+              'string' ||
+            typeof (body as Partial<ViewDocumentEditRequest>).content !==
+              'string'
+          ) {
+            sendJson(
+              res,
+              400,
+              {
+                error: 'Document edit content is required',
+              } satisfies ViewError,
+              false,
+            );
+            return;
+          }
+          const edit = body as ViewDocumentEditRequest;
+          if (
+            edit.baseContent.length > MAX_DOCUMENT_CONTENT_LENGTH ||
+            edit.content.length > MAX_DOCUMENT_CONTENT_LENGTH
+          ) {
+            sendJson(
+              res,
+              413,
+              { error: 'Document edit is too large' } satisfies ViewError,
+              false,
+            );
+            return;
+          }
+          try {
+            sendJson(
+              res,
+              200,
+              await store.editDocument(path, edit.baseContent, edit.content),
+              false,
+            );
+          } catch (error) {
+            if (error instanceof ViewDocumentConflictError) {
+              sendJson(
+                res,
+                409,
+                { error: error.message } satisfies ViewError,
+                false,
+              );
+              return;
+            }
+            if (!(error instanceof ViewDocumentNotFoundError)) throw error;
+            sendJson(
+              res,
+              404,
+              { error: error.message } satisfies ViewError,
+              false,
+            );
+          }
+          return;
+        }
         try {
           sendJson(res, 200, await store.getDocument(path), headOnly);
+        } catch (error) {
+          if (!(error instanceof ViewDocumentNotFoundError)) throw error;
+          sendJson(
+            res,
+            404,
+            { error: error.message } satisfies ViewError,
+            headOnly,
+          );
+        }
+        return;
+      }
+
+      if (url.pathname === '/api/document-source') {
+        const path = url.searchParams.get('path') ?? '';
+        try {
+          sendJson(res, 200, await store.getDocumentSource(path), headOnly);
         } catch (error) {
           if (!(error instanceof ViewDocumentNotFoundError)) throw error;
           sendJson(

--- a/src/view/store.ts
+++ b/src/view/store.ts
@@ -1,5 +1,13 @@
+import { randomUUID } from 'node:crypto';
 import { watch as watchFiles, type FSWatcher } from 'node:fs';
-import { readFile, realpath } from 'node:fs/promises';
+import {
+  readFile,
+  realpath,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
 import {
   basename,
   extname,
@@ -24,6 +32,10 @@ import { isSourceFileExtension } from '../source-formats.js';
 import { toPosix } from '../path.js';
 import { renderMarkdown } from './markdown.js';
 import { buildViewDiagnostics } from './diagnostics.js';
+import {
+  applyDocumentEdit,
+  ViewDocumentConflictError,
+} from './document-edit.js';
 import { buildGitDiffTree } from './git-diff.js';
 import { buildViewGraph } from './graph.js';
 import { buildViewTableOfContents } from './table-of-contents.js';
@@ -37,7 +49,9 @@ import {
 } from './git.js';
 import type {
   ViewDocument,
+  ViewDocumentEditResponse,
   ViewDocumentError,
+  ViewDocumentSource,
   ViewExternalDocument,
   ViewExternalFile,
   ViewGraph,
@@ -64,6 +78,8 @@ import {
 const DEFAULT_DEBOUNCE_MS = 75;
 const DEFAULT_GIT_POLL_MS = 2_000;
 const EXTERNAL_REFRESH_PATH = '@lat-external-refresh';
+const DOCUMENT_EDIT_WRITE_ATTEMPTS = 3;
+const DOCUMENT_EDIT_TEMP_PREFIX = '.lat-edit-';
 
 export type ViewProjectSnapshot = {
   generation: number;
@@ -330,6 +346,7 @@ export class ViewStore {
   private gitPollTimer: NodeJS.Timeout | null = null;
   private gitPollQueued = false;
   private refreshTail: Promise<void> = Promise.resolve();
+  private editTail: Promise<void> = Promise.resolve();
   private closed = false;
 
   constructor(
@@ -523,6 +540,81 @@ export class ViewStore {
     };
   }
 
+  private async editableDocumentPath(requestedPath: string): Promise<string> {
+    if (
+      !requestedPath ||
+      requestedPath.includes('\\') ||
+      isAbsolute(requestedPath) ||
+      !requestedPath.toLowerCase().endsWith('.md') ||
+      !this.snapshotValue.files.has(requestedPath)
+    ) {
+      throw new ViewDocumentNotFoundError('Markdown document not found');
+    }
+    let realFile: string;
+    try {
+      realFile = await realpath(resolve(this.latDir, requestedPath));
+    } catch {
+      throw new ViewDocumentNotFoundError('Markdown document not found');
+    }
+    if (!isInside(this.realLatDir, realFile)) {
+      throw new ViewDocumentNotFoundError('Markdown document not found');
+    }
+    return realFile;
+  }
+
+  async getDocumentSource(requestedPath: string): Promise<ViewDocumentSource> {
+    const path = await this.editableDocumentPath(requestedPath);
+    return { path: requestedPath, content: await readFile(path, 'utf8') };
+  }
+
+  editDocument(
+    requestedPath: string,
+    baseContent: string,
+    editedContent: string,
+  ): Promise<ViewDocumentEditResponse> {
+    const operation = this.editTail.then(async () => {
+      const path = await this.editableDocumentPath(requestedPath);
+      for (let attempt = 0; attempt < DOCUMENT_EDIT_WRITE_ATTEMPTS; attempt++) {
+        const currentContent = await readFile(path, 'utf8');
+        const edit = applyDocumentEdit(
+          baseContent,
+          editedContent,
+          currentContent,
+        );
+        if (edit.content === currentContent) {
+          return { path: requestedPath, ...edit };
+        }
+
+        const currentStat = await stat(path);
+        const temporaryPath = resolve(
+          this.latDir,
+          `${DOCUMENT_EDIT_TEMP_PREFIX}${process.pid}-${randomUUID()}.tmp`,
+        );
+        try {
+          await writeFile(temporaryPath, edit.content, {
+            encoding: 'utf8',
+            flag: 'wx',
+            mode: currentStat.mode,
+          });
+          if ((await readFile(path, 'utf8')) !== currentContent) continue;
+          await rename(temporaryPath, path);
+        } finally {
+          await rm(temporaryPath, { force: true });
+        }
+        await this.refresh([resolve(this.latDir, requestedPath)]);
+        return { path: requestedPath, ...edit };
+      }
+      throw new ViewDocumentConflictError(
+        'Could not save because this file kept changing. Your edits are still in the editor.',
+      );
+    });
+    this.editTail = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return operation;
+  }
+
   getSource(
     requestedPath: string,
     requestedSymbol = '',
@@ -584,12 +676,20 @@ export class ViewStore {
     this.watcher = null;
     for (const watcher of this.externalWatchers) watcher.close();
     this.externalWatchers = [];
+    await this.editTail;
     await this.refreshTail;
     this.listeners.clear();
   }
 
   private scheduleRefresh(path: string): void {
     if (this.closed) return;
+    if (
+      path !== EXTERNAL_REFRESH_PATH &&
+      basename(path).startsWith(DOCUMENT_EDIT_TEMP_PREFIX) &&
+      path.endsWith('.tmp')
+    ) {
+      return;
+    }
     const normalizedPath =
       path === EXTERNAL_REFRESH_PATH
         ? path

--- a/tests/data-source.test.ts
+++ b/tests/data-source.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   fetchViewJson,
+  updateViewDocument,
   VIEW_REQUEST_TIMEOUT_MS,
 } from '../view/src/data-source.js';
 
@@ -78,5 +79,24 @@ describe('view data source', () => {
 
     await expect(request).rejects.toMatchObject({ name: 'AbortError' });
     expect(cancelledFetch).toHaveBeenCalledTimes(1);
+  });
+
+  // @lat: [[lat.md/view/specs#View Tests#Edits local Markdown safely#Does not replay uncertain writes]]
+  it('does not replay an interrupted editor write', async () => {
+    const fetch = vi
+      .fn()
+      .mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+    vi.stubGlobal('fetch', fetch);
+
+    await expect(
+      updateViewDocument('lat.md', {
+        baseContent: '# Before\n',
+        content: '# After\n',
+      }),
+    ).rejects.toMatchObject({
+      name: 'NetworkError',
+      message: 'The server connection was interrupted. Try again.',
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/document-edit.test.ts
+++ b/tests/document-edit.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyDocumentEdit,
+  ViewDocumentConflictError,
+} from '../src/view/document-edit.js';
+
+describe('document edit patches', () => {
+  it('applies an edit directly when the file is unchanged', () => {
+    expect(
+      applyDocumentEdit('one\ntwo\n', 'one\nchanged\n', 'one\ntwo\n'),
+    ).toEqual({
+      content: 'one\nchanged\n',
+      merged: false,
+    });
+  });
+
+  it('preserves concurrent changes outside the edited hunk', () => {
+    const base =
+      '# Guide\n\nIntro.\n\n## First\n\nOld first.\n\n## Second\n\nOld second.\n';
+    const edited = base.replace('Old first.', 'Edited first.');
+    const current = base.replace('Old second.', 'Concurrent second.');
+
+    expect(applyDocumentEdit(base, edited, current)).toEqual({
+      content: edited.replace('Old second.', 'Concurrent second.'),
+      merged: true,
+    });
+  });
+
+  it('rejects edits that overlap a concurrent change', () => {
+    const base = '# Guide\n\nOriginal paragraph.\n';
+    expect(() =>
+      applyDocumentEdit(
+        base,
+        '# Guide\n\nUser paragraph.\n',
+        '# Guide\n\nConcurrent paragraph.\n',
+      ),
+    ).toThrow(ViewDocumentConflictError);
+  });
+
+  it('accepts an already-applied edit as an idempotent retry', () => {
+    expect(applyDocumentEdit('old\n', 'new\n', 'new\n')).toEqual({
+      content: 'new\n',
+      merged: true,
+    });
+  });
+});

--- a/tests/editor-diff.test.ts
+++ b/tests/editor-diff.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { afterEach, describe, expect, it } from 'vitest';
+import { editorDiff } from '../view/src/editor-diff.js';
+
+Object.assign(Range.prototype, {
+  getBoundingClientRect: () => new DOMRect(),
+  getClientRects: () => [] as unknown as DOMRectList,
+});
+
+describe('CodeMirror editor diff', () => {
+  const views: EditorView[] = [];
+
+  afterEach(() => {
+    for (const view of views) view.destroy();
+    views.length = 0;
+    document.body.replaceChildren();
+  });
+
+  function diffClass(original: string, current: string): string {
+    const parent = document.createElement('div');
+    document.body.append(parent);
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({
+        doc: current,
+        extensions: editorDiff(original),
+      }),
+    });
+    views.push(view);
+    return parent.innerHTML;
+  }
+
+  it('distinguishes added, modified, and deleted lines in the gutter', () => {
+    expect(diffClass('one\ntwo\nthree', 'one\nadded\ntwo\nthree')).toContain(
+      'cm-editor-diff-marker-added',
+    );
+    expect(diffClass('one\ntwo\nthree', 'one\nTWO\nthree')).toContain(
+      'cm-editor-diff-marker-modified',
+    );
+    expect(diffClass('one\ntwo\nthree', 'one\nthree')).toContain(
+      'cm-editor-diff-marker-deleted',
+    );
+    expect(diffClass('one\ntwo\nthree', 'one\ntwo\nthree')).not.toMatch(
+      /cm-editor-diff-marker-(?:added|modified|deleted)/,
+    );
+  });
+});

--- a/tests/markdown-editor.test.tsx
+++ b/tests/markdown-editor.test.tsx
@@ -1,0 +1,347 @@
+// @vitest-environment jsdom
+
+import { EditorView } from '@codemirror/view';
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchViewDocumentSource, updateViewDocument } = vi.hoisted(() => ({
+  fetchViewDocumentSource: vi.fn(),
+  updateViewDocument: vi.fn(),
+}));
+
+vi.mock('../view/src/data-source.js', () => ({
+  fetchViewDocumentSource,
+  updateViewDocument,
+}));
+
+import { DocumentModeSwitch } from '../view/src/DocumentModeSwitch.js';
+import { MarkdownEditor } from '../view/src/MarkdownEditor.js';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+Object.assign(Range.prototype, {
+  getBoundingClientRect: () => new DOMRect(),
+  getClientRects: () => [] as unknown as DOMRectList,
+});
+
+function mountedEditor(container: HTMLElement): EditorView {
+  const element = container.querySelector<HTMLElement>('.cm-editor');
+  const view = element ? EditorView.findFromDOM(element) : null;
+  if (!view) throw new Error('Expected a mounted CodeMirror editor');
+  return view;
+}
+
+function replaceEditorContent(view: EditorView, content: string): void {
+  view.dispatch({
+    changes: { from: 0, to: view.state.doc.length, insert: content },
+  });
+}
+
+describe('MarkdownEditor', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    fetchViewDocumentSource.mockReset();
+    updateViewDocument.mockReset();
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it('switches presentation and saves the loaded Markdown source explicitly', async () => {
+    const original = '# Guide\n\nOriginal.\n';
+    const edited = '# Guide\n\nEdited.\n';
+    fetchViewDocumentSource.mockResolvedValue({
+      path: 'guide.md',
+      content: original,
+    });
+    const onDirtyChange = vi.fn();
+    updateViewDocument.mockResolvedValue({
+      path: 'guide.md',
+      content: edited,
+      merged: false,
+    });
+    const onModeChange = vi.fn();
+
+    await act(async () => {
+      root.render(
+        createElement(
+          'div',
+          null,
+          createElement(DocumentModeSwitch, {
+            mode: 'edit',
+            onChange: onModeChange,
+          }),
+          createElement(MarkdownEditor, {
+            active: true,
+            onDirtyChange,
+            path: 'guide.md',
+            revision: 0,
+          }),
+        ),
+      );
+    });
+
+    const modeButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        '.document-mode-switch button',
+      ),
+    );
+    expect(modeButtons.map((button) => button.textContent)).toEqual([
+      'view',
+      'edit',
+    ]);
+    expect(modeButtons[1].getAttribute('aria-pressed')).toBe('true');
+    expect(modeButtons[0].querySelector('svg')).toBeNull();
+    expect(modeButtons[1].querySelector('svg')).not.toBeNull();
+    await act(async () => modeButtons[0].click());
+    expect(onModeChange).toHaveBeenCalledWith('view');
+
+    const editor = mountedEditor(container);
+    expect(editor.state.doc.toString()).toBe(original);
+    expect(editor.contentDOM.getAttribute('aria-label')).toBe(
+      'Markdown source for guide.md',
+    );
+    expect(editor.contentDOM.classList.contains('cm-lineWrapping')).toBe(true);
+    await act(async () => {
+      replaceEditorContent(editor, edited);
+    });
+    expect(
+      container.querySelector('.cm-editor-diff-marker-modified'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('.cm-editor-diff-line-modified'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('.markdown-editor-status span')?.textContent,
+    ).toBe('Unsaved changes');
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+
+    await act(async () => {
+      editor.contentDOM.dispatchEvent(
+        new FocusEvent('blur', { bubbles: true }),
+      );
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(updateViewDocument).not.toHaveBeenCalled();
+
+    const save = container.querySelector<HTMLButtonElement>(
+      '.markdown-editor-status button',
+    );
+    expect(save?.disabled).toBe(false);
+    await act(async () => save?.click());
+    expect(updateViewDocument).toHaveBeenCalledWith('guide.md', {
+      baseContent: original,
+      content: edited,
+    });
+    expect(
+      container.querySelector('.markdown-editor-status span')?.textContent,
+    ).toBe('Saved');
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+    expect(save?.disabled).toBe(true);
+    expect(
+      container.querySelector('.cm-editor-diff-marker-modified'),
+    ).toBeNull();
+  });
+
+  it('leaves edits made during a save pending for another explicit save', async () => {
+    const original = '# Guide\n\nOriginal.\n';
+    const firstEdit = '# Guide\n\nFirst edit.\n';
+    const secondEdit = '# Guide\n\nSecond edit.\n';
+    let resolveFirst!: (value: {
+      path: string;
+      content: string;
+      merged: boolean;
+    }) => void;
+    fetchViewDocumentSource.mockResolvedValue({
+      path: 'guide.md',
+      content: original,
+    });
+    updateViewDocument
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        path: 'guide.md',
+        content: secondEdit,
+        merged: false,
+      });
+
+    await act(async () => {
+      root.render(
+        createElement(MarkdownEditor, {
+          active: true,
+          path: 'guide.md',
+          revision: 0,
+        }),
+      );
+    });
+    const editor = mountedEditor(container);
+    await act(async () => replaceEditorContent(editor, firstEdit));
+    const save = container.querySelector<HTMLButtonElement>(
+      '.markdown-editor-status button',
+    );
+    await act(async () => save?.click());
+    expect(updateViewDocument).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      replaceEditorContent(editor, secondEdit);
+      resolveFirst({
+        path: 'guide.md',
+        content: firstEdit,
+        merged: false,
+      });
+      await Promise.resolve();
+    });
+
+    expect(updateViewDocument).toHaveBeenCalledTimes(1);
+    expect(
+      container.querySelector('.markdown-editor-status span')?.textContent,
+    ).toBe('Unsaved changes');
+    expect(
+      container.querySelector('.cm-editor-diff-marker-modified'),
+    ).not.toBeNull();
+
+    await act(async () => save?.click());
+    expect(updateViewDocument).toHaveBeenNthCalledWith(2, 'guide.md', {
+      baseContent: firstEdit,
+      content: secondEdit,
+    });
+    expect(editor.state.doc.toString()).toBe(secondEdit);
+  });
+
+  it('flushes with the save shortcut', async () => {
+    const original = '# Guide\n\nOriginal.\n';
+    const edited = '# Guide\n\nSave now.\n';
+    fetchViewDocumentSource.mockResolvedValue({
+      path: 'guide.md',
+      content: original,
+    });
+    updateViewDocument.mockResolvedValue({
+      path: 'guide.md',
+      content: edited,
+      merged: false,
+    });
+
+    await act(async () => {
+      root.render(
+        createElement(MarkdownEditor, {
+          active: true,
+          path: 'guide.md',
+          revision: 0,
+        }),
+      );
+    });
+    const editor = mountedEditor(container);
+    await act(async () => {
+      replaceEditorContent(editor, edited);
+      editor.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          ctrlKey: true,
+          key: 's',
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(updateViewDocument).toHaveBeenCalledWith('guide.md', {
+      baseContent: original,
+      content: edited,
+    });
+  });
+
+  it('keeps a conflicting draft visible', async () => {
+    const original = '# Guide\n\nOriginal.\n';
+    const edited = '# Guide\n\nBrowser edit.\n';
+    fetchViewDocumentSource.mockResolvedValue({
+      path: 'guide.md',
+      content: original,
+    });
+    updateViewDocument.mockRejectedValue(
+      new Error(
+        'Could not save because this file changed in the same area. Your edits are still in the editor.',
+      ),
+    );
+
+    await act(async () => {
+      root.render(
+        createElement(MarkdownEditor, {
+          active: true,
+          path: 'guide.md',
+          revision: 0,
+        }),
+      );
+    });
+    const editor = mountedEditor(container);
+    await act(async () => replaceEditorContent(editor, edited));
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>('.markdown-editor-status button')
+        ?.click(),
+    );
+
+    expect(editor.state.doc.toString()).toBe(edited);
+    expect(
+      container.querySelector('.markdown-editor-status span')?.textContent,
+    ).toContain('Your edits are still in the editor');
+    expect(
+      container
+        .querySelector('.markdown-editor-status')
+        ?.getAttribute('data-state'),
+    ).toBe('error');
+  });
+
+  it('reloads a deferred disk update after the draft returns to clean', async () => {
+    const original = '# Guide\n\nOriginal.\n';
+    const edited = '# Guide\n\nBrowser edit.\n';
+    const external = '# Guide\n\nExternal edit.\n';
+    fetchViewDocumentSource
+      .mockResolvedValueOnce({ path: 'guide.md', content: original })
+      .mockResolvedValueOnce({ path: 'guide.md', content: external });
+
+    await act(async () => {
+      root.render(
+        createElement(MarkdownEditor, {
+          active: true,
+          path: 'guide.md',
+          revision: 0,
+        }),
+      );
+    });
+    const editor = mountedEditor(container);
+    await act(async () => replaceEditorContent(editor, edited));
+    await act(async () => {
+      root.render(
+        createElement(MarkdownEditor, {
+          active: true,
+          path: 'guide.md',
+          revision: 1,
+        }),
+      );
+    });
+    expect(fetchViewDocumentSource).toHaveBeenCalledTimes(1);
+
+    await act(async () => replaceEditorContent(editor, original));
+
+    expect(fetchViewDocumentSource).toHaveBeenCalledTimes(2);
+    expect(editor.state.doc.toString()).toBe(external);
+    expect(
+      container.querySelector(
+        '.cm-editor-diff-marker-added, .cm-editor-diff-marker-modified, .cm-editor-diff-marker-deleted',
+      ),
+    ).toBeNull();
+  });
+});

--- a/tests/unsaved-changes.test.ts
+++ b/tests/unsaved-changes.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  blockUnsavedChangesUnload,
+  confirmDiscardUnsavedChanges,
+  UNSAVED_CHANGES_MESSAGE,
+} from '../view/src/unsaved-changes.js';
+
+describe('unsaved document changes', () => {
+  it('asks before discarding a dirty draft but not a clean document', () => {
+    const confirm = vi.fn(() => false);
+
+    expect(confirmDiscardUnsavedChanges(false, confirm)).toBe(true);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(confirmDiscardUnsavedChanges(true, confirm)).toBe(false);
+    expect(confirm).toHaveBeenCalledWith(UNSAVED_CHANGES_MESSAGE);
+  });
+
+  it('requests the native unload prompt only for a dirty draft', () => {
+    const cleanEvent = {
+      preventDefault: vi.fn(),
+      returnValue: 'unchanged',
+    } as unknown as BeforeUnloadEvent;
+    const dirtyEvent = {
+      preventDefault: vi.fn(),
+      returnValue: 'unchanged',
+    } as unknown as BeforeUnloadEvent;
+
+    expect(blockUnsavedChangesUnload(false, cleanEvent)).toBe(false);
+    expect(cleanEvent.preventDefault).not.toHaveBeenCalled();
+    expect(blockUnsavedChangesUnload(true, dirtyEvent)).toBe(true);
+    expect(dirtyEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(dirtyEvent.returnValue).toBe('');
+  });
+});

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -36,6 +36,8 @@ import { buildGitDiffTree } from '../src/view/git-diff.js';
 import { renderMarkdown as renderMarkdownTree } from '../src/view/markdown.js';
 import type {
   ViewDocument,
+  ViewDocumentEditResponse,
+  ViewDocumentSource,
   ViewDocumentTree,
   ViewGraph,
   ViewIndex,
@@ -490,6 +492,13 @@ describe('lat ui', () => {
       devDependencies: Record<string, string>;
     };
     const buildOnlyPackages = [
+      '@codemirror/commands',
+      '@codemirror/lang-markdown',
+      '@codemirror/language',
+      '@codemirror/merge',
+      '@codemirror/state',
+      '@codemirror/view',
+      '@lezer/highlight',
       'katex',
       'maplibre-gl',
       'mermaid',
@@ -2314,6 +2323,94 @@ describe('lat ui git state', () => {
 });
 
 describe('lat ui live project index', () => {
+  // @lat: [[lat.md/view/specs#View Tests#Edits local Markdown safely]]
+  it('applies editor patches over unrelated disk changes and rejects overlaps', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'lat-view-edit-'));
+    const liveLatDir = join(root, 'lat.md');
+    const documentPath = join(liveLatDir, 'lat.md');
+    mkdirSync(liveLatDir);
+    const base =
+      '# Editable\n\nThe editable document.\n\n## User area\n\nOriginal user text.\n\n## Concurrent area\n\nOriginal concurrent text.\n';
+    writeFileSync(documentPath, base);
+    const live = await startViewServer(
+      {
+        latDir: liveLatDir,
+        projectRoot: root,
+        styler: plainStyler,
+        mode: 'cli',
+      },
+      { clientDir: root, git: false, watch: false },
+    );
+
+    try {
+      const sourceResponse = await fetch(
+        new URL('/api/document-source?path=lat.md', live.url),
+      );
+      expect(sourceResponse.status).toBe(200);
+      await expect(sourceResponse.json()).resolves.toEqual({
+        path: 'lat.md',
+        content: base,
+      } satisfies ViewDocumentSource);
+
+      const concurrent = base.replace(
+        'Original concurrent text.',
+        'Concurrent disk text.',
+      );
+      writeFileSync(documentPath, concurrent);
+      const edited = base.replace('Original user text.', 'Edited user text.');
+      const editResponse = await fetch(
+        new URL('/api/document?path=lat.md', live.url),
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ baseContent: base, content: edited }),
+        },
+      );
+      expect(editResponse.status).toBe(200);
+      const edit = (await editResponse.json()) as ViewDocumentEditResponse;
+      expect(edit.merged).toBe(true);
+      expect(edit.content).toContain('Edited user text.');
+      expect(edit.content).toContain('Concurrent disk text.');
+      expect(readFileSync(documentPath, 'utf8')).toBe(edit.content);
+      expect(live.store.snapshot.files.get('lat.md')?.content).toBe(
+        edit.content,
+      );
+
+      writeFileSync(
+        documentPath,
+        edit.content.replace('Edited user text.', 'Second disk edit.'),
+      );
+      const conflictResponse = await fetch(
+        new URL('/api/document?path=lat.md', live.url),
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            baseContent: edit.content,
+            content: edit.content.replace(
+              'Edited user text.',
+              'Second browser edit.',
+            ),
+          }),
+        },
+      );
+      expect(conflictResponse.status).toBe(409);
+      await expect(conflictResponse.json()).resolves.toEqual({
+        error:
+          'Could not save because this file changed in the same area. Your edits are still in the editor.',
+      });
+      expect(readFileSync(documentPath, 'utf8')).toContain('Second disk edit.');
+
+      const outside = await fetch(
+        new URL('/api/document-source?path=../README.md', live.url),
+      );
+      expect(outside.status).toBe(404);
+    } finally {
+      await live.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   // @lat: [[lat.md/view/specs#View Tests#Updates long-running views incrementally]]
   it('updates cached files, backlinks, code refs, and clients incrementally', async () => {
     const root = mkdtempSync(join(tmpdir(), 'lat-view-live-'));

--- a/view/src/App.tsx
+++ b/view/src/App.tsx
@@ -1,4 +1,6 @@
 import {
+  lazy,
+  Suspense,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -19,6 +21,7 @@ import { DEFAULT_VIEW_LOGO_TEXT } from '../../src/view/protocol';
 import latLogoUrl from '../../website/public/logo.svg?url';
 import { FileTree } from './FileTree';
 import { MarkdownContent } from './MarkdownContent';
+import { DocumentModeSwitch, type DocumentMode } from './DocumentModeSwitch';
 import { DocumentToc } from './DocumentToc';
 import { fetchViewJson } from './data-source';
 import GraphView, { preloadViewGraph } from './GraphView';
@@ -55,6 +58,12 @@ import {
   staticViewBasePath,
   viewPathname,
 } from './static-mode';
+import {
+  blockUnsavedChangesUnload,
+  confirmDiscardUnsavedChanges,
+} from './unsaved-changes';
+
+const MarkdownEditor = lazy(() => import('./MarkdownEditor'));
 
 type ViewRoute =
   | { kind: 'search' }
@@ -299,11 +308,14 @@ export function App() {
   const [mobileNavigationOpen, setMobileNavigationOpen] = useState(false);
   const [openErrorsFor, setOpenErrorsFor] = useState<string | null>(null);
   const [sectionOutputId, setSectionOutputId] = useState<string | null>(null);
+  const [documentMode, setDocumentMode] = useState<DocumentMode>('view');
   const [historyScroll, setHistoryScroll] = useState<ViewScrollPosition | null>(
     null,
   );
   const pageRef = useRef<ViewPage | null>(page);
   pageRef.current = page;
+  const documentDirty = useRef(false);
+  const acceptedLocation = useRef(currentLocation());
   const pageRequestId = useRef(0);
   const positionedLocation = useRef<string | null>(null);
   const routeLocation = useMemo(() => viewRouteIdentity(location), [location]);
@@ -362,6 +374,8 @@ export function App() {
               : undefined,
         );
   const activePath = route?.kind === 'markdown' ? route.path : null;
+  const editingDocument =
+    !staticView && route?.kind === 'markdown' && documentMode === 'edit';
   const activeExternalTarget = route?.kind === 'external' ? route.target : null;
   const gitHasChanges =
     Object.keys(index?.git?.files ?? NO_GIT_FILES).length > 0;
@@ -426,6 +440,19 @@ export function App() {
   }, [routeLocation]);
 
   useEffect(() => {
+    setDocumentMode('view');
+    documentDirty.current = false;
+  }, [activePath]);
+
+  useEffect(() => {
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      blockUnsavedChangesUnload(documentDirty.current, event);
+    };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, []);
+
+  useEffect(() => {
     if (!mobileNavigationOpen) return;
     const body = window.document.body;
     const navigation = window.document.getElementById('mobile-file-navigation');
@@ -458,8 +485,8 @@ export function App() {
 
   useEffect(() => {
     const onPopState = (event: PopStateEvent) => {
-      positionedLocation.current = null;
-      setHistoryScroll(historyScrollPosition(event.state));
+      const previousLocation = acceptedLocation.current;
+      const nextLocation = currentLocation();
       const nextDocumentPath = documentPath(window.location.pathname);
       const nextExternal = externalTarget(
         window.location.pathname,
@@ -472,6 +499,20 @@ export function App() {
             (nextExternal
               ? `${nextExternal.handle}:${nextExternal.path}`
               : null));
+      if (
+        !preservesDocument &&
+        !confirmDiscardUnsavedChanges(
+          documentDirty.current,
+          window.confirm.bind(window),
+        )
+      ) {
+        window.history.pushState(null, '', previousLocation);
+        return;
+      }
+      if (!preservesDocument) documentDirty.current = false;
+      acceptedLocation.current = nextLocation;
+      positionedLocation.current = null;
+      setHistoryScroll(historyScrollPosition(event.state));
       if (
         viewPathname(window.location.pathname) !== '/graph' &&
         !preservesDocument
@@ -669,12 +710,22 @@ export function App() {
             return external ? `${external.handle}:${external.path}` : null;
           })()) &&
       isSameRenderedDocument(new URL(window.location.href), url);
-    saveCurrentScroll();
     const nextLocation = `${url.pathname}${url.search}${url.hash}`;
     if (nextLocation === currentLocation()) {
       if (!page || error) retryPage();
       return;
     }
+    if (
+      !preservesDocument &&
+      !confirmDiscardUnsavedChanges(
+        documentDirty.current,
+        window.confirm.bind(window),
+      )
+    ) {
+      return;
+    }
+    if (!preservesDocument) documentDirty.current = false;
+    saveCurrentScroll();
     positionedLocation.current = null;
     setHistoryScroll(null);
     const state =
@@ -682,6 +733,7 @@ export function App() {
         ? searchHistoryState(returnTo)
         : null;
     window.history.pushState(state, '', url);
+    acceptedLocation.current = nextLocation;
     if (!preservesDocument) {
       pageRequestId.current++;
       setPage(null);
@@ -760,7 +812,31 @@ export function App() {
       return;
     }
     event.preventDefault();
+    if (
+      !graphMode &&
+      !confirmDiscardUnsavedChanges(
+        documentDirty.current,
+        window.confirm.bind(window),
+      )
+    ) {
+      return;
+    }
+    if (!graphMode) documentDirty.current = false;
     setPersistedGraphMode(!graphMode);
+  }
+
+  function onDocumentModeChange(mode: DocumentMode): void {
+    if (
+      mode === 'view' &&
+      !confirmDiscardUnsavedChanges(
+        documentDirty.current,
+        window.confirm.bind(window),
+      )
+    ) {
+      return;
+    }
+    if (mode === 'view') documentDirty.current = false;
+    setDocumentMode(mode);
   }
 
   function onDocumentClick(event: MouseEvent<HTMLElement>): void {
@@ -917,36 +993,46 @@ export function App() {
           />
         ) : page?.kind === 'markdown' ? (
           <div className="document-layout">
-            <DocumentToc
-              gitEnabled={gitEnabled}
-              items={page.document.tableOfContents}
-              onNavigate={onNavigationClick}
-            />
+            {!editingDocument && (
+              <DocumentToc
+                gitEnabled={gitEnabled}
+                items={page.document.tableOfContents}
+                onNavigate={onNavigationClick}
+              />
+            )}
             <div className="document-column">
               <div className="document-header">
-                <div className="document-metadata">
-                  <div className="document-path">{page.document.path}</div>
-                  {page.document.frontmatter.requireCodeMention && (
-                    <div
-                      className="document-flag"
-                      title="Every leaf section must have an @lat code reference"
-                    >
-                      Code mentions required
-                    </div>
-                  )}
-                  {page.document.errors.length > 0 && (
-                    <button
-                      aria-controls="document-errors"
-                      aria-expanded={errorsOpen}
-                      className="document-error-toggle"
-                      onClick={() =>
-                        setOpenErrorsFor(errorsOpen ? null : errorPanelKey)
-                      }
-                      type="button"
-                    >
-                      {page.document.errors.length}{' '}
-                      {page.document.errors.length === 1 ? 'error' : 'errors'}
-                    </button>
+                <div className="document-header-line">
+                  <div className="document-metadata">
+                    <div className="document-path">{page.document.path}</div>
+                    {page.document.frontmatter.requireCodeMention && (
+                      <div
+                        className="document-flag"
+                        title="Every leaf section must have an @lat code reference"
+                      >
+                        Code mentions required
+                      </div>
+                    )}
+                    {page.document.errors.length > 0 && (
+                      <button
+                        aria-controls="document-errors"
+                        aria-expanded={errorsOpen}
+                        className="document-error-toggle"
+                        onClick={() =>
+                          setOpenErrorsFor(errorsOpen ? null : errorPanelKey)
+                        }
+                        type="button"
+                      >
+                        {page.document.errors.length}{' '}
+                        {page.document.errors.length === 1 ? 'error' : 'errors'}
+                      </button>
+                    )}
+                  </div>
+                  {!staticView && route?.kind === 'markdown' && (
+                    <DocumentModeSwitch
+                      mode={documentMode}
+                      onChange={onDocumentModeChange}
+                    />
                   )}
                 </div>
                 {errorsOpen && (
@@ -956,7 +1042,24 @@ export function App() {
                   />
                 )}
               </div>
-              {documentTree && (
+              {editingDocument && route?.kind === 'markdown' && (
+                <Suspense
+                  fallback={
+                    <div className="markdown-editor-state">Loading editor…</div>
+                  }
+                >
+                  <MarkdownEditor
+                    active
+                    key={route.path}
+                    onDirtyChange={(dirty) => {
+                      documentDirty.current = dirty;
+                    }}
+                    path={route.path}
+                    revision={projectChange.markdownGeneration}
+                  />
+                </Suspense>
+              )}
+              {!editingDocument && documentTree && (
                 <MarkdownContent
                   backReferences={page.document.backReferences}
                   onClick={onDocumentClick}

--- a/view/src/DocumentModeSwitch.tsx
+++ b/view/src/DocumentModeSwitch.tsx
@@ -1,0 +1,34 @@
+export type DocumentMode = 'view' | 'edit';
+
+export function DocumentModeSwitch({
+  mode,
+  onChange,
+}: {
+  mode: DocumentMode;
+  onChange: (mode: DocumentMode) => void;
+}) {
+  return (
+    <div
+      aria-label="Document presentation"
+      className="document-mode-switch"
+      role="group"
+    >
+      {(['view', 'edit'] as const).map((value) => (
+        <button
+          aria-pressed={mode === value}
+          key={value}
+          onClick={() => onChange(value)}
+          type="button"
+        >
+          {value === 'edit' && (
+            <svg aria-hidden="true" viewBox="0 0 14 14">
+              <path d="m3 10.8.5-2.5 5.8-5.8 1.4 1.4-5.8 5.8-2.9.1Z" />
+              <path d="m8.5 3.3 1.4 1.4" />
+            </svg>
+          )}
+          <span>{value}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/view/src/MarkdownEditor.tsx
+++ b/view/src/MarkdownEditor.tsx
@@ -1,0 +1,343 @@
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  indentWithTab,
+} from '@codemirror/commands';
+import { markdown } from '@codemirror/lang-markdown';
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { EditorState, Transaction } from '@codemirror/state';
+import {
+  drawSelection,
+  dropCursor,
+  EditorView,
+  highlightActiveLine,
+  highlightActiveLineGutter,
+  highlightSpecialChars,
+  keymap,
+  lineNumbers,
+} from '@codemirror/view';
+import { tags } from '@lezer/highlight';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchViewDocumentSource, updateViewDocument } from './data-source';
+import { editorDiff, setEditorDiffOriginal } from './editor-diff';
+
+type EditorStatus = {
+  kind: 'loading' | 'dirty' | 'saving' | 'saved' | 'error';
+  message: string;
+};
+
+const markdownHighlightStyle = HighlightStyle.define([
+  { tag: tags.heading, color: 'var(--syntax-title)', fontWeight: '700' },
+  { tag: [tags.link, tags.url], color: 'var(--link)' },
+  { tag: tags.emphasis, fontStyle: 'italic' },
+  { tag: tags.strong, fontWeight: '700' },
+  {
+    tag: [tags.keyword, tags.atom, tags.bool],
+    color: 'var(--syntax-keyword)',
+  },
+  { tag: [tags.string, tags.inserted], color: 'var(--syntax-string)' },
+  { tag: tags.number, color: 'var(--syntax-number)' },
+  { tag: [tags.comment, tags.quote], color: 'var(--syntax-comment)' },
+  { tag: [tags.monospace, tags.processingInstruction], color: 'var(--muted)' },
+  { tag: tags.invalid, color: 'var(--danger)' },
+]);
+
+export function MarkdownEditor({
+  active,
+  onDirtyChange,
+  path,
+  revision,
+}: {
+  active: boolean;
+  onDirtyChange?: (dirty: boolean) => void;
+  path: string;
+  revision: number;
+}) {
+  const [sourceLoaded, setSourceLoaded] = useState(false);
+  const [loadRevision, setLoadRevision] = useState(0);
+  const [dirty, setDirty] = useState(false);
+  const [status, setStatus] = useState<EditorStatus>({
+    kind: 'loading',
+    message: 'Loading source…',
+  });
+  const baseContent = useRef<string | null>(null);
+  const draftContent = useRef<string | null>(null);
+  const saveInFlight = useRef(false);
+  const mounted = useRef(true);
+  const onDirtyChangeRef = useRef(onDirtyChange);
+  onDirtyChangeRef.current = onDirtyChange;
+  const editorHost = useRef<HTMLDivElement>(null);
+  const editorView = useRef<EditorView | null>(null);
+  const applyingServerContent = useRef(false);
+  const loadedRevision = useRef(revision);
+
+  const setVisibleStatus = useCallback((next: EditorStatus) => {
+    if (mounted.current) setStatus(next);
+  }, []);
+
+  const setVisibleDirty = useCallback((next: boolean) => {
+    if (mounted.current) setDirty(next);
+    onDirtyChangeRef.current?.(next);
+  }, []);
+
+  const replaceEditorContent = useCallback(
+    (content: string, resetDiff = false) => {
+      const view = editorView.current;
+      if (!view) return;
+      const changed = view.state.doc.toString() !== content;
+      if (!changed && !resetDiff) return;
+      applyingServerContent.current = true;
+      try {
+        view.dispatch({
+          changes: changed
+            ? { from: 0, to: view.state.doc.length, insert: content }
+            : undefined,
+          effects: resetDiff ? setEditorDiffOriginal.of(content) : undefined,
+          annotations: Transaction.addToHistory.of(false),
+        });
+      } finally {
+        applyingServerContent.current = false;
+      }
+    },
+    [],
+  );
+
+  const resetDiffOriginal = useCallback((content: string) => {
+    editorView.current?.dispatch({
+      effects: setEditorDiffOriginal.of(content),
+      annotations: Transaction.addToHistory.of(false),
+    });
+  }, []);
+
+  const saveDraft = useCallback(async () => {
+    if (saveInFlight.current) return;
+    if (
+      baseContent.current === null ||
+      draftContent.current === null ||
+      baseContent.current === draftContent.current
+    ) {
+      return;
+    }
+    saveInFlight.current = true;
+    const sentBase = baseContent.current;
+    const sentContent = draftContent.current;
+    setVisibleStatus({ kind: 'saving', message: 'Saving…' });
+    try {
+      const result = await updateViewDocument(path, {
+        baseContent: sentBase,
+        content: sentContent,
+      });
+      if (draftContent.current === sentContent) {
+        baseContent.current = result.content;
+        draftContent.current = result.content;
+        replaceEditorContent(result.content, true);
+        setVisibleDirty(false);
+        setVisibleStatus({
+          kind: 'saved',
+          message: result.merged ? 'Saved with newer disk changes' : 'Saved',
+        });
+      } else {
+        // The submitted source is now the base for the remaining local delta.
+        // A later explicit save applies that delta to the latest disk content.
+        baseContent.current = sentContent;
+        resetDiffOriginal(sentContent);
+        setVisibleDirty(true);
+        setVisibleStatus({ kind: 'dirty', message: 'Unsaved changes' });
+      }
+    } catch (reason) {
+      setVisibleDirty(true);
+      setVisibleStatus({
+        kind: 'error',
+        message: reason instanceof Error ? reason.message : String(reason),
+      });
+    } finally {
+      saveInFlight.current = false;
+    }
+  }, [
+    path,
+    replaceEditorContent,
+    resetDiffOriginal,
+    setVisibleDirty,
+    setVisibleStatus,
+  ]);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!active || sourceLoaded) return;
+    const controller = new AbortController();
+    setStatus({ kind: 'loading', message: 'Loading source…' });
+    void fetchViewDocumentSource(path, controller.signal)
+      .then((source) => {
+        baseContent.current = source.content;
+        draftContent.current = source.content;
+        setSourceLoaded(true);
+        setVisibleDirty(false);
+        setStatus({ kind: 'saved', message: 'Saved' });
+      })
+      .catch((reason: unknown) => {
+        if (reason instanceof Error && reason.name === 'AbortError') return;
+        setStatus({
+          kind: 'error',
+          message: reason instanceof Error ? reason.message : String(reason),
+        });
+      });
+    return () => controller.abort();
+  }, [active, loadRevision, path, setVisibleDirty, sourceLoaded]);
+
+  useEffect(() => {
+    if (!sourceLoaded || revision === loadedRevision.current) return;
+    if (saveInFlight.current || baseContent.current !== draftContent.current) {
+      return;
+    }
+    loadedRevision.current = revision;
+    if (!active) {
+      baseContent.current = null;
+      draftContent.current = null;
+      setSourceLoaded(false);
+      return;
+    }
+    const controller = new AbortController();
+    void fetchViewDocumentSource(path, controller.signal)
+      .then((source) => {
+        baseContent.current = source.content;
+        draftContent.current = source.content;
+        replaceEditorContent(source.content, true);
+        setSourceLoaded(true);
+        setVisibleDirty(false);
+        setStatus({ kind: 'saved', message: 'Saved' });
+      })
+      .catch((reason: unknown) => {
+        if (reason instanceof Error && reason.name === 'AbortError') return;
+        setStatus({
+          kind: 'error',
+          message: reason instanceof Error ? reason.message : String(reason),
+        });
+      });
+    return () => controller.abort();
+  }, [
+    active,
+    path,
+    replaceEditorContent,
+    revision,
+    setVisibleDirty,
+    sourceLoaded,
+    status.kind,
+  ]);
+
+  const updateContent = useCallback(
+    (next: string): void => {
+      draftContent.current = next;
+      const nextDirty = saveInFlight.current || next !== baseContent.current;
+      setVisibleDirty(nextDirty);
+      if (!nextDirty) {
+        setStatus({ kind: 'saved', message: 'Saved' });
+        return;
+      }
+      setStatus({ kind: 'dirty', message: 'Unsaved changes' });
+    },
+    [setVisibleDirty],
+  );
+
+  useEffect(() => {
+    if (!active || !sourceLoaded || !editorHost.current) return;
+    const view = new EditorView({
+      parent: editorHost.current,
+      state: EditorState.create({
+        doc: draftContent.current ?? '',
+        extensions: [
+          history(),
+          lineNumbers(),
+          highlightActiveLineGutter(),
+          highlightSpecialChars(),
+          drawSelection(),
+          dropCursor(),
+          highlightActiveLine(),
+          EditorView.lineWrapping,
+          markdown(),
+          syntaxHighlighting(markdownHighlightStyle),
+          editorDiff(draftContent.current ?? ''),
+          EditorView.contentAttributes.of({
+            'aria-label': `Markdown source for ${path}`,
+            autocapitalize: 'off',
+            autocomplete: 'off',
+            autocorrect: 'off',
+            spellcheck: 'false',
+          }),
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged && !applyingServerContent.current) {
+              updateContent(update.state.doc.toString());
+            }
+          }),
+          keymap.of([
+            {
+              key: 'Mod-s',
+              preventDefault: true,
+              run: () => {
+                void saveDraft();
+                return true;
+              },
+            },
+            indentWithTab,
+            ...defaultKeymap,
+            ...historyKeymap,
+          ]),
+        ],
+      }),
+    });
+    editorView.current = view;
+    view.focus();
+    return () => {
+      editorView.current = null;
+      view.destroy();
+    };
+  }, [active, path, saveDraft, sourceLoaded, updateContent]);
+
+  if (!active) return null;
+
+  if (!sourceLoaded) {
+    return (
+      <div className="markdown-editor-state" data-state={status.kind}>
+        <span>{status.message}</span>
+        {status.kind === 'error' && (
+          <button
+            onClick={() => setLoadRevision((value) => value + 1)}
+            type="button"
+          >
+            Retry
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <section className="markdown-editor" aria-label={`Editing ${path}`}>
+      <div
+        aria-live="polite"
+        className="markdown-editor-status"
+        data-state={status.kind}
+      >
+        <span>{status.message}</span>
+        <button
+          disabled={!dirty || status.kind === 'saving'}
+          onClick={() => void saveDraft()}
+          type="button"
+        >
+          Save
+        </button>
+      </div>
+      <div className="markdown-editor-body">
+        <div ref={editorHost} />
+      </div>
+    </section>
+  );
+}
+
+export default MarkdownEditor;

--- a/view/src/data-source.ts
+++ b/view/src/data-source.ts
@@ -1,4 +1,7 @@
 import type {
+  ViewDocumentEditRequest,
+  ViewDocumentEditResponse,
+  ViewDocumentSource,
   ViewError,
   ViewExternalDocument,
   ViewSourceDocument,
@@ -36,7 +39,11 @@ function isTransientRequestError(reason: unknown): boolean {
   );
 }
 
-async function fetchJsonFile<T>(url: string, signal?: AbortSignal): Promise<T> {
+async function fetchJsonFile<T>(
+  url: string,
+  signal?: AbortSignal,
+  init: RequestInit = {},
+): Promise<T> {
   const controller = new AbortController();
   let timedOut = false;
   const abort = () => controller.abort();
@@ -46,10 +53,15 @@ async function fetchJsonFile<T>(url: string, signal?: AbortSignal): Promise<T> {
     timedOut = true;
     controller.abort();
   }, VIEW_REQUEST_TIMEOUT_MS);
+  const method = (init.method ?? 'GET').toUpperCase();
+  const attempts = method === 'GET' || method === 'HEAD' ? 2 : 1;
   try {
-    for (let attempt = 0; attempt < 2; attempt++) {
+    for (let attempt = 0; attempt < attempts; attempt++) {
       try {
-        const response = await fetch(url, { signal: controller.signal });
+        const response = await fetch(url, {
+          ...init,
+          signal: controller.signal,
+        });
         const value = (await response.json()) as T | ViewError;
         if (!response.ok) {
           throw new Error(
@@ -67,7 +79,7 @@ async function fetchJsonFile<T>(url: string, signal?: AbortSignal): Promise<T> {
         }
         if (controller.signal.aborted) throw reason;
         if (!isTransientRequestError(reason)) throw reason;
-        if (attempt === 0) continue;
+        if (attempt + 1 < attempts) continue;
         throw new ViewRequestConnectionError(
           'The server connection was interrupted. Try again.',
         );
@@ -80,6 +92,38 @@ async function fetchJsonFile<T>(url: string, signal?: AbortSignal): Promise<T> {
     globalThis.clearTimeout(timeout);
     signal?.removeEventListener('abort', abort);
   }
+}
+
+export function fetchViewDocumentSource(
+  path: string,
+  signal?: AbortSignal,
+): Promise<ViewDocumentSource> {
+  if (staticViewBasePath()) {
+    return Promise.reject(new Error('Static views cannot edit documents'));
+  }
+  return fetchJsonFile<ViewDocumentSource>(
+    `/api/document-source?path=${encodeURIComponent(path)}`,
+    signal,
+  );
+}
+
+export function updateViewDocument(
+  path: string,
+  edit: ViewDocumentEditRequest,
+  signal?: AbortSignal,
+): Promise<ViewDocumentEditResponse> {
+  if (staticViewBasePath()) {
+    return Promise.reject(new Error('Static views cannot edit documents'));
+  }
+  return fetchJsonFile<ViewDocumentEditResponse>(
+    `/api/document?path=${encodeURIComponent(path)}`,
+    signal,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(edit),
+    },
+  );
 }
 
 function staticDataUrl(path: string): string {

--- a/view/src/editor-diff.ts
+++ b/view/src/editor-diff.ts
@@ -1,0 +1,159 @@
+import { Chunk } from '@codemirror/merge';
+import {
+  RangeSet,
+  StateEffect,
+  StateField,
+  Text,
+  type Extension,
+} from '@codemirror/state';
+import {
+  Decoration,
+  EditorView,
+  GutterMarker,
+  gutter,
+  type DecorationSet,
+} from '@codemirror/view';
+
+type EditorDiffKind = 'added' | 'modified' | 'deleted';
+
+type EditorDiffState = {
+  original: Text;
+  chunks: readonly Chunk[];
+  markers: RangeSet<GutterMarker>;
+  decorations: DecorationSet;
+};
+
+const DIFF_CONFIG = { scanLimit: 500, timeout: 50 } as const;
+
+class EditorDiffMarker extends GutterMarker {
+  constructor(readonly kind: EditorDiffKind | 'spacer') {
+    super();
+  }
+
+  override eq(other: GutterMarker): boolean {
+    return other instanceof EditorDiffMarker && other.kind === this.kind;
+  }
+
+  override toDOM(): HTMLElement {
+    const marker = document.createElement('span');
+    marker.className = `cm-editor-diff-marker cm-editor-diff-marker-${this.kind}`;
+    if (this.kind !== 'spacer') {
+      marker.title = `${this.kind[0].toUpperCase()}${this.kind.slice(1)} since opening the editor`;
+    }
+    return marker;
+  }
+}
+
+const diffMarkers = {
+  added: new EditorDiffMarker('added'),
+  modified: new EditorDiffMarker('modified'),
+  deleted: new EditorDiffMarker('deleted'),
+} as const;
+const spacerMarker = new EditorDiffMarker('spacer');
+
+function text(source: string): Text {
+  return Text.of(source.split(/\r\n?|\n/));
+}
+
+function strongerKind(
+  previous: EditorDiffKind | undefined,
+  next: EditorDiffKind,
+): EditorDiffKind {
+  if (!previous || previous === next) return next;
+  return 'modified';
+}
+
+function presentDiff(
+  original: Text,
+  current: Text,
+  chunks: readonly Chunk[],
+): EditorDiffState {
+  const changedLines = new Map<number, EditorDiffKind>();
+  for (const chunk of chunks) {
+    const kind: EditorDiffKind =
+      chunk.fromB === chunk.toB
+        ? 'deleted'
+        : chunk.fromA === chunk.toA
+          ? 'added'
+          : 'modified';
+    const firstLine = current.lineAt(Math.min(chunk.fromB, current.length));
+    if (kind === 'deleted') {
+      changedLines.set(
+        firstLine.from,
+        strongerKind(changedLines.get(firstLine.from), kind),
+      );
+      continue;
+    }
+    const lastLine = current.lineAt(Math.min(chunk.endB, current.length));
+    for (let number = firstLine.number; number <= lastLine.number; number++) {
+      const position = current.line(number).from;
+      changedLines.set(
+        position,
+        strongerKind(changedLines.get(position), kind),
+      );
+    }
+  }
+
+  const markers = [...changedLines]
+    .sort(([left], [right]) => left - right)
+    .map(([position, kind]) => diffMarkers[kind].range(position));
+  const decorations = [...changedLines]
+    .filter(([, kind]) => kind !== 'deleted')
+    .sort(([left], [right]) => left - right)
+    .map(([position, kind]) =>
+      Decoration.line({
+        class: `cm-editor-diff-line cm-editor-diff-line-${kind}`,
+      }).range(position),
+    );
+  return {
+    original,
+    chunks,
+    markers: RangeSet.of(markers),
+    decorations: Decoration.set(decorations),
+  };
+}
+
+export const setEditorDiffOriginal = StateEffect.define<string>();
+
+export function editorDiff(originalSource: string): Extension {
+  const initialOriginal = text(originalSource);
+  return StateField.define<EditorDiffState>({
+    create(state) {
+      const chunks = Chunk.build(initialOriginal, state.doc, DIFF_CONFIG);
+      return presentDiff(initialOriginal, state.doc, chunks);
+    },
+    update(value, transaction) {
+      const replacement = transaction.effects.find((effect) =>
+        effect.is(setEditorDiffOriginal),
+      );
+      if (replacement) {
+        const original = text(replacement.value);
+        return presentDiff(
+          original,
+          transaction.state.doc,
+          Chunk.build(original, transaction.state.doc, DIFF_CONFIG),
+        );
+      }
+      if (!transaction.docChanged) return value;
+      const chunks = Chunk.updateB(
+        value.chunks,
+        value.original,
+        transaction.state.doc,
+        transaction.changes,
+        DIFF_CONFIG,
+      );
+      return presentDiff(value.original, transaction.state.doc, chunks);
+    },
+    provide: (field) => [
+      gutter({
+        class: 'cm-editorDiffGutter',
+        initialSpacer: () => spacerMarker,
+        markers: (view) => view.state.field(field).markers,
+      }),
+      EditorView.decorations.from(
+        field,
+        (value: EditorDiffState) => value.decorations,
+      ),
+    ],
+  });
+}

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -443,6 +443,66 @@ a {
   margin-bottom: 34px;
 }
 
+.document-header-line {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.document-header-line > .document-metadata {
+  min-width: 0;
+  flex: 1;
+}
+
+.document-mode-switch {
+  display: inline-flex;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+}
+
+.document-mode-switch button {
+  display: inline-flex;
+  padding: 4px 9px;
+  align-items: center;
+  gap: 4px;
+  color: var(--muted);
+  font: inherit;
+  font-size: 11px;
+  line-height: 1.2;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+}
+
+.document-mode-switch svg {
+  width: 11px;
+  height: 11px;
+  opacity: 0.7;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.15;
+}
+
+.document-mode-switch button + button {
+  border-left: 1px solid var(--panel-border);
+}
+
+.document-mode-switch button:hover {
+  color: var(--text);
+  background: var(--reference-control-hover);
+}
+
+.document-mode-switch button[aria-pressed='true'] {
+  color: var(--text);
+  background: var(--reference-control);
+}
+
 .document-layout {
   display: grid;
   grid-template-columns: minmax(0, 760px) 286px;
@@ -678,6 +738,193 @@ a {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 11px;
   font-weight: 700;
+}
+
+.markdown-editor,
+.markdown-editor-state {
+  width: 100%;
+  max-width: 760px;
+}
+
+.markdown-editor {
+  --editor-font-size: 13px;
+
+  overflow: hidden;
+  background: var(--code);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+}
+
+.markdown-editor-status {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-height: 30px;
+  padding: 8px 12px 7px;
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  line-height: 14px;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.markdown-editor-status button {
+  padding: 2px 8px;
+  color: var(--muted);
+  font: inherit;
+  border: 1px solid var(--panel-border);
+  border-radius: 4px;
+  background: var(--reference-control);
+  cursor: pointer;
+}
+
+.markdown-editor-status button:hover:not(:disabled) {
+  color: var(--text-secondary);
+  background: var(--reference-control-hover);
+}
+
+.markdown-editor-status button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.markdown-editor-status[data-state='dirty'],
+.markdown-editor-status[data-state='saving'] {
+  color: var(--warning);
+}
+
+.markdown-editor-status[data-state='error'] {
+  color: var(--danger);
+}
+
+.markdown-editor-body {
+  min-width: 0;
+}
+
+.markdown-editor .cm-editor {
+  min-height: calc(100vh - 180px);
+  color: var(--text);
+  background: transparent;
+}
+
+.markdown-editor .cm-editor.cm-focused {
+  outline: none;
+}
+
+.markdown-editor .cm-scroller {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: var(--editor-font-size);
+  line-height: 1.6;
+  overflow: auto;
+}
+
+.markdown-editor .cm-content {
+  min-height: calc(100vh - 180px);
+  padding: 18px 0 28px;
+  caret-color: var(--text);
+  tab-size: 2;
+}
+
+.markdown-editor .cm-line {
+  padding: 0 20px;
+}
+
+.markdown-editor .cm-gutters {
+  color: var(--muted);
+  background: var(--panel);
+  border-right: 1px solid var(--panel-border);
+}
+
+.markdown-editor .cm-lineNumbers .cm-gutterElement {
+  min-width: 42px;
+  padding: 0 10px 0 8px;
+}
+
+.markdown-editor .cm-activeLine,
+.markdown-editor .cm-activeLineGutter {
+  background: color-mix(in srgb, var(--sidebar-selection) 45%, transparent);
+}
+
+.markdown-editor .cm-editorDiffGutter {
+  width: 7px;
+  background: var(--panel);
+}
+
+.markdown-editor .cm-editorDiffGutter .cm-gutterElement {
+  display: flex;
+  padding: 0 2px;
+  align-items: stretch;
+}
+
+.markdown-editor .cm-editor-diff-marker {
+  display: block;
+  width: 3px;
+  min-height: 100%;
+  border-radius: 2px;
+}
+
+.markdown-editor .cm-editor-diff-marker-added {
+  background: var(--success);
+}
+
+.markdown-editor .cm-editor-diff-marker-modified {
+  background: var(--warning);
+}
+
+.markdown-editor .cm-editor-diff-marker-deleted {
+  background: var(--danger);
+}
+
+.markdown-editor .cm-editor-diff-marker-spacer {
+  visibility: hidden;
+}
+
+.markdown-editor .cm-editor-diff-line-added {
+  background: color-mix(in srgb, var(--success) 8%, transparent);
+}
+
+.markdown-editor .cm-editor-diff-line-modified {
+  background: color-mix(in srgb, var(--warning) 8%, transparent);
+}
+
+.markdown-editor .cm-cursor,
+.markdown-editor .cm-dropCursor {
+  border-left-color: var(--text);
+}
+
+.markdown-editor .cm-selectionBackground,
+.markdown-editor .cm-content ::selection,
+.markdown-editor .cm-focused .cm-selectionBackground {
+  background: var(--sidebar-selection);
+}
+
+.markdown-editor-state {
+  display: flex;
+  min-height: 140px;
+  padding: 24px;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--muted);
+  font-size: 13px;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+}
+
+.markdown-editor-state[data-state='error'] {
+  color: var(--danger);
+}
+
+.markdown-editor-state button {
+  padding: 5px 9px;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid currentColor;
+  border-radius: 5px;
 }
 
 .document-error-message {
@@ -2626,6 +2873,12 @@ a.wiki-link-active {
     grid-area: document;
     min-width: 0;
   }
+
+  .markdown-editor,
+  .markdown-editor-state {
+    grid-area: document;
+    min-width: 0;
+  }
 }
 
 @media (width < 64rem) {
@@ -2765,6 +3018,24 @@ a.wiki-link-active {
     --mobile-gutter: clamp(20px, 5vw, 48px);
 
     padding: 28px clamp(20px, 5vw, 48px) 80px;
+  }
+
+  .document-header-line {
+    align-items: flex-start;
+  }
+
+  .markdown-editor .cm-editor,
+  .markdown-editor .cm-content {
+    min-height: calc(100dvh - 240px);
+  }
+
+  .markdown-editor .cm-line {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
+  .markdown-editor {
+    --editor-font-size: 16px;
   }
 
   .document-toc {

--- a/view/src/unsaved-changes.ts
+++ b/view/src/unsaved-changes.ts
@@ -1,0 +1,19 @@
+export const UNSAVED_CHANGES_MESSAGE =
+  'You have unsaved changes. Discard them?';
+
+export function confirmDiscardUnsavedChanges(
+  dirty: boolean,
+  confirm: (message: string) => boolean,
+): boolean {
+  return !dirty || confirm(UNSAVED_CHANGES_MESSAGE);
+}
+
+export function blockUnsavedChangesUnload(
+  dirty: boolean,
+  event: BeforeUnloadEvent,
+): boolean {
+  if (!dirty) return false;
+  event.preventDefault();
+  event.returnValue = '';
+  return true;
+}


### PR DESCRIPTION
## Summary

- add a lazy-loaded CodeMirror editor behind a minimal View/Edit switch for live local Markdown files
- show unsaved line changes in the editor gutter and require explicit Save or the platform save shortcut
- preserve unrelated concurrent disk changes by applying the draft delta to the latest file, while retaining conflicting drafts for review
- confirm before discarding dirty drafts and keep static and external documents read-only
- avoid replaying editor PATCH requests when the transport outcome is uncertain

## Verification

- pnpm build
- pnpm test (301/301)
- pnpm typecheck
- lat check