### PR TITLE
Bump to 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lat.md",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "A knowledge graph for your codebase, written in markdown",
   "type": "module",
   "packageManager": "pnpm@10.30.2",


### PR DESCRIPTION
## 0.13.0

Lat can now connect a project graph to pinned upstream documentation and source code, browse and edit the graph in a local UI, and validate large projects much faster.

### Link upstream documentation and source

External sources make upstream documentation and code first-class, validated parts of a project's knowledge graph without copying them into the repository. Commit pinning keeps every reference reproducible for people, agents, CI, and published docs.

Run `lat external add` alone for interactive setup, or supply the complete source definition for non-interactive use:

```bash
lat external add node https://github.com/nodejs/node \
  --commit main \
  --prefix doc \
  --default-file-extension md \
  --strategy fetch
```

Lat resolves `main` to an immutable commit. You can then link directly to an upstream document heading or source symbol:

```md
[[node:api/assert#Strict assertion mode]]
[[react:packages/react/src/ReactClient.js#createElement]]
```

`lat check` retrieves only referenced files and validates the file and named fragment. External links also work with `section`, `expand`, `refs`, code mentions, MCP, backlinks, the graph, the UI, and static exports.

External documents may be Markdown, reStructuredText, or AsciiDoc. Supported source files use the same symbol links as local code. Sources can fetch individual files, use a managed partial checkout, or read a verified machine-local checkout without changing authored links.

### Browse, edit, and publish the graph

```bash
lat ui
lat ui build ./site
```

The new browser provides document and source navigation, backlinks, semantic search, validation errors, Git diffs, a table of contents, and a graph workspace. Referenced external files appear beside local documentation.

Local Markdown can be edited with conflict-aware saves that preserve unrelated disk changes. The renderer supports GFM, syntax highlighting, math, Mermaid, maps, and STL previews. `lat ui build` produces a portable, read-only static site.

### Faster, broader validation

Markdown, source symbols, and external documents now share versioned persistent analysis caches. Parsing and project discovery run concurrently, while format parsers load only on cache misses. In the large `nub` project, warm checks fell from roughly 4–5 seconds to about 200 ms; use `lat check --profile` to inspect a run.

`lat check` now also validates ordinary Markdown links, images, reference definitions, and GitHub-style heading fragments. Wiki links may explicitly include `.md`, and fragmentless links may target any existing repository file or directory.

Dart and Java join the supported source languages for symbol links, code mentions, external sources, highlighting, and caching.

### Other changes

- `lat search --debug` shows similarity scores; `--threshold` defaults to `0.35`.
- `lat init` defaults new projects to local embeddings unless hosted embeddings are explicitly configured.
- Codex lifecycle hooks are supported. The Stop hook accounts for tracked and untracked work and cleanly supports projects without Git.

### Behavior changes

- Undefined Markdown reference-style links are now errors. Define the reference or escape a literal opening bracket as `\[`.
- Search omits matches below `0.35` by default; pass `--threshold 0` to retain all non-negative matches.
- Parser and external-source cache schema changes invalidate and rebuild caches automatically.

### Validation

- `pnpm buildall`
- `pnpm test` — 306 tests passed
- freshly built `lat check`
- `npm pack --dry-run --json`
