### PR TITLE
Serve Markdown from extensionless UI routes

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -22,6 +22,8 @@ The live server's default-self Content Security Policy explicitly permits only O
 
 Read APIs accept only walked vault files or supported project source paths and reject traversal and escaping symlinks.
 
+Local Markdown documents use extensionless `/docs/...` browser routes. Appending `.md` addresses the exact Markdown source instead, with `text/markdown` from the live server and a physical `.md` file in static exports so agents can read the vault without the React protocol.
+
 ## Document tree protocol
 
 Document APIs carry one versioned, parser-neutral presentation tree so the browser can compose content as React elements instead of installing server-rendered HTML.
@@ -42,7 +44,7 @@ Static export traverses tree properties to discover linked source and external t
 
 [[src/cli/ui-build.ts#uiBuildCommand]] snapshots the current vault into a directory of HTML, JavaScript, CSS, and lazy JSON data that any ordinary static host can serve.
 
-The export preserves the file tree, rendered Markdown, wiki and ordinary Markdown navigation, validation state, backlinks, source views, local TOCs, and the graph workspace. Each document and source path gets a physical `index.html` shell; a compatibility shell migrates old graph URLs.
+The export preserves the file tree, rendered Markdown, wiki and ordinary Markdown navigation, validation state, backlinks, source views, local TOCs, and the graph workspace. Each extensionless document and source path gets a physical `index.html` shell; every local document also has an exact `.md` source sibling. A compatibility shell migrates old graph URLs.
 
 Each unique source file has one shared raw-text and highlighted-line payload. Manifest entries combine it with small request-specific payloads for focus, context, and references, avoiding code duplication across links into the same file.
 
@@ -54,7 +56,7 @@ The browser reads an immutable manifest instead of `/api/*`, never opens an even
 
 Vite emits lazy chunks, imported CSS, fonts, and renderer dependencies relative to their owning JavaScript or stylesheet. Generated route shells anchor only the entry assets at the configured base, so nested deployments do not leak requests to root `/assets/`.
 
-Relative Markdown links are rewritten against their source document so the extra static route directory does not change their target. Both the deployment root and a non-root base directory redirect to the exported entry document.
+Relative Markdown links are rewritten against their source document and then to extensionless UI routes, so the extra static route directory does not change their target or accidentally request raw Markdown. Both deployment entrypoints redirect to the exported index document.
 
 Builds reject any existing destination, including an empty directory or prior export. For a new path, the builder stages the complete artifact beside the destination and renames it into place only after generation succeeds.
 
@@ -111,6 +113,8 @@ Whenever cached changes exist, the toggle keeps an orange notification dot wheth
 ## Markdown navigation
 
 [[src/view/markdown.ts#renderMarkdown]] produces the safe document tree with ordinary Markdown links, resolved wiki links, heading fragments, and Git or diagnostic presentation metadata.
+
+Generated document links omit `.md`; the same route with `.md` is deliberately left to the browser as raw source. Relative links authored with `.md` are normalized to the extensionless UI route before rendering.
 
 Markdown and source metadata rows align with the sidebar header, while source metadata retains clear space before the code panel.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -9,7 +9,9 @@ Functional specifications for the browser server, static export, client navigati
 
 ## Serves the document index and browser shell
 
-The loopback server exposes the visible Markdown index, redirects its root to the vault index, and serves the client shell for document routes.
+The loopback server exposes the visible Markdown index, redirects its root to the extensionless vault-index route, and serves the client shell for extensionless document routes.
+
+Requesting the same route with `.md` returns the exact known vault file as `text/markdown`; missing or escaping paths remain unavailable. `HEAD` returns the same source headers without a body.
 
 By default the header renders the same Lat wordmark as the website. `lat ui --logo-text <text>` replaces it with safely rendered plain text.
 
@@ -19,7 +21,9 @@ The server anchors Vite's relative entry assets at `/assets/`, so every live doc
 
 ## Builds a static deployment
 
-`lat ui build [output]` emits a host-ready immutable snapshot with physical document and source routes, lazy graph data, and a compatibility entrypoint for old graph URLs.
+`lat ui build [output]` emits a host-ready immutable snapshot with physical extensionless document and source routes, lazy graph data, and a compatibility entrypoint for old graph URLs.
+
+Every local document also emits its exact source at the corresponding `.md` URL, while generated, relative, search, backlink, and graph navigation all target the extensionless React route.
 
 The static client keeps Markdown and wiki navigation, backlinks, validation, source views, TOCs, and graph inspection. It does not expose Git, search, or the runtime-only section command, perform live API requests, or subscribe to project changes.
 

--- a/src/view/document-route.ts
+++ b/src/view/document-route.ts
@@ -1,0 +1,68 @@
+const DOCUMENT_PREFIX = '/docs/';
+const MARKDOWN_EXTENSION = '.md';
+
+function encodePath(path: string): string {
+  return path.split('/').map(encodeURIComponent).join('/');
+}
+
+function decodeDocumentPath(pathname: string): string | null {
+  if (!pathname.startsWith(DOCUMENT_PREFIX)) return null;
+  try {
+    const path = pathname
+      .slice(DOCUMENT_PREFIX.length)
+      .split('/')
+      .map(decodeURIComponent)
+      .join('/');
+    return path && !path.endsWith('/') ? path : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Build the canonical, extensionless browser route for a Markdown file. */
+export function documentUrl(path: string, fragment = ''): string {
+  const routePath = path.endsWith(MARKDOWN_EXTENSION)
+    ? path.slice(0, -MARKDOWN_EXTENSION.length)
+    : path;
+  return `${DOCUMENT_PREFIX}${encodePath(routePath)}${fragment ? `#${encodeURIComponent(fragment)}` : ''}`;
+}
+
+/** Resolve an extensionless browser route back to its Markdown file path. */
+export function documentPath(pathname: string): string | null {
+  const path = decodeDocumentPath(pathname);
+  if (!path || path.toLowerCase().endsWith(MARKDOWN_EXTENSION)) return null;
+  return `${path}${MARKDOWN_EXTENSION}`;
+}
+
+/** Resolve an explicit `.md` route to the raw Markdown file it requests. */
+export function rawDocumentPath(pathname: string): string | null {
+  const path = decodeDocumentPath(pathname);
+  return path?.toLowerCase().endsWith(MARKDOWN_EXTENSION) ? path : null;
+}
+
+/** Keep relative Markdown-to-Markdown links inside the rendered document UI. */
+export function rewriteDocumentLink(value: string, sourcePath: string): string {
+  if (
+    !value ||
+    value.startsWith('#') ||
+    value.startsWith('/') ||
+    value.startsWith('//') ||
+    /^[a-z][a-z\d+.-]*:/i.test(value)
+  ) {
+    return value;
+  }
+
+  let resolved: URL;
+  try {
+    resolved = new URL(
+      value,
+      `http://lat.local${DOCUMENT_PREFIX}${encodePath(sourcePath)}`,
+    );
+  } catch {
+    return value;
+  }
+  if (resolved.origin !== 'http://lat.local') return value;
+  const path = rawDocumentPath(resolved.pathname);
+  if (!path) return value;
+  return `${documentUrl(path)}${resolved.search}${resolved.hash}`;
+}

--- a/src/view/graph.ts
+++ b/src/view/graph.ts
@@ -22,13 +22,10 @@ import { viewSourceTarget } from './source-target.js';
 import type { ViewGitSnapshot } from './git.js';
 import type { ExternalResolver, ExternalTarget } from '../external-sources.js';
 import { isDocumentPath, stripDocumentExtension } from '../document-formats.js';
+import { documentUrl } from './document-route.js';
 
 function encodedPath(path: string): string {
   return path.split('/').map(encodeURIComponent).join('/');
-}
-
-function documentUrl(path: string, fragment = ''): string {
-  return `/docs/${encodedPath(path)}${fragment ? `#${encodeURIComponent(fragment)}` : ''}`;
 }
 
 function sourceUrl(path: string, symbol = '', line = 0): string {

--- a/src/view/references.ts
+++ b/src/view/references.ts
@@ -22,6 +22,10 @@ import type {
   ViewSourceReference,
 } from './protocol.js';
 import { viewSourceTarget } from './source-target.js';
+import {
+  documentUrl as routeDocumentUrl,
+  rewriteDocumentLink,
+} from './document-route.js';
 
 export type SourceReferenceOrigin = {
   sectionId: string;
@@ -68,19 +72,7 @@ export function parseViewMarkdownFile(
 }
 
 function contextMarkdownLink(requestedPath: string, url: string): string {
-  if (
-    url.startsWith('/') ||
-    url.startsWith('//') ||
-    /^[a-z][a-z\d+.-]*:/i.test(url)
-  ) {
-    return url;
-  }
-  const encodedPath = requestedPath
-    .split('/')
-    .map(encodeURIComponent)
-    .join('/');
-  const resolved = new URL(url, `http://lat.local/docs/${encodedPath}`);
-  return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+  return rewriteDocumentLink(url, requestedPath);
 }
 
 function documentUrl(
@@ -91,11 +83,8 @@ function documentUrl(
   const path = toPosix(
     relative(latDir, resolve(projectRoot, section.filePath)),
   );
-  const encoded = path.split('/').map(encodeURIComponent).join('/');
-  const fragment = section.githubSlug
-    ? `#${encodeURIComponent(section.githubSlug)}`
-    : '';
-  return `/docs/${encoded}${fragment}`;
+  const fragment = section.githubSlug ? section.githubSlug : '';
+  return routeDocumentUrl(path, fragment);
 }
 
 function breadcrumbs(

--- a/src/view/repository.ts
+++ b/src/view/repository.ts
@@ -46,6 +46,7 @@ import {
 } from './references.js';
 import { buildViewTableOfContents } from './table-of-contents.js';
 import { viewSourceTarget } from './source-target.js';
+import { documentUrl } from './document-route.js';
 
 export class ViewDocumentNotFoundError extends Error {}
 export class ViewSourceNotFoundError extends Error {}
@@ -57,10 +58,6 @@ function isInside(root: string, candidate: string): boolean {
     rel === '' ||
     (!isAbsolute(rel) && rel !== '..' && !rel.startsWith(`..${sep}`))
   );
-}
-
-function documentUrl(path: string): string {
-  return `/docs/${path.split('/').map(encodeURIComponent).join('/')}`;
 }
 
 function sourceUrl(

--- a/src/view/search.ts
+++ b/src/view/search.ts
@@ -2,6 +2,7 @@ import { dirname, relative, resolve } from 'node:path';
 import type { SectionMatch } from '../lattice-model.js';
 import { toPosix } from '../path.js';
 import type { ViewSearchResponse, ViewSearchResult } from './protocol.js';
+import { documentUrl } from './document-route.js';
 
 const VIEW_SEARCH_LIMIT = 10;
 
@@ -28,12 +29,6 @@ const defaultDependencies: ViewSearchDependencies = {
   },
 };
 
-function documentUrl(path: string, headingId?: string): string {
-  const encodedPath = path.split('/').map(encodeURIComponent).join('/');
-  const fragment = headingId ? `#${encodeURIComponent(headingId)}` : '';
-  return `/docs/${encodedPath}${fragment}`;
-}
-
 function viewSearchResult(
   latDir: string,
   match: SectionMatch,
@@ -50,7 +45,7 @@ function viewSearchResult(
     path,
     breadcrumbs: [...fileBreadcrumbs, ...section.id.split('#').slice(1)],
     description: section.firstParagraph,
-    url: documentUrl(path, section.githubSlug),
+    url: documentUrl(path, section.githubSlug ?? ''),
     score: match.score ?? 0,
   };
 }

--- a/src/view/server.ts
+++ b/src/view/server.ts
@@ -26,6 +26,7 @@ import {
 import { createViewSearch, type ViewSearch } from './search.js';
 import { createViewStore, type ViewStore } from './store.js';
 import { rewriteClientAssetUrls } from './client-shell.js';
+import { documentUrl, rawDocumentPath } from './document-route.js';
 
 const DEFAULT_HOST = '127.0.0.1';
 export const DEFAULT_VIEW_PORT = 4242;
@@ -51,10 +52,6 @@ export type ViewServerOptions = {
   watch?: boolean;
   externalCa?: string | Buffer;
 };
-
-function documentUrl(path: string): string {
-  return `/docs/${path.split('/').map(encodeURIComponent).join('/')}`;
-}
 
 function setSecurityHeaders(res: ServerResponse): void {
   res.setHeader(
@@ -499,6 +496,25 @@ export async function startViewServer(
           return;
         }
         await sendClientFile(res, path, headOnly, true);
+        return;
+      }
+
+      const rawMarkdownPath = rawDocumentPath(url.pathname);
+      if (rawMarkdownPath) {
+        try {
+          const source = await store.getDocumentSource(rawMarkdownPath);
+          res.setHeader('Cache-Control', 'no-cache');
+          send(
+            res,
+            200,
+            'text/markdown; charset=utf-8',
+            source.content,
+            headOnly,
+          );
+        } catch (error) {
+          if (!(error instanceof ViewDocumentNotFoundError)) throw error;
+          send(res, 404, 'text/plain; charset=utf-8', error.message, headOnly);
+        }
         return;
       }
 

--- a/src/view/static-build.ts
+++ b/src/view/static-build.ts
@@ -33,6 +33,11 @@ import {
 } from './static-protocol.js';
 import { createViewStore } from './store.js';
 import { rewriteClientAssetUrls } from './client-shell.js';
+import {
+  documentPath,
+  documentUrl,
+  rawDocumentPath,
+} from './document-route.js';
 
 const BUILD_MARKER = '.lat-ui-build';
 const defaultClientDir = fileURLToPath(new URL('./client/', import.meta.url));
@@ -105,7 +110,12 @@ export function staticViewUrl(value: string, basePath: string): string {
   }
   if (url.origin !== 'http://lat.local') return value;
 
-  for (const prefix of ['/docs/', '/code/', '/external/'] as const) {
+  if (url.pathname.startsWith('/docs/')) {
+    const route = url.pathname.slice(1).replace(/\/+$/, '');
+    const suffix = `${url.search}${url.hash}`;
+    return `${basePath}${route}${suffix}`;
+  }
+  for (const prefix of ['/code/', '/external/'] as const) {
     if (!url.pathname.startsWith(prefix)) continue;
     const route = url.pathname.slice(1).replace(/\/+$/, '');
     return `${basePath}${route}/${url.search}${url.hash}`;
@@ -117,16 +127,7 @@ export function staticViewUrl(value: string, basePath: string): string {
 }
 
 function documentPathFromUrl(value: URL): string | null {
-  if (!value.pathname.startsWith('/docs/')) return null;
-  try {
-    return value.pathname
-      .slice('/docs/'.length)
-      .split('/')
-      .map(decodeURIComponent)
-      .join('/');
-  } catch {
-    return null;
-  }
+  return documentPath(value.pathname) ?? rawDocumentPath(value.pathname);
 }
 
 function rewriteHtmlLink(
@@ -141,7 +142,6 @@ function rewriteHtmlLink(
   let resolved: URL;
   try {
     const externalAt = sourcePath.indexOf(':');
-    const currentPath = sourcePath.split('/').map(encodeURIComponent).join('/');
     const currentRoute =
       externalAt > 0 && !documentPaths.has(sourcePath)
         ? `/external/${encodeURIComponent(sourcePath.slice(0, externalAt))}/${sourcePath
@@ -149,7 +149,7 @@ function rewriteHtmlLink(
             .split('/')
             .map(encodeURIComponent)
             .join('/')}`
-        : `/docs/${currentPath}`;
+        : documentUrl(sourcePath);
     resolved = new URL(
       decodeHtmlUrlAttribute(value),
       `http://lat.local${currentRoute}`,
@@ -172,7 +172,7 @@ function rewriteHtmlLink(
     return value;
   }
   return staticViewUrl(
-    `${resolved.pathname}${resolved.search}${resolved.hash}`,
+    `${documentUrl(documentPath)}${resolved.search}${resolved.hash}`,
     basePath,
   );
 }
@@ -692,7 +692,11 @@ export async function buildStaticView(
         join(payloadDir, dataPath),
         rewriteDocument(document, basePath, sectionPaths, documentPaths),
       );
-      const route = `docs/${path}`;
+      const source = await store.getDocumentSource(path);
+      const rawPath = join(payloadDir, 'docs', ...path.split('/'));
+      await mkdir(dirname(rawPath), { recursive: true });
+      await writeFile(rawPath, source.content);
+      const route = `docs/${path.slice(0, -'.md'.length)}`;
       await writeRouteShell(payloadDir, route, shell);
     }
 
@@ -786,7 +790,7 @@ export async function buildStaticView(
     await writeRouteShell(payloadDir, 'graph', shell);
     await writeJson(join(payloadDir, 'data/manifest.json'), manifest);
     const entryRedirect = redirectShell(
-      staticViewUrl(`/docs/${index.entry}`, basePath),
+      staticViewUrl(documentUrl(index.entry), basePath),
     );
     await writeFile(join(payloadDir, 'index.html'), entryRedirect);
     if (payloadDir !== stagingDir) {

--- a/src/view/store.ts
+++ b/src/view/store.ts
@@ -74,6 +74,7 @@ import {
   type ViewParsedMarkdownFile,
   type ViewReferenceIndex,
 } from './references.js';
+import { rewriteDocumentLink } from './document-route.js';
 
 const DEFAULT_DEBOUNCE_MS = 75;
 const DEFAULT_GIT_POLL_MS = 2_000;
@@ -477,7 +478,10 @@ export class ViewStore {
       file.content,
       requestedPath,
       resolver,
-      { errors: [...(snapshot.diagnostics.get(requestedPath) ?? [])] },
+      {
+        errors: [...(snapshot.diagnostics.get(requestedPath) ?? [])],
+        rewriteMarkdownLink: (url) => rewriteDocumentLink(url, requestedPath),
+      },
     );
     const errors = [...(snapshot.diagnostics.get(requestedPath) ?? [])];
     const gitFile = snapshot.git.files.get(requestedPath);
@@ -489,7 +493,11 @@ export class ViewStore {
           file.content,
           requestedPath,
           resolver,
-          { errors },
+          {
+            errors,
+            rewriteMarkdownLink: (url) =>
+              rewriteDocumentLink(url, requestedPath),
+          },
           gitTree,
         )
       : null;

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -66,6 +66,8 @@ import {
   type FileTreeNode,
 } from '../view/src/file-tree.js';
 import {
+  documentPath,
+  documentUrl,
   graphInspectorLinkUrl,
   graphModeStorageKey,
   graphNode,
@@ -212,9 +214,9 @@ describe('lat ui', () => {
 
     const rootResponse = await fetch(view.url, { redirect: 'manual' });
     expect(rootResponse.status).toBe(302);
-    expect(rootResponse.headers.get('location')).toBe('/docs/lat.md');
+    expect(rootResponse.headers.get('location')).toBe('/docs/lat');
 
-    const shellResponse = await fetch(new URL('/docs/guide.md', view.url));
+    const shellResponse = await fetch(new URL('/docs/guide', view.url));
     expect(shellResponse.status).toBe(200);
     const shell = await shellResponse.text();
     expect(shell).toContain('lat ui shell');
@@ -231,6 +233,33 @@ describe('lat ui', () => {
     expect(contentSecurityPolicy).toContain(
       "img-src 'self' data: https://github.githubassets.com",
     );
+
+    const rawResponse = await fetch(new URL('/docs/guide.md', view.url));
+    expect(rawResponse.status).toBe(200);
+    expect(rawResponse.headers.get('content-type')).toBe(
+      'text/markdown; charset=utf-8',
+    );
+    expect(await rawResponse.text()).toBe(
+      readFileSync(join(latDir, 'guide.md'), 'utf8'),
+    );
+
+    const rawHeadResponse = await fetch(new URL('/docs/guide.md', view.url), {
+      method: 'HEAD',
+    });
+    expect(rawHeadResponse.status).toBe(200);
+    expect(rawHeadResponse.headers.get('content-type')).toBe(
+      'text/markdown; charset=utf-8',
+    );
+    expect(await rawHeadResponse.text()).toBe('');
+
+    const missingRawResponse = await fetch(
+      new URL('/docs/missing.md', view.url),
+    );
+    expect(missingRawResponse.status).toBe(404);
+    const escapingRawResponse = await fetch(
+      new URL('/docs/..%2F..%2FREADME.md', view.url),
+    );
+    expect(escapingRawResponse.status).toBe(404);
 
     const sourceShell = await fetch(new URL('/code/src/app.ts', view.url));
     expect(sourceShell.status).toBe(200);
@@ -259,6 +288,12 @@ describe('lat ui', () => {
   it('builds a static deployment without live Git or search services', async () => {
     expect(viewViteConfig).toMatchObject({ base: './' });
     expect(normalizeStaticViewBasePath('/project')).toBe('/project/');
+    expect(staticViewUrl('/docs/guide', '/project/')).toBe(
+      '/project/docs/guide',
+    );
+    expect(staticViewUrl('/docs/guide.md', '/project/')).toBe(
+      '/project/docs/guide.md',
+    );
     expect(staticViewUrl('/graph?node=document%3Alat.md', '/project/')).toBe(
       '/project/graph/?node=document%3Alat.md',
     );
@@ -340,7 +375,7 @@ describe('lat ui', () => {
       ) as ViewDocument;
       expect(viewDocumentGitHtml(document)).toBeNull();
       expect(viewDocumentHtml(document)).toContain(
-        'href="/project/docs/guide.md/#details"',
+        'href="/project/docs/guide#details"',
       );
       expect(viewDocumentHtml(document)).toContain(
         'href="/project/code/src/app.ts/?from=',
@@ -353,12 +388,15 @@ describe('lat ui', () => {
         true,
       );
       expect(graph.nodes.map((node) => node.url)).toContain(
-        '/project/docs/lat.md/',
+        '/project/docs/lat',
       );
       expect(graph.nodes.some((node) => node.kind === 'source')).toBe(true);
 
-      expect(existsSync(join(payloadDir, 'docs', 'lat.md', 'index.html'))).toBe(
+      expect(existsSync(join(payloadDir, 'docs', 'lat', 'index.html'))).toBe(
         true,
+      );
+      expect(readFileSync(join(payloadDir, 'docs', 'lat.md'), 'utf8')).toBe(
+        readFileSync(join(staticContext.latDir, 'lat.md'), 'utf8'),
       );
       expect(
         existsSync(join(payloadDir, 'code', 'src', 'app.ts', 'index.html')),
@@ -372,7 +410,7 @@ describe('lat ui', () => {
       expect(existsSync(join(outputDir, 'data'))).toBe(false);
 
       const shell = readFileSync(
-        join(payloadDir, 'docs', 'lat.md', 'index.html'),
+        join(payloadDir, 'docs', 'lat', 'index.html'),
         'utf8',
       );
       expect(shell).toContain('/project/assets/app.js');
@@ -382,10 +420,10 @@ describe('lat ui', () => {
         'globalThis.__LAT_STATIC_VIEW__={"basePath":"/project/"}',
       );
       expect(readFileSync(join(outputDir, 'index.html'), 'utf8')).toContain(
-        '/project/docs/lat.md/',
+        '/project/docs/lat',
       );
       expect(readFileSync(join(payloadDir, 'index.html'), 'utf8')).toContain(
-        '/project/docs/lat.md/',
+        '/project/docs/lat',
       );
 
       const discovery = createCodeReferenceDiscovery(staticProjectRoot);
@@ -396,9 +434,9 @@ describe('lat ui', () => {
       expect(
         scanned.refs.some((reference) => reference.file.startsWith('site/')),
       ).toBe(false);
-      expect(
-        sourceFiles.some((path) => path.startsWith(`${outputDir}/`)),
-      ).toBe(false);
+      expect(sourceFiles.some((path) => path.startsWith(`${outputDir}/`))).toBe(
+        false,
+      );
       const disableRipgrep = process.env._LAT_DISABLE_RG;
       process.env._LAT_DISABLE_RG = '1';
       try {
@@ -410,9 +448,7 @@ describe('lat ui', () => {
         ]);
         expect(fallbackScan.refs).toEqual(scanned.refs);
         expect(
-          fallbackSourceFiles.some((path) =>
-            path.startsWith(`${outputDir}/`),
-          ),
+          fallbackSourceFiles.some((path) => path.startsWith(`${outputDir}/`)),
         ).toBe(false);
       } finally {
         if (disableRipgrep === undefined) delete process.env._LAT_DISABLE_RG;
@@ -557,10 +593,10 @@ describe('lat ui', () => {
       '/graph?node=document%3Aguide.md',
     );
     expect(graphNode('?node=document%3Aguide.md')).toBe('document:guide.md');
-    const sectionTarget = '/docs/guide.md#details';
+    const sectionTarget = '/docs/guide#details';
     const targetedGraphUrl = graphUrl('document:guide.md', sectionTarget);
     expect(targetedGraphUrl).toBe(
-      '/graph?node=document%3Aguide.md&target=%2Fdocs%2Fguide.md%23details',
+      '/graph?node=document%3Aguide.md&target=%2Fdocs%2Fguide%23details',
     );
     expect(graphTarget(new URL(targetedGraphUrl, view.url).search)).toBe(
       sectionTarget,
@@ -608,11 +644,11 @@ describe('lat ui', () => {
       graphTargetForNode(graph, documentNode!, sectionTarget, view.url),
     ).toBe(sectionTarget);
     expect(
-      graphTargetForNode(graph, documentNode!, '/docs/lat.md', view.url),
+      graphTargetForNode(graph, documentNode!, '/docs/lat', view.url),
     ).toBe(documentNode!.url);
     const sameDocumentLink = graphInspectorLinkUrl(
       '#details',
-      '/docs/guide.md',
+      '/docs/guide',
       view.url,
     );
     expect(`${sameDocumentLink?.pathname}${sameDocumentLink?.hash}`).toBe(
@@ -700,13 +736,13 @@ describe('lat ui', () => {
     expect(searchUrl('runner details')).toBe('/search?q=runner+details');
     expect(searchQuery('?q=runner+details')).toBe('runner details');
     expect(searchUrl('')).toBe('/search');
-    expect(searchReturnTo(searchHistoryState('/docs/guide.md#details'))).toBe(
-      '/docs/guide.md#details',
+    expect(searchReturnTo(searchHistoryState('/docs/guide#details'))).toBe(
+      '/docs/guide#details',
     );
     expect(searchReturnTo(null)).toBeNull();
     expect(searchEscapeAction('runner details')).toBe('clear');
     expect(searchEscapeAction('')).toBe('close');
-    expect(searchButtonAction('/docs/guide.md')).toBe('open');
+    expect(searchButtonAction('/docs/guide')).toBe('open');
     expect(searchButtonAction('/search')).toBe('close');
 
     const emptyResponse = await fetch(new URL('/api/search?query=', view.url));
@@ -729,7 +765,7 @@ describe('lat ui', () => {
           path: 'guide.md',
           breadcrumbs: ['guide', 'Guide', 'Details'],
           description: 'Relative Markdown links preserve heading fragments.',
-          url: '/docs/guide.md#details',
+          url: '/docs/guide#details',
           score: 0.82,
         },
       ],
@@ -783,7 +819,7 @@ describe('lat ui', () => {
     expect(viewDocumentHtml(document)).toContain(
       '<h1 id="view-project">View Project</h1>',
     );
-    expect(viewDocumentHtml(document)).toContain('href="guide.md#details"');
+    expect(viewDocumentHtml(document)).toContain('href="/docs/guide#details"');
     expect(viewDocumentHtml(document)).not.toContain('require-code-mention');
 
     const links = await renderMarkdown(
@@ -1301,16 +1337,16 @@ describe('lat ui', () => {
     const document = (await response.json()) as ViewDocument;
 
     expect(viewDocumentHtml(document)).toContain(
-      '<a href="/docs/guide.md">wiki navigation<span class="wiki-link-ref-count" aria-label="2 references">2</span></a>',
+      '<a href="/docs/guide">wiki navigation<span class="wiki-link-ref-count" aria-label="2 references">2</span></a>',
     );
     expect(viewDocumentHtml(document)).toContain(
-      '<a href="/docs/guide.md#details">wiki heading links<span class="wiki-link-ref-count" aria-label="5 references">5</span></a>',
+      '<a href="/docs/guide#details">wiki heading links<span class="wiki-link-ref-count" aria-label="5 references">5</span></a>',
     );
     expect(viewDocumentHtml(document)).toContain(
-      '<a href="/docs/guide.md#details">the same heading again<span class="wiki-link-ref-count" aria-label="5 references">5</span></a>',
+      '<a href="/docs/guide#details">the same heading again<span class="wiki-link-ref-count" aria-label="5 references">5</span></a>',
     );
     expect(viewDocumentHtml(document)).toContain(
-      '<a href="/docs/guide.md#details" class="wiki-link-segmented"><span class="wiki-link-context">guide#</span><span class="wiki-link-leaf">Details</span><span class="wiki-link-ref-count" aria-label="5 references">5</span></a>',
+      '<a href="/docs/guide#details" class="wiki-link-segmented"><span class="wiki-link-context">guide#</span><span class="wiki-link-leaf">Details</span><span class="wiki-link-ref-count" aria-label="5 references">5</span></a>',
     );
     expect(viewDocumentHtml(document)).toContain(
       'href="/code/src/app.ts?from=lat.md%2Flat%23View+Project',
@@ -1381,10 +1417,10 @@ describe('lat ui', () => {
       const sparseReferences = await renderMarkdown(
         '[[orphan]]',
         'lat.md',
-        async () => ({ href: '/docs/orphan.md', referenceCount }),
+        async () => ({ href: '/docs/orphan', referenceCount }),
       );
       expect(sparseReferences.html).toBe(
-        '<p><a href="/docs/orphan.md">orphan</a></p>',
+        '<p><a href="/docs/orphan">orphan</a></p>',
       );
     }
   });
@@ -1443,7 +1479,7 @@ describe('lat ui', () => {
       paragraph:
         'Source targets such as src/app.ts#run open their definitions; the guide explains them.',
       paragraphTree: expect.objectContaining({ version: 1, type: 'root' }),
-      url: '/docs/lat.md#view-project',
+      url: '/docs/lat#view-project',
     });
     expect(source.otherReferences).toEqual([
       {
@@ -1451,7 +1487,7 @@ describe('lat ui', () => {
         breadcrumbs: ['guide', 'Guide', 'Details'],
         paragraph: 'The guide also references the same runner.',
         paragraphTree: expect.objectContaining({ version: 1, type: 'root' }),
-        url: '/docs/guide.md#details',
+        url: '/docs/guide#details',
       },
     ]);
     expect(paragraphTreeHtml(source.context)).toContain(
@@ -1461,7 +1497,7 @@ describe('lat ui', () => {
       'code-link-language code-language-ts',
     );
     expect(paragraphTreeHtml(source.context)).toContain(
-      'href="/docs/guide.md#details"',
+      'href="/docs/guide#details"',
     );
     expect(paragraphTreeHtml(source.otherReferences[0])).toContain(
       'wiki-link-code wiki-link-active',
@@ -1492,7 +1528,7 @@ describe('lat ui', () => {
       kind: 'markdown',
       sectionId: 'lat.md/lat#View Project',
       breadcrumbs: ['lat', 'View Project'],
-      url: '/docs/lat.md#view-project',
+      url: '/docs/lat#view-project',
     });
     expect(details?.references[1]).toMatchObject({
       kind: 'markdown',
@@ -1592,13 +1628,13 @@ describe('lat ui', () => {
     const navigate = vi.fn();
     const clipboard = { writeText: vi.fn(async () => {}) };
     const sectionUrl = navigateAndCopySectionLink(
-      new URL('/docs/lat.md#view-project', view.url).href,
+      new URL('/docs/lat#view-project', view.url).href,
       'unreferenced',
       navigate,
       clipboard,
     );
     expect(sectionUrl.href).toBe(
-      new URL('/docs/lat.md#unreferenced', view.url).href,
+      new URL('/docs/lat#unreferenced', view.url).href,
     );
     expect(navigate).toHaveBeenCalledWith(sectionUrl);
     expect(clipboard.writeText).toHaveBeenCalledWith(sectionUrl.href);
@@ -1627,7 +1663,7 @@ describe('lat ui', () => {
     expect(sectionOutput.output).toContain('> ## Unreferenced');
     expect(sectionOutput.output).toContain('`lat section "section#id"`');
     expect(documentTreeToHtml(sectionOutput.tree)).toContain(
-      'href="/docs/lat.md#unreferenced"',
+      'href="/docs/lat#unreferenced"',
     );
     expect(documentTreeToHtml(sectionOutput.tree)).toContain('<blockquote>');
     expect(documentTreeToHtml(sectionOutput.tree)).toContain(
@@ -1853,23 +1889,25 @@ describe('lat ui', () => {
     expect(getElementById).not.toHaveBeenCalled();
     expect(scrollIntoView).not.toHaveBeenCalled();
 
-    expect(viewRouteIdentity('/docs/guide.md#features')).toBe('/docs/guide.md');
-    expect(viewRouteIdentity('/docs/guide.md#installation')).toBe(
-      '/docs/guide.md',
-    );
+    expect(documentUrl('nested/my guide.md')).toBe('/docs/nested/my%20guide');
+    expect(documentPath('/docs/nested/my%20guide')).toBe('nested/my guide.md');
+    expect(documentPath('/docs/nested/my%20guide.md')).toBeNull();
+
+    expect(viewRouteIdentity('/docs/guide#features')).toBe('/docs/guide');
+    expect(viewRouteIdentity('/docs/guide#installation')).toBe('/docs/guide');
     expect(viewRouteIdentity('/code/parser.ts#parse')).toBe(
       '/code/parser.ts#parse',
     );
     expect(
       isSameRenderedDocument(
-        new URL('http://lat.local/docs/guide.md#features'),
-        new URL('http://lat.local/docs/guide.md#installation'),
+        new URL('http://lat.local/docs/guide#features'),
+        new URL('http://lat.local/docs/guide#installation'),
       ),
     ).toBe(true);
     expect(
       isSameRenderedDocument(
-        new URL('http://lat.local/docs/guide.md'),
-        new URL('http://lat.local/docs/other.md'),
+        new URL('http://lat.local/docs/guide'),
+        new URL('http://lat.local/docs/other'),
       ),
     ).toBe(false);
     expect(
@@ -1883,11 +1921,11 @@ describe('lat ui', () => {
   // @lat: [[lat.md/view/specs#View Tests#Restores history scroll positions]]
   it('preserves scroll positions in navigation history state', () => {
     const state = historyStateWithScroll(
-      searchHistoryState('/docs/guide.md#details'),
+      searchHistoryState('/docs/guide#details'),
       { left: 12, top: 480 },
     );
 
-    expect(searchReturnTo(state)).toBe('/docs/guide.md#details');
+    expect(searchReturnTo(state)).toBe('/docs/guide#details');
     expect(historyScrollPosition(state)).toEqual({ left: 12, top: 480 });
     expect(historyScrollPosition({ latScrollPosition: { top: '480' } })).toBe(
       null,

--- a/view/src/navigation.ts
+++ b/view/src/navigation.ts
@@ -1,8 +1,11 @@
 import type { ViewGraph, ViewGraphNode } from '../../src/view/protocol';
 import { isDocumentPath } from '../../src/document-formats';
 import { staticViewRoute, viewPathname } from './static-mode';
+import {
+  documentPath as routeDocumentPath,
+  documentUrl as routeDocumentUrl,
+} from '../../src/view/document-route';
 
-const DOCUMENT_PREFIX = '/docs/';
 const SOURCE_PREFIX = '/code/';
 const EXTERNAL_PREFIX = '/external/';
 
@@ -14,22 +17,12 @@ type DocumentScroller = {
 };
 
 export function documentUrl(path: string): string {
-  const encoded = path.split('/').map(encodeURIComponent).join('/');
-  return staticViewRoute(`docs/${encoded}/`) ?? `${DOCUMENT_PREFIX}${encoded}`;
+  const route = routeDocumentUrl(path);
+  return staticViewRoute(route.slice(1)) ?? route;
 }
 
 export function documentPath(pathname: string): string | null {
-  pathname = viewPathname(pathname);
-  if (!pathname.startsWith(DOCUMENT_PREFIX)) return null;
-  try {
-    return pathname
-      .slice(DOCUMENT_PREFIX.length)
-      .split('/')
-      .map(decodeURIComponent)
-      .join('/');
-  } catch {
-    return null;
-  }
+  return routeDocumentPath(viewPathname(pathname));
 }
 
 /** Build the browser route for one canonical external target. */


### PR DESCRIPTION
## Summary

- make local Markdown UI routes extensionless across navigation, search, graph, and backlinks
- serve explicit .md URLs as exact Markdown source with the correct live content type
- emit both clean route shells and raw Markdown files in static builds
- rewrite authored relative Markdown links to stay inside the rendered UI

## Verification

- pnpm buildall
- pnpm test (306 tests)
- lat check
- verified the generated website through Next.js: the extensionless URL serves HTML and the .md URL serves byte-identical text/markdown