### PR TITLE
Hide external icons on linked images

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -116,7 +116,7 @@ Markdown and source metadata rows align with the sidebar header, while source me
 
 Rendered sections use heading scale and whitespace without horizontal separators between headings.
 
-Rendered link text is always underlined. A [[src/view/document-tree.ts#decorateExternalSiteLinks|parser-neutral tree pass]] adds external-link icons across Markdown, reStructuredText, and AsciiDoc; language badges, reference counts, and those icons remain undecorated.
+Rendered link text is always underlined. A [[src/view/document-tree.ts#decorateExternalSiteLinks|parser-neutral tree pass]] adds external-link icons across Markdown, reStructuredText, and AsciiDoc, except when a link wraps an image; language badges, reference counts, and those icons remain undecorated.
 
 Document responses project every parsed heading and canonical GitHub slug into a local TOC. Its H1 entry stays bold at the base indentation, while subsection indentation remains relative to the first subsection level.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -57,6 +57,8 @@ Static export discovers and rewrites links by traversing node properties while r
 
 Markdown normalizes into a safe tree with GitHub-style heading ids and intact relative destinations. HTTP(S) and protocol-relative links gain decorative external-site icons in documents and reference contexts.
 
+Links wrapping images omit the external-site icon so badges and other linked embeds remain visually intact.
+
 GitHub-flavored pipe tables render as semantic HTML tables. Wide tables stay within the document column and scroll horizontally instead of flattening into pipe-delimited text or widening the page.
 
 Single- and double-tilde GitHub strikethrough syntax renders semantic deleted text rather than literal delimiters.

--- a/src/view/document-tree.ts
+++ b/src/view/document-tree.ts
@@ -103,6 +103,17 @@ function isExternalSiteUrl(value: string): boolean {
   return /^(?:https?:)?\/\//i.test(value);
 }
 
+function containsElementTag(
+  element: ViewDocumentElement,
+  tagName: string,
+): boolean {
+  return element.children.some(
+    (child) =>
+      child.type === 'element' &&
+      (child.tagName === tagName || containsElementTag(child, tagName)),
+  );
+}
+
 /** Apply parser-neutral presentation to links that leave the current site. */
 export function decorateExternalSiteLinks(
   tree: ViewDocumentTree,
@@ -120,6 +131,8 @@ export function decorateExternalSiteLinks(
     const classes = classNames(element.properties.className);
     if (!classes.includes('external-link')) classes.push('external-link');
     element.properties.className = classes;
+    if (containsElementTag(element, 'img')) return;
+
     const alreadyDecorated = element.children.some(
       (child) =>
         child.type === 'element' &&

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -798,6 +798,18 @@ describe('lat ui', () => {
     expect(links.html).toContain('<a href="guide.md#details">local</a>');
     expect(links.html).toContain('<a href="mailto:hi@example.com">email</a>');
 
+    const linkedImage = await renderMarkdown(
+      '[![CI](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/vercel-labs/lat.md/actions)',
+      'lat.md',
+    );
+    expect(linkedImage.html).toContain(
+      'href="https://github.com/vercel-labs/lat.md/actions" class="external-link"',
+    );
+    expect(linkedImage.html).toContain(
+      '<img src="https://img.shields.io/badge/build-passing-brightgreen" alt="CI">',
+    );
+    expect(linkedImage.html).not.toContain('external-link-icon');
+
     const table = await renderMarkdown(
       '| Mitigation | What Nub does |\n| --- | --- |\n| Native | Nothing. The version already ships it. |\n| Polyfill | Installs a JavaScript polyfill, guarded by a `typeof` feature detect. |',
       'guide.md',


### PR DESCRIPTION
## Summary

- skip decorative external-link icons when an anchor contains an image
- preserve external-link classification for linked badges and image embeds
- add regression coverage for a GitHub-style badge link
- document the shared Markdown and external-document behavior

## Testing

- pnpm typecheck
- pnpm format:check
- pnpm test (306 tests)
- lat check