### PR TITLE
Discover source references from tracked files

### DIFF
--- a/lat.md/dev-process.md
+++ b/lat.md/dev-process.md
@@ -122,19 +122,21 @@ pnpm --filter lat-md-website build
 
 ## File Walking
 
-All directory walking goes through [[src/walk.ts#walkEntries]], the single entry point with nested `.gitignore` support that excludes `.git/` and dotfiles or dot-directories before recursive traversal.
+All directory walking goes through [[src/walk.ts#walkEntries]], the single entry point with nested `.gitignore` support that excludes `.git/`, dotfiles, dot-directories, and symlinks before recursive traversal.
 
 `walkEntries()` retains `ignore-walk`'s nested ignore-rule contexts but owns traversal itself. A bounded queue runs one asynchronous directory job per available CPU; each job uses `readdir` directory entries instead of per-entry `lstat` calls, filters files with file semantics only, and submits visible child directories back to the queue. Results are sorted after reduction, not cached, so long-lived processes such as the MCP server always observe the current filesystem.
 
 Nearest-project discovery and Markdown file listing live in parser-free [[src/project-discovery.ts]]. Finding `lat.md/` walks ancestor paths without loading the directory walker; listing Markdown files dynamically loads `walkEntries()` only when enumeration is requested.
 
-Pre-traversal dot filtering prevents transient files under Lat-owned `.cache` directories from racing concurrent project scans. The nested `.lat-ui-build` marker is the sole exception because the TypeScript code scanner consumes it to exclude the marker's complete generated output directory.
+Pre-traversal filtering prevents transient files under dot-directories and dependency trees under `node_modules/` from racing or polluting non-Git project scans.
 
 [[src/code-refs.ts#walkFiles]] calls `walkEntries()` then additionally skips `.md` files, `lat.md/`, `.claude/`, and sub-projects (directories containing their own `lat.md/`).
 
 [[src/code-refs.ts#createCodeReferenceDiscovery]] exposes separate lazy operations for scanning `@lat:` comments and listing the supported source-file scope. The project-scoped object coalesces repeated calls and shares ripgrep exclusion discovery; [[src/code-refs.ts#scanCodeRefs]] and [[src/code-refs.ts#discoverSourceFiles]] are focused one-shot APIs for callers that need only one result.
 
-Both operations first try `rg` (ripgrep), falling back to pure TypeScript discovery and scanning. Ripgrep honors nested `.gitignore` files even outside a Git checkout, uses the fallback's case-insensitive ignore semantics, and excludes dot paths, Markdown, Lat documentation, generated UI output, and nested Lat projects. The [[src/source-formats.ts#SOURCE_FILE_EXTENSIONS|supported-source registry]] becomes a custom rg file type rather than positive globs, because positive globs can re-include ignored files. The UI requests the explicit source inventory for its live-update scope; `lat check` requests only references.
+Git projects enumerate their tracked regular source files once, excluding symlinks, sources beneath dot-directories, the root vault, and nested Lat projects, then give that identical ordered list to ripgrep or the TypeScript scanner. Untracked build output and ignored files therefore never enter project validation.
+
+Outside Git, both operations first try `rg` (ripgrep), falling back to pure TypeScript discovery and scanning. Ripgrep honors nested `.gitignore` files, uses the fallback's case-insensitive ignore semantics, and excludes dot paths, Markdown, Lat documentation, dependency trees, and nested Lat projects. The [[src/source-formats.ts#SOURCE_FILE_EXTENSIONS|supported-source registry]] becomes a custom rg file type rather than positive globs, because positive globs can re-include ignored files. The UI requests the explicit source inventory for its live-update scope; `lat check` requests only references.
 
 The TS fallback uses `walkFiles` for discovery and exclusion filtering, then reads and scans supported files through a bounded async pool with one slot per CPU available to the process. Both paths sort file and reference results by source position, so scheduling cannot reorder references or read diagnostics. `CodeRef.file` is always stored as a projectRoot-relative path; consumers convert to cwd-relative only at display time. Setting `_LAT_DISABLE_RG=1` forces the TS fallback; used in tests to cover both paths.
 

--- a/lat.md/tests/check-code-refs.md
+++ b/lat.md/tests/check-code-refs.md
@@ -19,6 +19,8 @@ Given a `lat.md` file with [[markdown#Frontmatter#require-code-mention]] and a l
 
 `scanCodeRefs` and the separate `discoverSourceFiles` API share the central source-extension registry across ripgrep and TypeScript fallbacks. Unsupported files are neither searched nor included in the UI's source watch scope.
 
+Git projects inspect tracked regular files; non-Git projects walk visible, non-ignored files.
+
 ## Scans Dart references around annotations
 
 Dart `// @lat:` references retain their authored line numbers before ordinary declarations and between metadata annotations and declarations, and dangling targets remain normal code-reference errors.

--- a/lat.md/tests/ts-fallback.md
+++ b/lat.md/tests/ts-fallback.md
@@ -33,4 +33,8 @@ With more source files than the machine-derived fallback concurrency slots, the 
 
 ## Matches ripgrep discovery semantics
 
-The source-discovery and code-reference APIs return matching ordered files and references through TypeScript and ripgrep across nested ignores, negations, dot paths, generated output, nested Lat projects, and non-Git directories.
+The source-discovery and code-reference APIs return matching ordered files and references through TypeScript and ripgrep across nested ignores, negations, dot paths, symlinks, dependency trees, nested Lat projects, and non-Git directories.
+
+## Git repositories scan tracked sources
+
+Both scanners consume the same Git-tracked regular-file list while excluding symlinks, files beneath dot-directories, untracked files, and complete nested Lat projects.

--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -60,7 +60,7 @@ Relative Markdown links are rewritten against their source document and then to 
 
 Builds reject any existing destination, including an empty directory or prior export. For a new path, the builder stages the complete artifact beside the destination and renames it into place only after generation succeeds.
 
-The generated marker makes later project-wide scans ignore the artifact instead of indexing rendered JSON or bundles as source. Any destination that could contain the project root is also rejected.
+Git-backed projects naturally exclude generated artifacts from later project-wide scans because source discovery reads the tracked-file set. Any destination that could contain the project root is also rejected.
 
 ## Live Markdown editing
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -39,8 +39,6 @@ Entry assets use that base, while lazy JavaScript, CSS, fonts, and renderer chun
 
 Any existing output path is rejected before snapshot work begins, including an empty directory or prior generated export. Callers must remove it explicitly or choose a new destination.
 
-The generated marker excludes the entire artifact from both ripgrep and fallback code-reference scans, preventing exported JSON and bundles from polluting project checks or search.
-
 ## Builds the website wiki from published embedding packages
 
 Website deployments compile the current Lat UI against pinned npm releases of the embedding engine and model package, avoiding Rust, WASM, and model generation in the Vercel build.

--- a/src/code-refs.ts
+++ b/src/code-refs.ts
@@ -1,28 +1,24 @@
+import { lstatSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { availableParallelism } from 'node:os';
-import { join, posix, relative } from 'node:path';
+import { join, relative } from 'node:path';
 import { isSourceFilePath, SOURCE_FILE_EXTENSIONS } from './source-formats.js';
 import { toPosix } from './path.js';
-import { walkEntries } from './walk.js';
+import { ALWAYS_IGNORED_DIRECTORIES, walkEntries } from './walk.js';
 import type { Profiler } from './profiler.js';
 
 /** Glob patterns used to exclude directories/files from code-ref scanning.
  *  Shared between rg args and the TS fallback's walkFiles filter. */
-const EXCLUDE_DIRS = ['lat.md', '.claude'];
+const EXCLUDE_DIRS = ['lat.md', '.claude', ...ALWAYS_IGNORED_DIRECTORIES];
 const EXCLUDE_GLOBS = ['*.md', '.*', '**/.*'];
 const RG_IGNORE_ARGS = ['--no-require-git', '--ignore-file-case-insensitive'];
 
 /** Walk supported source files for code-ref scanning. Uses walkEntries for
- *  .gitignore support, then additionally skips lat.md/, .claude/, generated
- *  output, and sub-projects. */
+ *  .gitignore support, then additionally skips lat.md/, .claude/, and
+ *  sub-projects. */
 export async function walkFiles(dir: string): Promise<string[]> {
   const entries = (await walkEntries(dir)).map(toPosix);
-  const generatedOutputs = new Set(
-    entries
-      .filter((entry) => entry.endsWith('/.lat-ui-build'))
-      .map((entry) => `${posix.dirname(entry)}/`),
-  );
 
   // Collect directories that contain their own lat.md/ (sub-projects)
   const subProjects = new Set<string>();
@@ -37,7 +33,6 @@ export async function walkFiles(dir: string): Promise<string[]> {
         isSourceFilePath(e) &&
         !e.startsWith('lat.md/') &&
         !e.startsWith('.claude/') &&
-        ![...generatedOutputs].some((prefix) => e.startsWith(prefix)) &&
         ![...subProjects].some((prefix) => e.startsWith(prefix)),
     )
     .map((e) => join(dir, e));
@@ -148,44 +143,71 @@ async function findSubProjects(projectRoot: string): Promise<string[]> {
   return [...subProjects];
 }
 
-/** Find static UI exports so generated JSON and bundles never become code refs. */
-async function findGeneratedOutputs(projectRoot: string): Promise<string[]> {
+function nestedLatProjects(paths: readonly string[]): string[] {
+  const projects = new Set<string>();
+  for (const path of paths) {
+    const index = path.indexOf('/lat.md/');
+    if (index !== -1) projects.add(path.slice(0, index));
+  }
+  return [...projects];
+}
+
+function hasDotDirectory(path: string): boolean {
+  const parts = path.split('/');
+  return parts.slice(0, -1).some((part) => part.startsWith('.'));
+}
+
+/** List readable regular source files tracked by the enclosing Git repository. */
+async function findGitTrackedSourceFiles(
+  projectRoot: string,
+): Promise<string[] | null> {
   const out = await tryExec(
-    'rg',
-    [
-      '--files',
-      ...RG_IGNORE_ARGS,
-      '--hidden',
-      '--glob',
-      '**/.lat-ui-build',
-      '.',
-    ],
+    'git',
+    ['ls-files', '--stage', '-z', '--', '.'],
     projectRoot,
   );
-  if (!out) return [];
+  if (out === null) return null;
 
-  return [
-    ...new Set(
-      out
-        .split('\n')
-        .filter(Boolean)
-        .map((line) => toPosix(line).replace(/^\.\//, ''))
-        .filter((line) => line.endsWith('/.lat-ui-build'))
-        .map((line) => posix.dirname(line)),
-    ),
-  ];
+  const entries = out
+    .split('\0')
+    .filter(Boolean)
+    .flatMap((entry) => {
+      const tab = entry.indexOf('\t');
+      if (tab === -1) return [];
+      const mode = entry.slice(0, entry.indexOf(' '));
+      if (mode !== '100644' && mode !== '100755') return [];
+      return [toPosix(entry.slice(tab + 1))];
+    });
+  const subProjects = nestedLatProjects(entries);
+  const candidates = entries.filter(
+    (path) =>
+      isSourceFilePath(path) &&
+      !hasDotDirectory(path) &&
+      !path.startsWith('lat.md/') &&
+      !subProjects.some(
+        (project) => path === project || path.startsWith(`${project}/`),
+      ),
+  );
+
+  return candidates
+    .flatMap((path) => {
+      const absolute = join(projectRoot, path);
+      try {
+        return lstatSync(absolute).isFile() ? [absolute] : [];
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+        throw error;
+      }
+    })
+    .sort((a, b) => a.localeCompare(b, 'en'));
 }
 
 /** Build rg glob exclusion args. */
-function rgExcludeArgs(
-  subProjects: string[],
-  generatedOutputs: string[],
-): string[] {
+function rgExcludeArgs(subProjects: string[]): string[] {
   const args: string[] = [];
   for (const dir of EXCLUDE_DIRS) args.push('--glob', `!${dir}/`);
   for (const glob of EXCLUDE_GLOBS) args.push('--glob', `!${glob}`);
   for (const sp of subProjects) args.push('--glob', `!${sp}/`);
-  for (const output of generatedOutputs) args.push('--glob', `!${output}/`);
   return args;
 }
 
@@ -205,15 +227,59 @@ async function discoverRipgrepExcludes(
   projectRoot: string,
   profile?: Pick<Profiler, 'time'>,
 ): Promise<string[]> {
-  const [subProjects, generatedOutputs] = await Promise.all([
-    profileScan(profile, 'find nested lat.md projects with ripgrep', () =>
-      findSubProjects(projectRoot),
-    ),
-    profileScan(profile, 'find generated UI outputs with ripgrep', () =>
-      findGeneratedOutputs(projectRoot),
-    ),
-  ]);
-  return rgExcludeArgs(subProjects, generatedOutputs);
+  const subProjects = await profileScan(
+    profile,
+    'find nested lat.md projects with ripgrep',
+    () => findSubProjects(projectRoot),
+  );
+  return rgExcludeArgs(subProjects);
+}
+
+function ripgrepPathBatches(paths: string[]): string[][] {
+  const batches: string[][] = [];
+  let batch: string[] = [];
+  let length = 0;
+  for (const path of paths) {
+    if (batch.length > 0 && length + path.length + 1 > 16_000) {
+      batches.push(batch);
+      batch = [];
+      length = 0;
+    }
+    batch.push(path);
+    length += path.length + 1;
+  }
+  if (batch.length > 0) batches.push(batch);
+  return batches;
+}
+
+async function runRipgrepBatches(
+  projectRoot: string,
+  args: string[],
+  paths: string[],
+): Promise<string[] | null> {
+  const batches = ripgrepPathBatches(paths);
+  if (batches.length === 0) return [];
+  const results = new Array<string | null>(batches.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(availableParallelism(), batches.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        const index = nextIndex++;
+        if (index >= batches.length) return;
+        results[index] = await tryExec(
+          'rg',
+          [...args, '--', ...batches[index]],
+          projectRoot,
+        );
+      }
+    }),
+  );
+
+  return results.some((result) => result === null)
+    ? null
+    : (results as string[]);
 }
 
 /** Search supported source files for code references with ripgrep. */
@@ -221,6 +287,7 @@ async function tryRipgrepCodeRefs(
   projectRoot: string,
   excludes: string[],
   profile?: Pick<Profiler, 'time'>,
+  files?: string[],
 ): Promise<CodeRef[] | null> {
   const searchArgs = [
     '--no-heading',
@@ -230,16 +297,26 @@ async function tryRipgrepCodeRefs(
     ...rgSourceIncludeArgs(),
     ...excludes,
     '@lat:.*\\[\\[',
-    '.',
   ];
-  const out = await profileScan(
+  const outputs = await profileScan(
     profile,
     'scan @lat references with ripgrep',
-    () => tryExec('rg', searchArgs, projectRoot),
+    () =>
+      files
+        ? runRipgrepBatches(
+            projectRoot,
+            searchArgs,
+            files.map((file) => toPosix(relative(projectRoot, file))),
+          )
+        : tryExec('rg', [...searchArgs, '.'], projectRoot).then((output) =>
+            output === null ? null : [output],
+          ),
   );
-  if (out === null) return null;
+  if (outputs === null) return null;
 
-  const { refs } = parseGrepOutput(out, projectRoot);
+  const refs = outputs.flatMap(
+    (output) => parseGrepOutput(output, projectRoot).refs,
+  );
   refs.sort((a, b) => a.file.localeCompare(b.file, 'en') || a.line - b.line);
   return refs;
 }
@@ -398,14 +475,25 @@ export function createCodeReferenceDiscovery(
   profile?: Pick<Profiler, 'time'>,
 ): CodeReferenceDiscovery {
   let excludesPromise: Promise<string[]> | undefined;
+  let trackedFilesPromise: Promise<string[] | null> | undefined;
   let sourceFilesPromise: Promise<string[]> | undefined;
   let scanPromise: Promise<ScanResult> | undefined;
 
   const ripgrepExcludes = () =>
     (excludesPromise ??= discoverRipgrepExcludes(projectRoot, profile));
 
+  const trackedFiles = () =>
+    (trackedFilesPromise ??= profileScan(
+      profile,
+      'list tracked source files with git',
+      () => findGitTrackedSourceFiles(projectRoot),
+    ));
+
   const listSourceFiles = () =>
     (sourceFilesPromise ??= (async () => {
+      const tracked = await trackedFiles();
+      if (tracked !== null) return tracked;
+
       if (process.env._LAT_DISABLE_RG !== '1') {
         const files = await tryRipgrepSourceFiles(
           projectRoot,
@@ -422,11 +510,13 @@ export function createCodeReferenceDiscovery(
 
   const scan = () =>
     (scanPromise ??= (async () => {
+      const tracked = await trackedFiles();
       if (process.env._LAT_DISABLE_RG !== '1') {
         const refs = await tryRipgrepCodeRefs(
           projectRoot,
-          await ripgrepExcludes(),
+          tracked === null ? await ripgrepExcludes() : [],
           profile,
+          tracked ?? undefined,
         );
         if (refs !== null) return { refs };
       }

--- a/src/view/static-build.ts
+++ b/src/view/static-build.ts
@@ -40,7 +40,6 @@ import {
   rawDocumentPath,
 } from './document-route.js';
 
-const BUILD_MARKER = '.lat-ui-build';
 const defaultClientDir = fileURLToPath(new URL('./client/', import.meta.url));
 
 export type StaticViewBuildOptions = {
@@ -827,11 +826,6 @@ export async function buildStaticView(
     if (payloadDir !== stagingDir) {
       await writeFile(join(stagingDir, 'index.html'), entryRedirect);
     }
-    await writeFile(
-      join(stagingDir, BUILD_MARKER),
-      `${JSON.stringify({ version: 1 })}\n`,
-    );
-
     await rename(stagingDir, outputDir);
     return {
       documents: documents.size,

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -27,6 +27,9 @@ type IgnoreWalkerConstructor = new (
 const IgnoreWalker = (walk as unknown as { Walker: IgnoreWalkerConstructor })
   .Walker;
 
+/** Dependency trees are never project source, even without ignore metadata. */
+export const ALWAYS_IGNORED_DIRECTORIES = ['node_modules'] as const;
+
 class IgnoreContext extends IgnoreWalker {
   filterEntry(
     entry: string,
@@ -39,10 +42,10 @@ class IgnoreContext extends IgnoreWalker {
         .split(/[\\/]/)
         .some(
           (part) =>
-            part.startsWith('.') &&
-            part !== '.' &&
-            part !== '..' &&
-            part !== '.lat-ui-build',
+            ALWAYS_IGNORED_DIRECTORIES.includes(
+              part as (typeof ALWAYS_IGNORED_DIRECTORIES)[number],
+            ) ||
+            (part.startsWith('.') && part !== '.' && part !== '..'),
         )
     ) {
       return false;
@@ -72,6 +75,8 @@ async function readDirectory(job: DirectoryJob): Promise<DirectoryResult> {
   const directories: DirectoryJob[] = [];
   const files: string[] = [];
   for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+
     if (entry.isDirectory()) {
       const passDirectory = job.ignoreContext.filterEntry(entry.name, true);
       if (!passDirectory) continue;

--- a/tests/code-refs.test.ts
+++ b/tests/code-refs.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
 import { availableParallelism, tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -80,6 +81,8 @@ async function createDiscoveryParityProject(): Promise<string> {
     'pruned/reincluded',
     '.hidden',
     'generated',
+    'node_modules/highlight.js',
+    'packages/example/node_modules/highlight.js',
     'subproject/lat.md',
     'subproject/src',
   ];
@@ -154,10 +157,24 @@ async function createDiscoveryParityProject(): Promise<string> {
       join(root, '.hidden', 'ignored.ts'),
       codeReference('//', 'Specs#hidden'),
     ),
-    writeFile(join(root, 'generated', '.lat-ui-build'), ''),
     writeFile(
-      join(root, 'generated', 'ignored.ts'),
+      join(root, 'generated', 'visible.ts'),
       codeReference('//', 'Specs#generated'),
+    ),
+    writeFile(
+      join(root, 'node_modules', 'highlight.js', 'ignored.ts'),
+      codeReference('//', 'Specs#root dependency'),
+    ),
+    writeFile(
+      join(
+        root,
+        'packages',
+        'example',
+        'node_modules',
+        'highlight.js',
+        'ignored.ts',
+      ),
+      codeReference('//', 'Specs#nested dependency'),
     ),
     writeFile(join(root, 'subproject', 'lat.md', 'specs.md'), '# Specs\n'),
     writeFile(
@@ -165,6 +182,10 @@ async function createDiscoveryParityProject(): Promise<string> {
       codeReference('//', 'Specs#subproject'),
     ),
   ]);
+
+  if (process.platform !== 'win32') {
+    await symlink('src/visible.ts', join(root, 'linked.ts'));
+  }
 
   return root;
 }
@@ -187,10 +208,7 @@ describe('supported source code-reference scanning', () => {
       const scanOperations: string[] = [];
       const [preferred, preferredFiles] = await Promise.all([
         scanCodeRefs(root, {
-          async time<T>(
-            label: string,
-            work: () => Promise<T>,
-          ): Promise<T> {
+          async time<T>(label: string, work: () => Promise<T>): Promise<T> {
             scanOperations.push(label);
             return work();
           },
@@ -258,6 +276,7 @@ describe('supported source code-reference scanning', () => {
         fallbackDiscovery.listSourceFiles(),
       ]);
       expect(relativeFiles(root, fallbackFiles)).toEqual([
+        'generated/visible.ts',
         'nested/kept.skip.ts',
         'nested/visible.ts',
         'pruned/reincluded/kept.ts',
@@ -267,6 +286,64 @@ describe('supported source code-reference scanning', () => {
 
       delete process.env._LAT_DISABLE_RG;
       if (!(await hasRipgrep())) return;
+      const preferredDiscovery = createCodeReferenceDiscovery(root);
+      const [preferred, preferredFiles] = await Promise.all([
+        preferredDiscovery.scan(),
+        preferredDiscovery.listSourceFiles(),
+      ]);
+      expect(relativeFiles(root, preferredFiles)).toEqual(
+        relativeFiles(root, fallbackFiles),
+      );
+      expect(comparableRefs(preferred)).toEqual(comparableRefs(fallback));
+    } finally {
+      if (original === undefined) delete process.env._LAT_DISABLE_RG;
+      else process.env._LAT_DISABLE_RG = original;
+    }
+  });
+
+  // @lat: [[tests/ts-fallback#Git repositories scan tracked sources]]
+  it('uses the same tracked source scope with ripgrep and TypeScript', async () => {
+    const root = await createDiscoveryParityProject();
+    execFileSync('git', ['init', '--quiet'], { cwd: root });
+    execFileSync(
+      'git',
+      [
+        'add',
+        '.gitignore',
+        'nested/.gitignore',
+        '.hidden/ignored.ts',
+        'nested/visible.ts',
+        'src/visible.ts',
+        'subproject/lat.md/specs.md',
+        'subproject/src/ignored.ts',
+      ],
+      { cwd: root },
+    );
+    const symlinkBlob = execFileSync('git', ['hash-object', '-w', '--stdin'], {
+      cwd: root,
+      encoding: 'utf8',
+      input: 'src/visible.ts\n',
+    }).trim();
+    execFileSync(
+      'git',
+      ['update-index', '--add', '--cacheinfo', `120000,${symlinkBlob},linked.ts`],
+      { cwd: root },
+    );
+    const original = process.env._LAT_DISABLE_RG;
+
+    try {
+      process.env._LAT_DISABLE_RG = '1';
+      const fallbackDiscovery = createCodeReferenceDiscovery(root);
+      const [fallback, fallbackFiles] = await Promise.all([
+        fallbackDiscovery.scan(),
+        fallbackDiscovery.listSourceFiles(),
+      ]);
+      expect(relativeFiles(root, fallbackFiles)).toEqual([
+        'nested/visible.ts',
+        'src/visible.ts',
+      ]);
+
+      delete process.env._LAT_DISABLE_RG;
       const preferredDiscovery = createCodeReferenceDiscovery(root);
       const [preferred, preferredFiles] = await Promise.all([
         preferredDiscovery.scan(),

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -14,7 +14,6 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { plainStyler, type CmdContext } from '../src/context.js';
-import { createCodeReferenceDiscovery } from '../src/code-refs.js';
 import { uiCommand } from '../src/cli/ui.js';
 import { uiBuildCommand } from '../src/cli/ui-build.js';
 import { analyzeMarkdownFile } from '../src/markdown-analysis.js';
@@ -450,34 +449,7 @@ describe('lat ui', () => {
         '/project/docs/lat',
       );
 
-      const discovery = createCodeReferenceDiscovery(staticProjectRoot);
-      const [scanned, sourceFiles] = await Promise.all([
-        discovery.scan(),
-        discovery.listSourceFiles(),
-      ]);
-      expect(
-        scanned.refs.some((reference) => reference.file.startsWith('site/')),
-      ).toBe(false);
-      expect(sourceFiles.some((path) => path.startsWith(`${outputDir}/`))).toBe(
-        false,
-      );
-      const disableRipgrep = process.env._LAT_DISABLE_RG;
-      process.env._LAT_DISABLE_RG = '1';
-      try {
-        const fallbackDiscovery =
-          createCodeReferenceDiscovery(staticProjectRoot);
-        const [fallbackScan, fallbackSourceFiles] = await Promise.all([
-          fallbackDiscovery.scan(),
-          fallbackDiscovery.listSourceFiles(),
-        ]);
-        expect(fallbackScan.refs).toEqual(scanned.refs);
-        expect(
-          fallbackSourceFiles.some((path) => path.startsWith(`${outputDir}/`)),
-        ).toBe(false);
-      } finally {
-        if (disableRipgrep === undefined) delete process.env._LAT_DISABLE_RG;
-        else process.env._LAT_DISABLE_RG = disableRipgrep;
-      }
+      expect(existsSync(join(outputDir, '.lat-ui-build'))).toBe(false);
 
       await expect(
         uiBuildCommand(staticContext, outputDir, {


### PR DESCRIPTION
Use the Git-tracked regular-file set as the authoritative source scope and feed it to both ripgrep and the TypeScript fallback. Exclude symlinks and source files beneath dot-prefixed directories in Git and non-Git projects, preserve matching nested `.gitignore` behavior, skip dependency trees, batch ripgrep paths, and remove generated marker files.

## Stack

Merge in this order; each PR is based on the one above it.

1. #128 — Validate Lat with the built CLI
2. #124 — Support linked resources inside Markdown vaults
**3. #126 — Discover source references from tracked files**
4. #125 — Centralize semantic search threshold policy
5. #127 — Share the Lat UI Express runtime
6. #122 — Build and deploy Lat UI sites
7. #129 — Reorganize the Lat vault as the public site