### PR TITLE
Validate Lat with the built CLI

### DIFF
--- a/.github/workflows/lat-check.yaml
+++ b/.github/workflows/lat-check.yaml
@@ -9,4 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: lars20070/lat-check-action@v1
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm buildall
+      - run: node dist/src/cli/index.js check

--- a/lat.md/dev-process.md
+++ b/lat.md/dev-process.md
@@ -104,6 +104,8 @@ Every test run includes a full `tsc --noEmit` pass over the entire codebase. If 
 
 CI (`.github/workflows/ci.yml`) runs the full `pnpm buildall` + `vitest` suite on a `[ubuntu-latest, windows-latest]` matrix (`fail-fast: false`) so platform-specific regressions — path separators (see [[parser#Short Ref Resolution]]) and line endings — are caught before release.
 
+The separate graph-validation workflow installs and builds the workspace, then runs `lat check` through the checkout's built CLI. This lets unreleased parser and validation behavior verify the repository without third-party actions or the last npm release.
+
 Cross-platform correctness relies on two conventions: stored paths are always POSIX ([[src/path.ts#toPosix]]), and a repo-root `.gitattributes` (`eol=lf`) keeps Windows checkouts from rewriting line endings and breaking the markdown roundtrip. Functional init tests run the built CLI and database seeding in child processes so native libsql handles close before temp cleanup. Lower-level tests that retain handles or spawn a fake `git` use [[tests/util.ts#rmDirBestEffort]].
 
 ## Website Development


### PR DESCRIPTION
Build the repository CLI in CI and use that exact artifact to validate the Lat knowledge graph. This removes the third-party lat-check action and ensures graph validation follows the source under review.

## Stack

Merge in this order; each PR is based on the one above it.

**1. #128 — Validate Lat with the built CLI**
2. #124 — Support linked resources inside Markdown vaults
3. #126 — Discover source references from tracked files
4. #125 — Centralize semantic search threshold policy
5. #127 — Share the Lat UI Express runtime
6. #122 — Build and deploy Lat UI sites
7. #129 — Reorganize the Lat vault as the public site