### PR TITLE
Persist expanded file tree directories

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -128,7 +128,7 @@ Wide layouts give the sticky TOC a fixed 286px column and the available viewport
 
 A moving end-of-page activation line makes short final sections reachable.
 
-The sidebar is a natural-order file tree. Root `lat.md` and each `name/name.md` directory index stay first; selecting a directory opens its index and expands the directory. When external files are referenced, an `External sources` label separates source-handle folders from the local tree.
+The sidebar is a natural-order file tree. Root `lat.md` and each `name/name.md` directory index stay first; selecting a directory opens its index and expands the directory. Expanded directories remain open while navigating and are restored from deployment-scoped local storage after reload. When external files are referenced, an `External sources` label separates source-handle folders from the local tree.
 
 Every section heading exposes a burger-icon action menu, with a numeric badge only when references exist. It shows incoming Markdown, wiki, and `@lat:` locations or an empty state, followed by stacked muted actions that copy the navigated URL or canonical section ID.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -229,6 +229,10 @@ Vault paths form a natural-order hierarchy with root and directory index files p
 
 Selecting a directory opens its `name/name.md` index and keeps the directory expanded.
 
+## Preserves expanded directories
+
+Directories stay independently expanded while navigation moves between files and folders. The open paths persist in deployment-scoped local storage and are restored after reload; unavailable storage only limits persistence to the current page.
+
 ## Stabilizes fragment navigation immediately
 
 Fragment links position rendered documents without smooth scrolling so content is immediately interactive.

--- a/tests/file-tree.test.tsx
+++ b/tests/file-tree.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FileTree } from '../view/src/FileTree.js';
+import { fileTreeStorageKey } from '../view/src/file-tree.js';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+describe('FileTree', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  // @lat: [[lat.md/view/specs#View Tests#Preserves expanded directories]]
+  it('keeps visited directories open and restores them from local storage', async () => {
+    const storageKey = fileTreeStorageKey(null);
+    const renderTree = async (activePath: string) => {
+      await act(async () => {
+        root.render(
+          <FileTree
+            activeExternalTarget={null}
+            activePath={activePath}
+            errorCounts={{}}
+            externalFiles={[]}
+            files={[
+              'lat.md',
+              'api/api.md',
+              'api/reference.md',
+              'guides/guides.md',
+              'guides/setup.md',
+            ]}
+            gitFiles={{}}
+            onNavigate={vi.fn()}
+            storageKey={storageKey}
+          />,
+        );
+      });
+    };
+
+    await renderTree('guides/setup.md');
+    let directories = Array.from(
+      container.querySelectorAll<HTMLDetailsElement>('.tree-directory'),
+    );
+    expect(directories.map(({ open }) => open)).toEqual([false, true]);
+
+    await renderTree('api/reference.md');
+    directories = Array.from(
+      container.querySelectorAll<HTMLDetailsElement>('.tree-directory'),
+    );
+    expect(directories.map(({ open }) => open)).toEqual([true, true]);
+    expect(JSON.parse(window.localStorage.getItem(storageKey) ?? '[]')).toEqual(
+      ['api', 'guides'],
+    );
+
+    await act(async () => root.unmount());
+    root = createRoot(container);
+    await renderTree('lat.md');
+    directories = Array.from(
+      container.querySelectorAll<HTMLDetailsElement>('.tree-directory'),
+    );
+    expect(directories.map(({ open }) => open)).toEqual([true, true]);
+
+    await act(async () => {
+      directories[0].querySelector('summary')?.click();
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+    expect(directories.map(({ open }) => open)).toEqual([false, true]);
+    expect(JSON.parse(window.localStorage.getItem(storageKey) ?? '[]')).toEqual(
+      ['guides'],
+    );
+  });
+});

--- a/view/src/App.tsx
+++ b/view/src/App.tsx
@@ -20,6 +20,7 @@ import type {
 import { DEFAULT_VIEW_LOGO_TEXT } from '../../src/view/protocol';
 import latLogoUrl from '../../website/public/logo.svg?url';
 import { FileTree } from './FileTree';
+import { fileTreeStorageKey } from './file-tree';
 import { MarkdownContent } from './MarkdownContent';
 import { DocumentModeSwitch, type DocumentMode } from './DocumentModeSwitch';
 import { DocumentToc } from './DocumentToc';
@@ -282,6 +283,7 @@ function errorMessage(reason: unknown): string {
 export function App() {
   const staticView = isStaticView();
   const graphModeKey = graphModeStorageKey(staticViewBasePath());
+  const fileTreeKey = fileTreeStorageKey(staticViewBasePath());
   const [location, setLocation] = useState(currentLocation);
   const [index, setIndex] = useState<ViewIndex | null>(null);
   const [page, setPage] = useState<ViewPage | null>(null);
@@ -951,6 +953,7 @@ export function App() {
                 gitEnabled ? (index.git?.files ?? NO_GIT_FILES) : NO_GIT_FILES
               }
               onNavigate={onNavigationClick}
+              storageKey={fileTreeKey}
             />
           )}
           {!index && indexError && (

--- a/view/src/FileTree.tsx
+++ b/view/src/FileTree.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type MouseEvent } from 'react';
+import { useEffect, useMemo, useState, type MouseEvent } from 'react';
 import {
   buildExternalFileTree,
   buildFileTree,
@@ -6,7 +6,9 @@ import {
   expandDirectory,
   fileTreeErrorCount,
   fileTreeGitStatus,
+  readOpenDirectories,
   type FileTreeNode,
+  writeOpenDirectories,
 } from './file-tree';
 import type {
   ViewExternalFile,
@@ -22,6 +24,7 @@ type FileTreeProps = {
   files: string[];
   gitFiles: Record<string, ViewGitFileStatus>;
   onNavigate: (event: MouseEvent<HTMLAnchorElement>) => void;
+  storageKey: string;
 };
 
 function isActiveFile(
@@ -61,14 +64,18 @@ function TreeNode({
   errorCounts,
   gitFiles,
   node,
+  onDirectoryToggle,
   onNavigate,
+  openDirectories,
 }: {
   activePath: string | null;
   activeExternalTarget: string | null;
   errorCounts: FileTreeProps['errorCounts'];
   gitFiles: FileTreeProps['gitFiles'];
   node: FileTreeNode;
+  onDirectoryToggle: (path: string, open: boolean) => void;
   onNavigate: FileTreeProps['onNavigate'];
+  openDirectories: ReadonlySet<string>;
 }) {
   if (node.kind === 'directory') {
     const index = directoryIndex(node);
@@ -78,8 +85,12 @@ function TreeNode({
       <details
         className="tree-directory"
         open={
+          openDirectories.has(node.path) ||
           containsActiveFile(node, activePath, activeExternalTarget) ||
           undefined
+        }
+        onToggle={(event) =>
+          onDirectoryToggle(node.path, event.currentTarget.open)
         }
       >
         <summary>
@@ -88,6 +99,7 @@ function TreeNode({
               href={fileUrl(index)}
               onClick={(event) => {
                 expandDirectory(event.currentTarget.closest('details'));
+                onDirectoryToggle(node.path, true);
                 onNavigate(event);
               }}
             >
@@ -114,7 +126,9 @@ function TreeNode({
               gitFiles={gitFiles}
               key={child.path}
               node={child}
+              onDirectoryToggle={onDirectoryToggle}
               onNavigate={onNavigate}
+              openDirectories={openDirectories}
             />
           ))}
         </div>
@@ -177,17 +191,69 @@ export function FileTree({
   files,
   gitFiles,
   onNavigate,
+  storageKey,
 }: FileTreeProps) {
   const tree = useMemo(() => buildFileTree(files), [files]);
   const externalTree = useMemo(
     () => buildExternalFileTree(externalFiles),
     [externalFiles],
   );
+  const [openDirectories, setOpenDirectories] = useState<Set<string>>(() => {
+    try {
+      return readOpenDirectories(window.localStorage, storageKey);
+    } catch {
+      return new Set();
+    }
+  });
+  const activeDirectories = useMemo(() => {
+    const paths = new Set<string>();
+    const collect = (nodes: FileTreeNode[]): void => {
+      for (const node of nodes) {
+        if (
+          node.kind === 'directory' &&
+          containsActiveFile(node, activePath, activeExternalTarget)
+        ) {
+          paths.add(node.path);
+          collect(node.children);
+        }
+      }
+    };
+    collect(tree);
+    collect(externalTree);
+    return paths;
+  }, [activeExternalTarget, activePath, externalTree, tree]);
+
+  useEffect(() => {
+    if ([...activeDirectories].every((path) => openDirectories.has(path))) {
+      return;
+    }
+    setOpenDirectories((current) => {
+      const next = new Set(current);
+      for (const path of activeDirectories) next.add(path);
+      return next;
+    });
+  }, [activeDirectories, openDirectories]);
+
+  useEffect(() => {
+    try {
+      writeOpenDirectories(window.localStorage, storageKey, openDirectories);
+    } catch {
+      // Storage can be unavailable; expansion still lasts for this page load.
+    }
+  }, [openDirectories, storageKey]);
+
+  const onDirectoryToggle = (path: string, open: boolean): void => {
+    setOpenDirectories((current) => {
+      if (current.has(path) === open) return current;
+      const next = new Set(current);
+      if (open) next.add(path);
+      else next.delete(path);
+      return next;
+    });
+  };
+
   return (
-    <div
-      className="file-tree"
-      key={activePath ?? activeExternalTarget ?? undefined}
-    >
+    <div className="file-tree">
       {tree.map((node) => (
         <TreeNode
           activePath={activePath}
@@ -196,7 +262,9 @@ export function FileTree({
           gitFiles={gitFiles}
           key={node.path}
           node={node}
+          onDirectoryToggle={onDirectoryToggle}
           onNavigate={onNavigate}
+          openDirectories={openDirectories}
         />
       ))}
       {externalTree.length > 0 && (
@@ -216,7 +284,9 @@ export function FileTree({
           gitFiles={gitFiles}
           key={node.path}
           node={node}
+          onDirectoryToggle={onDirectoryToggle}
           onNavigate={onNavigate}
+          openDirectories={openDirectories}
         />
       ))}
     </div>

--- a/view/src/file-tree.ts
+++ b/view/src/file-tree.ts
@@ -27,6 +27,12 @@ type MutableDirectory = {
 
 type MutableNode = MutableDirectory | Extract<FileTreeNode, { kind: 'file' }>;
 
+type FileTreeStorage = {
+  getItem: (key: string) => string | null;
+  removeItem: (key: string) => void;
+  setItem: (key: string, value: string) => void;
+};
+
 const finderCollator = new Intl.Collator(undefined, {
   numeric: true,
   sensitivity: 'base',
@@ -76,6 +82,42 @@ export function directoryIndex(
 /** Ensure an indexed directory is visibly expanded before navigating into it. */
 export function expandDirectory(directory: { open: boolean } | null): void {
   if (directory) directory.open = true;
+}
+
+/** Scope persisted sidebar expansion to one live or static deployment. */
+export function fileTreeStorageKey(basePath: string | null): string {
+  return `lat.ui.open-directories:${basePath ?? '/'}`;
+}
+
+/** Read the valid directory paths saved by a previous browser session. */
+export function readOpenDirectories(
+  storage: FileTreeStorage,
+  key: string,
+): Set<string> {
+  const value = storage.getItem(key);
+  if (!value) return new Set();
+  try {
+    const paths: unknown = JSON.parse(value);
+    if (!Array.isArray(paths)) return new Set();
+    return new Set(
+      paths.filter((path): path is string => typeof path === 'string'),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+/** Persist expanded directory paths, removing empty state from storage. */
+export function writeOpenDirectories(
+  storage: FileTreeStorage,
+  key: string,
+  paths: ReadonlySet<string>,
+): void {
+  if (paths.size === 0) {
+    storage.removeItem(key);
+    return;
+  }
+  storage.setItem(key, JSON.stringify([...paths].sort()));
 }
 
 /** Sum validation errors below a file or directory for propagated markers. */


### PR DESCRIPTION
## Summary

- keep independently expanded sidebar directories open during navigation
- restore expanded paths from deployment-scoped local storage after reload
- persist manual expansion and collapse while gracefully handling unavailable storage
- document the behavior and add a browser regression test

## Testing

- pnpm typecheck
- pnpm format:check
- pnpm test (307 tests)
- lat check