### PR TITLE
Centralize semantic search defaults

### DIFF
--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -340,13 +340,13 @@ Implementation: [[src/mcp/server.ts]]
 Semantic search across `lat.md` sections using vector embeddings. Works **offline by default** — no
 API key required.
 
-Usage: `lat search [query] [--limit=5] [--threshold=0.35] [--debug]`
+Usage: `lat search [query] [--limit=<n>] [--threshold=<score>] [--debug]`
 
 Query is optional — `lat search` with no query just builds the index on first use. `lat search` only reads; rebuilding is [[cli#reindex]]. Results include a navigation hint footer suggesting `lat locate`, `lat refs`, and `lat search` for further exploration — this makes the tools self-documenting so agents discover them organically.
 
 `--debug` appends each result's cosine-similarity score, rounded to six decimal places. Scores stay hidden by default, including in the MCP `lat_search` output.
 
-Search returns only results whose cosine-similarity score is at least `--threshold` (`0.35` by default). The accepted range is `0` to `1`; lower the threshold to favor recall or raise it to favor precision. MCP `lat_search` uses the same default and accepts the same optional threshold. All search paths discard negative similarities, including UI and prompt-hook retrieval, because they indicate semantic opposition rather than relevance.
+Search returns at most `--limit` results ([[src/search/search.ts#DEFAULT_SEARCH_LIMIT]] by default) whose cosine-similarity score is at least `--threshold` ([[src/search/search.ts#DEFAULT_SEARCH_THRESHOLD]] by default). The accepted threshold range is `0` to `1`; lower it to favor recall or raise it to favor precision. The vector-search core owns both defaults: CLI, MCP, and prompt-hook retrieval share them unless their interfaces supply an explicit override, while the UI deliberately requests its own named limit.
 
 Core search logic in [[src/cli/search.ts#runSearch]] (returns matched sections), used by both the CLI command and [[cli#mcp]] `lat_search` tool. Indexing/storage internals are in `src/search/`; all embedding generation lives in the `@lat.md/embed` package (see [[cli#search#Embeddings]]).
 

--- a/lat.md/tests/search.md
+++ b/lat.md/tests/search.md
@@ -2,6 +2,7 @@
 lat:
   require-code-mention: true
 ---
+
 # Search
 
 Tests in `tests/search.test.ts`.
@@ -39,10 +40,14 @@ first.
 Semantic search returns only candidates at or above the requested cosine-similarity threshold so
 callers can trade recall for less low-relevance noise.
 
-### Discards negative similarity scores
+### Applies the shared default similarity threshold
 
-Every semantic-search path applies a zero score floor even without an explicit relevance threshold,
-so results pointing away from the query in embedding space are never returned.
+Every semantic-search path applies [[src/search/search.ts#DEFAULT_SEARCH_THRESHOLD]] unless its public interface supplies an
+explicit override, keeping CLI, MCP, hooks, and UI ranking policy aligned.
+
+### Applies the shared default result limit
+
+CLI, MCP, and prompt-hook semantic search use [[src/search/search.ts#DEFAULT_SEARCH_LIMIT]] unless a caller explicitly overrides it; the UI retains its named presentation-specific limit.
 
 ### Finds performance section for latency query
 

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -5,6 +5,7 @@ import { findLatticeDir } from '../project-discovery.js';
 import { plainStyler, type CmdContext } from '../context.js';
 import { expandPrompt } from './expand.js';
 import { runSearch } from './search.js';
+import { DEFAULT_SEARCH_LIMIT } from '../search/search.js';
 import { getSection, formatSectionOutput } from './section.js';
 import { checkMd, checkCodeRefs, checkIndex, checkSections } from './check.js';
 import { CheckRunContext } from './check-context.js';
@@ -69,10 +70,16 @@ async function searchAndExpand(
     // Read-only: search an existing index but never build/update it here. A fresh
     // repo's first prompt must not trigger a full local embed pass — that's what
     // `lat search` / `lat reindex` are for. Returns no matches until then.
-    result = await runSearch(ctx.latDir, userPrompt, 5, undefined, {
-      buildIndex: false,
-      project: await commandProjectAnalysis(ctx),
-    });
+    result = await runSearch(
+      ctx.latDir,
+      userPrompt,
+      DEFAULT_SEARCH_LIMIT,
+      undefined,
+      {
+        buildIndex: false,
+        project: await commandProjectAnalysis(ctx),
+      },
+    );
   } catch {
     // No usable backend (e.g. reindex required, key rejected) — skip semantic
     // enrichment silently rather than blocking the user's prompt.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,6 +11,10 @@ import { fileURLToPath } from 'node:url';
 import { Command, InvalidArgumentError } from 'commander';
 import { resolveCheckContext, resolveContext } from './context.js';
 import type { CmdResult } from '../context.js';
+import {
+  DEFAULT_SEARCH_LIMIT,
+  DEFAULT_SEARCH_THRESHOLD,
+} from '../search/search.js';
 
 type CheckTargetArgs = {
   args: string[];
@@ -342,11 +346,15 @@ program
   .command('search')
   .description('Semantic search across lat.md sections')
   .argument('[query]', 'search query in plain English')
-  .option('--limit <n>', 'max results', '5')
+  .option(
+    '--limit <n>',
+    `max results (default: ${DEFAULT_SEARCH_LIMIT})`,
+    String(DEFAULT_SEARCH_LIMIT),
+  )
   .option('--debug', 'show result similarity scores')
   .option(
     '--threshold <score>',
-    'minimum cosine similarity score (default: 0.35)',
+    `minimum cosine similarity score (default: ${DEFAULT_SEARCH_THRESHOLD})`,
     parseSimilarityThreshold,
   )
   .action(

--- a/src/cli/search.ts
+++ b/src/cli/search.ts
@@ -18,7 +18,7 @@ import {
   type Embedder,
 } from '../search/embedder.js';
 import { indexSections, type IndexStats } from '../search/index.js';
-import { DEFAULT_SEARCH_THRESHOLD, searchSections } from '../search/search.js';
+import { searchSections } from '../search/search.js';
 import type { SectionMatch } from '../lattice-model.js';
 import {
   analyzeMarkdownProject,
@@ -256,7 +256,7 @@ export async function searchCommand(
     const project = await commandProjectAnalysis(ctx);
     const result = await runSearch(ctx.latDir, query, opts.limit, progress, {
       project,
-      threshold: opts.threshold ?? DEFAULT_SEARCH_THRESHOLD,
+      threshold: opts.threshold,
     });
 
     if (result.matches.length === 0) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,7 +7,10 @@ import { plainStyler, type CmdContext, type CmdResult } from '../context.js';
 import { locateCommand } from '../cli/locate.js';
 import { sectionCommand } from '../cli/section.js';
 import { searchCommand } from '../cli/search.js';
-import { DEFAULT_SEARCH_THRESHOLD } from '../search/search.js';
+import {
+  DEFAULT_SEARCH_LIMIT,
+  DEFAULT_SEARCH_THRESHOLD,
+} from '../search/search.js';
 import { expandCommand } from '../cli/expand.js';
 import { checkAllCommand } from '../cli/check.js';
 import { refsCommand, type Scope } from '../cli/refs.js';
@@ -64,8 +67,8 @@ export async function startMcpServer(): Promise<void> {
       limit: z
         .number()
         .optional()
-        .default(5)
-        .describe('Max results (default 5)'),
+        .default(DEFAULT_SEARCH_LIMIT)
+        .describe(`Max results (default ${DEFAULT_SEARCH_LIMIT})`),
       threshold: z
         .number()
         .min(0)

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -1,6 +1,7 @@
 import type { Client } from '@libsql/client';
 import type { Embedder } from './embedder.js';
 
+export const DEFAULT_SEARCH_LIMIT = 5;
 export const DEFAULT_SEARCH_THRESHOLD = 0.35;
 
 export type SearchResult = {
@@ -15,8 +16,8 @@ export async function searchSections(
   db: Client,
   query: string,
   embedder: Embedder,
-  limit = 5,
-  threshold = 0,
+  limit = DEFAULT_SEARCH_LIMIT,
+  threshold = DEFAULT_SEARCH_THRESHOLD,
 ): Promise<SearchResult[]> {
   const [queryVec] = await embedder.embed([query]);
   const vecJson = JSON.stringify(queryVec);

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -12,7 +12,11 @@ import {
   closeDb,
 } from '../src/search/db.js';
 import { indexSections } from '../src/search/index.js';
-import { searchSections } from '../src/search/search.js';
+import {
+  DEFAULT_SEARCH_LIMIT,
+  DEFAULT_SEARCH_THRESHOLD,
+  searchSections,
+} from '../src/search/search.js';
 import { runSearch } from '../src/cli/search.js';
 import { formatResultList } from '../src/format.js';
 import { plainStyler, type CmdContext } from '../src/context.js';
@@ -95,6 +99,8 @@ describe('search (rag, local)', () => {
       db,
       'how do we handle user login and security?',
       embedder,
+      DEFAULT_SEARCH_LIMIT,
+      0,
     );
     expect(results.length).toBeGreaterThan(0);
     expect(results[0].id).toContain('Authentication');
@@ -105,9 +111,21 @@ describe('search (rag, local)', () => {
   // @lat: [[search#RAG Tests#Filters results below the similarity threshold]]
   it('filters results below the similarity threshold', async () => {
     const query = 'how do we handle user login and security?';
-    const results = await searchSections(db, query, embedder);
+    const results = await searchSections(
+      db,
+      query,
+      embedder,
+      DEFAULT_SEARCH_LIMIT,
+      0,
+    );
     const threshold = (results[0].score + results[1].score) / 2;
-    const filtered = await searchSections(db, query, embedder, 5, threshold);
+    const filtered = await searchSections(
+      db,
+      query,
+      embedder,
+      DEFAULT_SEARCH_LIMIT,
+      threshold,
+    );
 
     expect(filtered.map((result) => result.id)).toEqual([results[0].id]);
     expect(filtered[0].score).toBeGreaterThanOrEqual(threshold);
@@ -119,6 +137,8 @@ describe('search (rag, local)', () => {
       db,
       'what tools do we use to measure response times?',
       embedder,
+      DEFAULT_SEARCH_LIMIT,
+      0,
     );
     expect(results.length).toBeGreaterThan(0);
     expect(results[0].id).toContain('Performance');
@@ -182,12 +202,44 @@ describe('search result formatting', () => {
   });
 });
 
-describe('search score floor', () => {
-  // @lat: [[search#RAG Tests#Discards negative similarity scores]]
-  it('discards negative cosine similarities without an explicit threshold', async () => {
+describe('search threshold policy', () => {
+  // @lat: [[search#RAG Tests#Applies the shared default result limit]]
+  it('applies the shared default result limit', async () => {
+    const db = {
+      execute: vi.fn().mockResolvedValue({ rows: [] }),
+    } as unknown as Client;
+    const embedder = {
+      name: 'test',
+      dimensions: 1,
+      embed: vi.fn().mockResolvedValue([[1]]),
+    };
+
+    await searchSections(db, 'query', embedder);
+
+    expect(db.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ args: ['[1]', '[1]', DEFAULT_SEARCH_LIMIT] }),
+    );
+  });
+
+  // @lat: [[search#RAG Tests#Applies the shared default similarity threshold]]
+  it('applies the shared default unless a caller overrides it', async () => {
     const db = {
       execute: vi.fn().mockResolvedValue({
         rows: [
+          {
+            id: 'relevant',
+            file: 'relevant.md',
+            heading: 'Relevant',
+            content: 'Relevant match',
+            score: DEFAULT_SEARCH_THRESHOLD,
+          },
+          {
+            id: 'weak',
+            file: 'weak.md',
+            heading: 'Weak',
+            content: 'Weak match',
+            score: DEFAULT_SEARCH_THRESHOLD - 0.01,
+          },
           {
             id: 'negative',
             file: 'negative.md',
@@ -211,9 +263,21 @@ describe('search score floor', () => {
       embed: vi.fn().mockResolvedValue([[1]]),
     };
 
-    const results = await searchSections(db, 'query', embedder);
+    const defaults = await searchSections(db, 'query', embedder);
+    const overridden = await searchSections(
+      db,
+      'query',
+      embedder,
+      DEFAULT_SEARCH_LIMIT,
+      0,
+    );
 
-    expect(results.map((result) => result.id)).toEqual(['zero']);
+    expect(defaults.map((result) => result.id)).toEqual(['relevant']);
+    expect(overridden.map((result) => result.id)).toEqual([
+      'relevant',
+      'weak',
+      'zero',
+    ]);
   });
 });
 
@@ -261,6 +325,8 @@ describe('search (rag, legacy cache upgrade)', () => {
         latDir,
         'how do we handle user login and security?',
         5,
+        undefined,
+        { threshold: 0 },
       );
       expect(result.matches.length).toBeGreaterThan(0);
       expect(result.matches[0].section.id).toContain('Authentication');


### PR DESCRIPTION
Make the vector-search primitive own the shared result-limit and similarity-threshold defaults so CLI, MCP, and prompt hooks inherit one policy while retaining explicit overrides. The UI deliberately keeps its named presentation-specific result limit.\n\nDocumentation links those defaults to their source constants instead of duplicating literal values.\n\n## Stack\n\nMerge in this order; each PR is based on the one above it.\n\n1. #128 — Validate Lat with the built CLI\n2. #124 — Support linked resources inside Markdown vaults\n3. #126 — Discover source references from tracked files\n**4. #125 — Centralize semantic search defaults**\n5. #127 — Share the Lat UI Express runtime\n6. #122 — Build and deploy Lat UI sites\n7. #129 — Reorganize the Lat vault as the public site