### PR TITLE
Support linked resources inside Markdown vaults

### DIFF
--- a/lat.md/markdown.md
+++ b/lat.md/markdown.md
@@ -157,6 +157,8 @@ Ordinary markdown links (`[text](path)`) to local files are validated for existe
 
 Targets resolve against the containing file's directory. A link that leaves `lat.md/` (`../../AGENTS.md`) is checked like any other. Inline links, images, and reference definitions (`[id]: ./path.md`) all participate; code samples and bracket-like text in raw HTML do not.
 
+Non-Markdown files stored inside `lat.md/` are valid only when ordinary Markdown links or images reference them. The live browser serves these contained resources and static exports copy only those the rendered documents use.
+
 Fragments targeting Markdown files must match a GitHub-style heading id. GitHub lowercases headings, removes punctuation, replaces spaces with hyphens, and suffixes duplicate ids with `-1`, `-2`, and so on. Bare fragments target the containing file and are validated the same way.
 
 Full (`[text][id]`), collapsed (`[id][]`), and shortcut (`[id]`) references without a matching definition are errors. Literal bracketed prose must escape its opening bracket (`\[id]`), keeping link intent explicit in Lat's strict Markdown dialect.

--- a/lat.md/tests/check-index.md
+++ b/lat.md/tests/check-index.md
@@ -32,7 +32,7 @@ Given a subdirectory index file that lists a file which does not exist on disk, 
 
 ## Detects non-markdown file
 
-Given a checked directory containing a file without a `.md` extension (e.g. `README`), `checkIndex` reports it as an error since only markdown files belong in the documentation directory.
+Given a checked directory containing an unreferenced file without a `.md` extension (e.g. `README`), `checkIndex` reports it as an error; non-Markdown files linked from vault Markdown are accepted as local resources.
 
 ## Non-markdown files excluded from index listing
 

--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -20,7 +20,7 @@ Map fences lazily request OpenFreeMap's hosted OpenStreetMap vector style throug
 
 The live server's default-self Content Security Policy explicitly permits only OpenFreeMap tile connections, GitHub custom emoji images, and bundled data fonts needed by those supported renderers.
 
-Read APIs accept only walked vault files or supported project source paths and reject traversal and escaping symlinks.
+Read APIs accept only walked vault files, contained document resources, or supported project source paths and reject traversal and escaping symlinks.
 
 Local Markdown documents use extensionless `/docs/...` browser routes. Appending `.md` addresses the exact Markdown source instead, with `text/markdown` from the live server and a physical `.md` file in static exports so agents can read the vault without the React protocol.
 
@@ -44,7 +44,7 @@ Static export traverses tree properties to discover linked source and external t
 
 [[src/cli/ui-build.ts#uiBuildCommand]] snapshots the current vault into a directory of HTML, JavaScript, CSS, and lazy JSON data that any ordinary static host can serve.
 
-The export preserves the file tree, rendered Markdown, wiki and ordinary Markdown navigation, validation state, backlinks, source views, local TOCs, and the graph workspace. Each extensionless document and source path gets a physical `index.html` shell; every local document also has an exact `.md` source sibling. A compatibility shell migrates old graph URLs.
+The export preserves the file tree, rendered Markdown, wiki and ordinary Markdown navigation, validation state, backlinks, source views, local TOCs, and the graph workspace. Each extensionless document and source path gets a physical `index.html` shell; every local document also has an exact `.md` source sibling, and referenced vault resources are copied under `resources/`. A compatibility shell migrates old graph URLs.
 
 Each unique source file has one shared raw-text and highlighted-line payload. Manifest entries combine it with small request-specific payloads for focus, context, and references, avoiding code duplication across links into the same file.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -13,6 +13,8 @@ The loopback server exposes the visible Markdown index, redirects its root to th
 
 Requesting the same route with `.md` returns the exact known vault file as `text/markdown`; missing or escaping paths remain unavailable. `HEAD` returns the same source headers without a body.
 
+Contained non-Markdown resources referenced by documents are served through `/resources/...`; missing files, directory traversal, and escaping symlinks remain unavailable.
+
 By default the header renders the same Lat wordmark as the website. `lat ui --logo-text <text>` replaces it with safely rendered plain text.
 
 The browser shell keeps a default-self Content Security Policy while allowing the OpenFreeMap tile endpoint, GitHub's custom emoji image host, and data-backed renderer fonts.
@@ -23,7 +25,7 @@ The server anchors Vite's relative entry assets at `/assets/`, so every live doc
 
 `lat ui build [output]` emits a host-ready immutable snapshot with physical extensionless document and source routes, lazy graph data, and a compatibility entrypoint for old graph URLs.
 
-Every local document also emits its exact source at the corresponding `.md` URL, while generated, relative, search, backlink, and graph navigation all target the extensionless React route.
+Every local document also emits its exact source at the corresponding `.md` URL, while referenced vault resources are copied under `resources/` and generated, relative, search, backlink, and graph navigation all target the extensionless React route.
 
 The static client keeps Markdown and wiki navigation, backlinks, validation, source views, TOCs, and graph inspection. It does not expose Git, search, or the runtime-only section command, perform live API requests, or subscribe to project changes.
 

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -483,15 +483,41 @@ export async function checkIndex(
   const errors: IndexError[] = [];
   const allPaths = await run.entries();
 
-  // Flag non-.md files. The machine-local external override is the one
-  // intentional non-Markdown configuration file in the vault.
+  const referencedResources = new Set<string>();
+  for (const file of await run.markdownFiles()) {
+    for (const link of await run.links(file)) {
+      if ('identifier' in link) continue;
+      const target = parseLocalMarkdownTarget(link.url);
+      if (!target || target.kind === 'invalid-backslash' || !target.path) {
+        continue;
+      }
+      const absolutePath = resolve(dirname(file), target.path);
+      const resourcePath = toPosix(relative(latticeDir, absolutePath));
+      if (
+        resourcePath &&
+        resourcePath !== '..' &&
+        !resourcePath.startsWith('../') &&
+        !resourcePath.toLowerCase().endsWith('.md')
+      ) {
+        referencedResources.add(resourcePath);
+      }
+    }
+  }
+
+  // Flag non-.md files unless Markdown reaches them as local resources. The
+  // machine-local external override is the other intentional non-Markdown
+  // configuration file in the vault.
   for (const p of allPaths) {
     const name = p.includes('/') ? p.slice(p.lastIndexOf('/') + 1) : p;
-    if (!name.endsWith('.md') && p !== 'config.local.yaml') {
+    if (
+      !name.endsWith('.md') &&
+      p !== 'config.local.yaml' &&
+      !referencedResources.has(p)
+    ) {
       const relDir = basename(latticeDir) + '/';
       errors.push({
         dir: relDir,
-        message: `"${p}" is not a .md file — only markdown files belong in the checked directory`,
+        message: `"${p}" is not a .md file or a referenced local resource — remove it or link to it from Markdown`,
       });
     }
   }

--- a/src/view/document-route.ts
+++ b/src/view/document-route.ts
@@ -1,4 +1,5 @@
 const DOCUMENT_PREFIX = '/docs/';
+const RESOURCE_PREFIX = '/resources/';
 const MARKDOWN_EXTENSION = '.md';
 
 function encodePath(path: string): string {
@@ -40,6 +41,37 @@ export function rawDocumentPath(pathname: string): string | null {
   return path?.toLowerCase().endsWith(MARKDOWN_EXTENSION) ? path : null;
 }
 
+/** Build the browser route for a non-Markdown file stored in the vault. */
+export function documentResourceUrl(path: string): string {
+  return `${RESOURCE_PREFIX}${encodePath(path)}`;
+}
+
+/** Resolve a browser resource route to a safe vault-relative file path. */
+export function documentResourcePath(pathname: string): string | null {
+  if (!pathname.startsWith(RESOURCE_PREFIX)) return null;
+  try {
+    const segments = pathname
+      .slice(RESOURCE_PREFIX.length)
+      .split('/')
+      .map(decodeURIComponent);
+    if (
+      segments.length === 0 ||
+      segments.some(
+        (segment) =>
+          !segment ||
+          segment === '.' ||
+          segment === '..' ||
+          segment.includes('\\'),
+      )
+    ) {
+      return null;
+    }
+    return segments.join('/');
+  } catch {
+    return null;
+  }
+}
+
 /** Keep relative Markdown-to-Markdown links inside the rendered document UI. */
 export function rewriteDocumentLink(value: string, sourcePath: string): string {
   if (
@@ -63,6 +95,10 @@ export function rewriteDocumentLink(value: string, sourcePath: string): string {
   }
   if (resolved.origin !== 'http://lat.local') return value;
   const path = rawDocumentPath(resolved.pathname);
-  if (!path) return value;
-  return `${documentUrl(path)}${resolved.search}${resolved.hash}`;
+  if (path) {
+    return `${documentUrl(path)}${resolved.search}${resolved.hash}`;
+  }
+  const resourcePath = decodeDocumentPath(resolved.pathname);
+  if (!resourcePath) return value;
+  return `${documentResourceUrl(resourcePath)}${resolved.search}${resolved.hash}`;
 }

--- a/src/view/markdown.ts
+++ b/src/view/markdown.ts
@@ -584,6 +584,11 @@ export async function renderMarkdown(
       node.url = options.rewriteMarkdownLink(authoredUrl);
     }
   });
+  visit(tree, 'image', (node) => {
+    if (options.rewriteMarkdownLink) {
+      node.url = options.rewriteMarkdownLink(node.url);
+    }
+  });
 
   const firstHeading = tree.children.find((node) => node.type === 'heading');
   const title = firstHeading

--- a/src/view/server.ts
+++ b/src/view/server.ts
@@ -26,7 +26,11 @@ import {
 import { createViewSearch, type ViewSearch } from './search.js';
 import { createViewStore, type ViewStore } from './store.js';
 import { rewriteClientAssetUrls } from './client-shell.js';
-import { documentUrl, rawDocumentPath } from './document-route.js';
+import {
+  documentResourcePath,
+  documentUrl,
+  rawDocumentPath,
+} from './document-route.js';
 
 const DEFAULT_HOST = '127.0.0.1';
 export const DEFAULT_VIEW_PORT = 4242;
@@ -119,8 +123,17 @@ function contentType(path: string): string {
       return 'text/javascript; charset=utf-8';
     case '.json':
       return 'application/json; charset=utf-8';
+    case '.gif':
+      return 'image/gif';
+    case '.jpeg':
+    case '.jpg':
+      return 'image/jpeg';
+    case '.png':
+      return 'image/png';
     case '.svg':
       return 'image/svg+xml';
+    case '.webp':
+      return 'image/webp';
     case '.woff2':
       return 'font/woff2';
     default:
@@ -511,6 +524,19 @@ export async function startViewServer(
             source.content,
             headOnly,
           );
+        } catch (error) {
+          if (!(error instanceof ViewDocumentNotFoundError)) throw error;
+          send(res, 404, 'text/plain; charset=utf-8', error.message, headOnly);
+        }
+        return;
+      }
+
+      const resourcePath = documentResourcePath(url.pathname);
+      if (resourcePath) {
+        try {
+          const body = await store.getDocumentResource(resourcePath);
+          res.setHeader('Cache-Control', 'no-cache');
+          send(res, 200, contentType(resourcePath), body, headOnly);
         } catch (error) {
           if (!(error instanceof ViewDocumentNotFoundError)) throw error;
           send(res, 404, 'text/plain; charset=utf-8', error.message, headOnly);

--- a/src/view/static-build.ts
+++ b/src/view/static-build.ts
@@ -34,6 +34,7 @@ import {
 import { createViewStore } from './store.js';
 import { rewriteClientAssetUrls } from './client-shell.js';
 import {
+  documentResourcePath,
   documentPath,
   documentUrl,
   rawDocumentPath,
@@ -114,6 +115,10 @@ export function staticViewUrl(value: string, basePath: string): string {
     const route = url.pathname.slice(1).replace(/\/+$/, '');
     const suffix = `${url.search}${url.hash}`;
     return `${basePath}${route}${suffix}`;
+  }
+  if (url.pathname.startsWith('/resources/')) {
+    const route = url.pathname.slice(1);
+    return `${basePath}${route}${url.search}${url.hash}`;
   }
   for (const prefix of ['/code/', '/external/'] as const) {
     if (!url.pathname.startsWith(prefix)) continue;
@@ -571,6 +576,7 @@ export async function buildStaticView(
     const shell = clientShell(clientHtml, basePath);
     const index = { ...store.getIndex(), git: null, logoText };
     const documents = new Map<string, ViewDocument>();
+    const documentResources = new Set<string>();
     const sourceRequests = new Map<string, ViewStaticSourceRequest>();
     const externalRequests = new Set<string>();
 
@@ -581,6 +587,17 @@ export async function buildStaticView(
     for (const path of index.files) {
       const document = await store.getDocument(path);
       documents.set(path, document);
+      for (const url of documentTreeUrls(document.tree)) {
+        let parsed: URL;
+        try {
+          parsed = new URL(url, 'http://lat.local');
+        } catch {
+          continue;
+        }
+        if (parsed.origin !== 'http://lat.local') continue;
+        const resourcePath = documentResourcePath(parsed.pathname);
+        if (resourcePath) documentResources.add(resourcePath);
+      }
       sourceRequestsFromDocument(document, sourceRequests);
       externalRequestsFromDocument(
         document,
@@ -698,6 +715,20 @@ export async function buildStaticView(
       await writeFile(rawPath, source.content);
       const route = `docs/${path.slice(0, -'.md'.length)}`;
       await writeRouteShell(payloadDir, route, shell);
+    }
+
+    for (const path of [...documentResources].sort()) {
+      let content: Buffer;
+      try {
+        content = await store.getDocumentResource(path);
+      } catch (error) {
+        throw new Error(
+          `Could not export document resource ${path}: ${(error as Error).message}`,
+        );
+      }
+      const outputPath = join(payloadDir, 'resources', ...path.split('/'));
+      await mkdir(dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, content);
     }
 
     const sourceFiles = new Map<string, string>();

--- a/src/view/store.ts
+++ b/src/view/store.ts
@@ -575,6 +575,28 @@ export class ViewStore {
     return { path: requestedPath, content: await readFile(path, 'utf8') };
   }
 
+  async getDocumentResource(requestedPath: string): Promise<Buffer> {
+    if (
+      !requestedPath ||
+      requestedPath.includes('\\') ||
+      isAbsolute(requestedPath) ||
+      requestedPath.toLowerCase().endsWith('.md')
+    ) {
+      throw new ViewDocumentNotFoundError('Document resource not found');
+    }
+    let path: string;
+    try {
+      path = await realpath(resolve(this.latDir, requestedPath));
+      if (!isInside(this.realLatDir, path) || !(await stat(path)).isFile()) {
+        throw new ViewDocumentNotFoundError('Document resource not found');
+      }
+      return await readFile(path);
+    } catch (error) {
+      if (error instanceof ViewDocumentNotFoundError) throw error;
+      throw new ViewDocumentNotFoundError('Document resource not found');
+    }
+  }
+
   editDocument(
     requestedPath: string,
     baseContent: string,

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -2022,11 +2022,12 @@ describe('error-long-body', () => {
 
 describe('error-non-md-file', () => {
   // @lat: [[check-index#Detects non-markdown file]]
-  it('reports non-.md file as error', async () => {
+  it('reports an unreferenced non-.md file but allows a linked resource', async () => {
     const errors = await checkIndex(latDir('error-non-md-file'));
     const nonMd = errors.filter((e) => e.message.includes('not a .md file'));
     expect(nonMd).toHaveLength(1);
     expect(nonMd[0].message).toContain('README');
+    expect(nonMd[0].message).not.toContain('asset.svg');
   });
 
   // @lat: [[check-index#Non-markdown files excluded from index listing]]

--- a/tests/cases/error-non-md-file/lat.md/asset.svg
+++ b/tests/cases/error-non-md-file/lat.md/asset.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+  <title>Project asset</title>
+  <path d="M0 0h1v1H0z"/>
+</svg>

--- a/tests/cases/error-non-md-file/lat.md/lat.md
+++ b/tests/cases/error-non-md-file/lat.md/lat.md
@@ -2,4 +2,6 @@
 
 Project documentation root.
 
+![Project asset](asset.svg)
+
 - [[notes]] — Some notes

--- a/tests/cases/view-project/lat.md/lat.md
+++ b/tests/cases/view-project/lat.md/lat.md
@@ -7,6 +7,8 @@ lat:
 
 Documentation used to exercise the local browser.
 
+![Project mark](media/project.svg)
+
 [Read the guide](guide.md#details).
 
 The browser resolves [[guide|wiki navigation]], [[guide#Details|wiki heading links]], and [[guide#Details|the same heading again]].

--- a/tests/cases/view-project/lat.md/media/project.svg
+++ b/tests/cases/view-project/lat.md/media/project.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <title>Project mark</title>
+  <circle cx="8" cy="8" r="7" fill="#ddd"/>
+</svg>

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -261,6 +261,21 @@ describe('lat ui', () => {
     );
     expect(escapingRawResponse.status).toBe(404);
 
+    const resourceResponse = await fetch(
+      new URL('/resources/media/project.svg', view.url),
+    );
+    expect(resourceResponse.status).toBe(200);
+    expect(resourceResponse.headers.get('content-type')).toBe('image/svg+xml');
+    expect(await resourceResponse.text()).toContain('<circle');
+    const missingResourceResponse = await fetch(
+      new URL('/resources/media/missing.svg', view.url),
+    );
+    expect(missingResourceResponse.status).toBe(404);
+    const escapingResourceResponse = await fetch(
+      new URL('/resources/..%2F..%2Fpackage.json', view.url),
+    );
+    expect(escapingResourceResponse.status).toBe(404);
+
     const sourceShell = await fetch(new URL('/code/src/app.ts', view.url));
     expect(sourceShell.status).toBe(200);
     expect(await sourceShell.text()).toContain('lat ui shell');
@@ -296,6 +311,9 @@ describe('lat ui', () => {
     );
     expect(staticViewUrl('/graph?node=document%3Alat.md', '/project/')).toBe(
       '/project/graph/?node=document%3Alat.md',
+    );
+    expect(staticViewUrl('/resources/media/project.svg', '/project/')).toBe(
+      '/project/resources/media/project.svg',
     );
     expect(staticViewAssetUrl('/assets/logo.svg', '/project/')).toBe(
       '/project/assets/logo.svg',
@@ -406,6 +424,12 @@ describe('lat ui', () => {
       expect(existsSync(join(payloadDir, 'graph', 'index.html'))).toBe(true);
       expect(existsSync(join(payloadDir, 'search', 'index.html'))).toBe(false);
       expect(existsSync(join(payloadDir, 'assets', 'app.js'))).toBe(true);
+      expect(
+        readFileSync(
+          join(payloadDir, 'resources', 'media', 'project.svg'),
+          'utf8',
+        ),
+      ).toContain('<circle');
       expect(existsSync(join(outputDir, 'assets'))).toBe(false);
       expect(existsSync(join(outputDir, 'data'))).toBe(false);
 
@@ -658,13 +682,13 @@ describe('lat ui', () => {
       graphSelectionForUrl(
         graph,
         new URL(
-          '/code/src/app.ts?from=lat.md%2Flat%23View+Project&line=16#run',
+          '/code/src/app.ts?from=lat.md%2Flat%23View+Project&line=18#run',
           view.url,
         ),
       ),
     ).toEqual({
       nodeId: 'source:src/app.ts#run',
-      target: '/code/src/app.ts?from=lat.md%2Flat%23View+Project&line=16#run',
+      target: '/code/src/app.ts?from=lat.md%2Flat%23View+Project&line=18#run',
     });
     expect(
       graphSelectionForUrl(graph, new URL('/code/src/app.ts?at=5', view.url)),
@@ -1363,7 +1387,10 @@ describe('lat ui', () => {
     expect(viewDocumentHtml(document)).toContain(
       'href="/code/src/app.ts?from=lat.md%2Flat%23View+Project',
     );
-    expect(viewDocumentHtml(document)).toContain('line=16#run');
+    expect(viewDocumentHtml(document)).toContain('line=18#run');
+    expect(viewDocumentHtml(document)).toContain(
+      'src="/resources/media/project.svg"',
+    );
     expect(viewDocumentHtml(document)).toContain(
       'class="wiki-link-segmented wiki-link-code"',
     );
@@ -1481,7 +1508,7 @@ describe('lat ui', () => {
     url.searchParams.set('path', 'src/app.ts');
     url.searchParams.set('symbol', 'run');
     url.searchParams.set('from', 'lat.md/lat#View Project');
-    url.searchParams.set('line', '16');
+    url.searchParams.set('line', '18');
     const response = await fetch(url);
     const source = (await response.json()) as ViewSourceDocument;
 


### PR DESCRIPTION
Allow Markdown documents to link contained non-Markdown files without making arbitrary vault files valid. Serve and copy referenced resources securely in live and static UI modes, with containment and MIME coverage.

## Stack

Merge in this order; each PR is based on the one above it.

1. #128 — Validate Lat with the built CLI
**2. #124 — Support linked resources inside Markdown vaults**
3. #126 — Discover source references from tracked files
4. #125 — Centralize semantic search threshold policy
5. #127 — Share the Lat UI Express runtime
6. #122 — Build and deploy Lat UI sites
7. #129 — Reorganize the Lat vault as the public site