### PR TITLE
Reuse indexed semantic search sessions

### DIFF
--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -348,7 +348,7 @@ Query is optional — `lat search` with no query just builds the index on first 
 
 Search returns at most `--limit` results ([[src/search/search.ts#DEFAULT_SEARCH_LIMIT]] by default) whose cosine-similarity score is at least `--threshold` ([[src/search/search.ts#DEFAULT_SEARCH_THRESHOLD]] by default). The accepted threshold range is `0` to `1`; lower it to favor recall or raise it to favor precision. The vector-search core owns both defaults: CLI, MCP, and prompt-hook retrieval share them unless their interfaces supply an explicit override, while the UI deliberately requests its own named limit.
 
-Core search logic in [[src/cli/search.ts#runSearch]] (returns matched sections), used by both the CLI command and [[cli#mcp]] `lat_search` tool. Indexing/storage internals are in `src/search/`; all embedding generation lives in the `@lat.md/embed` package (see [[cli#search#Embeddings]]).
+Core search logic in [[src/cli/search.ts#runSearch]] (returns matched sections), used by both the CLI command and [[cli#mcp]] `lat_search` tool. [[src/search/query.ts#openIndexedSearchSession]] reuses one database handle and embedder when a runtime serves multiple queries. Indexing/storage internals are in `src/search/`; all embedding generation lives in the `@lat.md/embed` package (see [[cli#search#Embeddings]]).
 
 ### Backend selection
 

--- a/lat.md/tests/search.md
+++ b/lat.md/tests/search.md
@@ -87,3 +87,11 @@ search: the mismatched table is dropped and rebuilt at 384 dims and the query su
 
 This is the pre-versioning `.cache` upgrade path — before, the stale table was queried and threw a
 raw dimension-mismatch error.
+
+### Reuses an indexed search session
+
+An indexed search session opens its database and embedder once, applies each query's limit and threshold, resolves known section ids, and closes owned resources exactly once.
+
+### Skips an unbuilt search index
+
+Opening a query-only session before an index exists returns no matches without loading an embedder, while still closing the database cleanly.

--- a/src/cli/search.ts
+++ b/src/cli/search.ts
@@ -20,6 +20,8 @@ import {
 import { indexSections, type IndexStats } from '../search/index.js';
 import { searchSections } from '../search/search.js';
 import type { SectionMatch } from '../lattice-model.js';
+import type { Section } from '../lattice-model.js';
+import { searchIndexedSections } from '../search/query.js';
 import {
   analyzeMarkdownProject,
   commandProjectAnalysis,
@@ -43,13 +45,14 @@ async function withDb<T>(
   latDir: string,
   progress: IndexProgress | undefined,
   project: MarkdownProjectAnalysis,
+  cacheDir: string | undefined,
   fn: (
     db: Awaited<ReturnType<typeof openDb>>,
     embedder: Embedder,
     project: MarkdownProjectAnalysis,
   ) => Promise<T>,
 ): Promise<T> {
-  const db = openDb(latDir);
+  const db = openDb(latDir, cacheDir);
 
   try {
     await ensureMeta(db);
@@ -117,21 +120,6 @@ async function withDb<T>(
   }
 }
 
-/** Resolve raw search hits (by id) to full section matches. */
-async function resolveMatches(
-  project: MarkdownProjectAnalysis,
-  results: { id: string; score: number }[],
-): Promise<SectionMatch[]> {
-  if (results.length === 0) return [];
-
-  return results.flatMap((result) => {
-    const section = project.sectionById.get(result.id.toLowerCase());
-    return section
-      ? [{ section, reason: 'semantic match', score: result.score }]
-      : [];
-  });
-}
-
 /**
  * Run a semantic search across lat.md sections.
  * Handles indexing (with optional progress callback). Returns matched sections.
@@ -150,35 +138,24 @@ export async function runSearch(
   opts?: {
     buildIndex?: boolean;
     project?: MarkdownProjectAnalysis;
+    sectionById?: ReadonlyMap<string, Section>;
     threshold?: number;
+    cacheDir?: string;
   },
 ): Promise<SearchResult> {
   if (opts?.buildIndex === false) {
-    const db = openDb(latDir);
-    try {
-      await ensureMeta(db);
-      const stored = await getStoredModel(db);
-      // Never built (or a legacy pre-versioning cache) — leave building to
-      // `lat search`; don't load the embedder just to embed the query.
-      if (stored === null) return { query, matches: [] };
-      const embedder = await embedderForIndex(stored, latDir);
-      await ensureSectionsSchema(db, embedder.dimensions);
-      const results = await searchSections(
-        db,
-        query,
-        embedder,
-        limit,
-        opts.threshold,
-      );
-      const project =
-        opts.project ??
-        (await analyzeMarkdownProject(latDir, dirname(latDir), {
+    const sectionById =
+      opts.sectionById ??
+      opts.project?.sectionById ??
+      (
+        await analyzeMarkdownProject(latDir, dirname(latDir), {
           executor: 'auto',
-        }));
-      return { query, matches: await resolveMatches(project, results) };
-    } finally {
-      await closeDb(db);
-    }
+        })
+      ).sectionById;
+    return searchIndexedSections(latDir, query, limit, sectionById, {
+      cacheDir: opts.cacheDir,
+      threshold: opts.threshold,
+    });
   }
 
   const project =
@@ -186,16 +163,30 @@ export async function runSearch(
     (await analyzeMarkdownProject(latDir, dirname(latDir), {
       executor: 'auto',
     }));
-  return withDb(latDir, progress, project, async (db, embedder, analyzed) => {
-    const results = await searchSections(
-      db,
-      query,
-      embedder,
-      limit,
-      opts?.threshold,
-    );
-    return { query, matches: await resolveMatches(analyzed, results) };
-  });
+  return withDb(
+    latDir,
+    progress,
+    project,
+    opts?.cacheDir,
+    async (db, embedder, analyzed) => {
+      const results = await searchSections(
+        db,
+        query,
+        embedder,
+        limit,
+        opts?.threshold,
+      );
+      return {
+        query,
+        matches: results.flatMap((result) => {
+          const section = analyzed.sectionById.get(result.id.toLowerCase());
+          return section
+            ? [{ section, reason: 'semantic match', score: result.score }]
+            : [];
+        }),
+      };
+    },
+  );
 }
 
 /**
@@ -206,13 +197,14 @@ export async function runIndex(
   latDir: string,
   progress?: IndexProgress,
   analyzedProject?: MarkdownProjectAnalysis,
+  options: { cacheDir?: string } = {},
 ): Promise<void> {
   const project =
     analyzedProject ??
     (await analyzeMarkdownProject(latDir, dirname(latDir), {
       executor: 'auto',
     }));
-  await withDb(latDir, progress, project, async () => {});
+  await withDb(latDir, progress, project, options.cacheDir, async () => {});
 }
 
 export function cliProgress(s: Styler): IndexProgress {

--- a/src/search/db.ts
+++ b/src/search/db.ts
@@ -2,8 +2,8 @@ import { createClient, type Client } from '@libsql/client';
 import { mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 
-export function openDb(latDir: string): Client {
-  const cacheDir = join(latDir, '.cache');
+export function openDb(latDir: string, requestedCacheDir?: string): Client {
+  const cacheDir = requestedCacheDir ?? join(latDir, '.cache');
   mkdirSync(cacheDir, { recursive: true });
 
   const client = createClient({

--- a/src/search/embedder.ts
+++ b/src/search/embedder.ts
@@ -9,6 +9,11 @@ import { getLlmKey, getRepoEmbedding } from '../config.js';
 export type { Embedder };
 export { EmbeddingAuthError };
 
+export type CreateSearchEngine = (key?: string) => Promise<Embedder>;
+
+const defaultCreateSearchEngine: CreateSearchEngine = (key) =>
+  key ? createEmbedder({ key }) : createEmbedder({ model: minilm });
+
 /** `meta.embedding_model` value for an embedder, e.g. `local:minilm-l6-v2:384`. */
 export function modelKey(embedder: Embedder): string {
   return `${embedder.name}:${embedder.dimensions}`;
@@ -47,15 +52,16 @@ export function localEmbedder(): Promise<Embedder> {
 export async function embedderForIndex(
   storedModel: string | null,
   latDir: string,
+  createSearchEngine: CreateSearchEngine = defaultCreateSearchEngine,
 ): Promise<Embedder> {
   if (storedModel === null) {
-    if (getRepoEmbedding(latDir) === 'local') return localEmbedder();
+    if (getRepoEmbedding(latDir) === 'local') return createSearchEngine();
     // No durable preference — decide from the environment, record it later.
-    return embedderFromEnv();
+    return createSearchEngine(getLlmKey());
   }
 
   if (storedModel.startsWith('local:')) {
-    return localEmbedder(); // ignores LAT_LLM_KEY entirely
+    return createSearchEngine(); // ignores LAT_LLM_KEY entirely
   }
 
   // Remote-pinned index: needs a key that resolves to the same model.
@@ -66,7 +72,7 @@ export async function embedderForIndex(
         `Run 'lat reindex' to switch to the local model or restore the key.`,
     );
   }
-  const embedder = await createEmbedder({ key });
+  const embedder = await createSearchEngine(key);
   if (modelKey(embedder) !== storedModel) {
     throw new ReindexRequiredError(
       `This index was built with '${storedModel}', but the current key resolves ` +

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -1,0 +1,108 @@
+import type { Section, SectionMatch } from '../lattice-model.js';
+import {
+  closeDb,
+  ensureMeta,
+  ensureSectionsSchema,
+  getStoredModel,
+  openDb,
+} from './db.js';
+import { embedderForIndex, type CreateSearchEngine } from './embedder.js';
+import { searchSections } from './search.js';
+
+export type IndexedSearchResult = {
+  query: string;
+  matches: SectionMatch[];
+};
+
+export type IndexedSearchSession = {
+  search: (
+    query: string,
+    limit: number,
+    threshold?: number,
+  ) => Promise<IndexedSearchResult>;
+  close: () => Promise<void>;
+};
+
+/** Open one reusable database and embedder for a sequence of index queries. */
+export async function openIndexedSearchSession(
+  latDir: string,
+  sectionById: ReadonlyMap<string, Section>,
+  options: {
+    cacheDir?: string;
+    createSearchEngine?: CreateSearchEngine;
+  } = {},
+): Promise<IndexedSearchSession> {
+  const db = openDb(latDir, options.cacheDir);
+  let closed = false;
+  const close = async () => {
+    if (closed) return;
+    closed = true;
+    await closeDb(db);
+  };
+  try {
+    await ensureMeta(db);
+    const stored = await getStoredModel(db);
+    if (stored === null) {
+      return {
+        search: async (query) => {
+          if (closed) throw new Error('Search session is closed');
+          return { query, matches: [] };
+        },
+        close,
+      };
+    }
+    const embedder = await embedderForIndex(
+      stored,
+      latDir,
+      options.createSearchEngine,
+    );
+    await ensureSectionsSchema(db, embedder.dimensions);
+    return {
+      async search(query, limit, threshold) {
+        if (closed) throw new Error('Search session is closed');
+        const results = await searchSections(
+          db,
+          query,
+          embedder,
+          limit,
+          threshold,
+        );
+        return {
+          query,
+          matches: results.flatMap((result) => {
+            const section = sectionById.get(result.id.toLowerCase());
+            return section
+              ? [
+                  {
+                    section,
+                    reason: 'semantic match',
+                    score: result.score,
+                  } satisfies SectionMatch,
+                ]
+              : [];
+          }),
+        };
+      },
+      close,
+    };
+  } catch (error) {
+    await close();
+    throw error;
+  }
+}
+
+/** Query a finished index and resolve its ids from precomputed section data. */
+export async function searchIndexedSections(
+  latDir: string,
+  query: string,
+  limit: number,
+  sectionById: ReadonlyMap<string, Section>,
+  options: { cacheDir?: string; threshold?: number } = {},
+): Promise<IndexedSearchResult> {
+  const session = await openIndexedSearchSession(latDir, sectionById, options);
+  try {
+    return await session.search(query, limit, options.threshold);
+  } finally {
+    await session.close();
+  }
+}

--- a/tests/search-query.test.ts
+++ b/tests/search-query.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Section } from '../src/lattice-model.js';
+
+const mocks = vi.hoisted(() => ({
+  closeDb: vi.fn(),
+  embedderForIndex: vi.fn(),
+  ensureMeta: vi.fn(),
+  ensureSectionsSchema: vi.fn(),
+  getStoredModel: vi.fn(),
+  openDb: vi.fn(),
+  searchSections: vi.fn(),
+}));
+
+vi.mock('../src/search/db.js', () => ({
+  closeDb: mocks.closeDb,
+  ensureMeta: mocks.ensureMeta,
+  ensureSectionsSchema: mocks.ensureSectionsSchema,
+  getStoredModel: mocks.getStoredModel,
+  openDb: mocks.openDb,
+}));
+
+vi.mock('../src/search/embedder.js', () => ({
+  embedderForIndex: mocks.embedderForIndex,
+}));
+
+vi.mock('../src/search/search.js', () => ({
+  searchSections: mocks.searchSections,
+}));
+
+import { openIndexedSearchSession } from '../src/search/query.js';
+
+const section: Section = {
+  id: 'lat.md/guide#Guide',
+  heading: 'Guide',
+  depth: 1,
+  file: 'lat.md/guide',
+  filePath: 'lat.md/guide.md',
+  children: [],
+  startLine: 1,
+  endLine: 3,
+  firstParagraph: 'A guide.',
+};
+
+describe('indexed search sessions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.openDb.mockReturnValue({ database: 'test' });
+    mocks.ensureMeta.mockResolvedValue(undefined);
+    mocks.ensureSectionsSchema.mockResolvedValue(undefined);
+    mocks.closeDb.mockResolvedValue(undefined);
+    mocks.getStoredModel.mockResolvedValue('local:test:1');
+    mocks.embedderForIndex.mockResolvedValue({
+      name: 'local:test',
+      dimensions: 1,
+      embed: vi.fn(),
+    });
+    mocks.searchSections.mockResolvedValue([
+      { id: section.id, score: 0.8 },
+      { id: 'lat.md/missing#Missing', score: 0.7 },
+    ]);
+  });
+
+  // @lat: [[tests/search#RAG Tests#Reuses an indexed search session]]
+  it('reuses one database and embedder across queries', async () => {
+    const createSearchEngine = vi.fn();
+    const sectionById = new Map([[section.id.toLowerCase(), section]]);
+    const session = await openIndexedSearchSession(
+      '/project/lat.md',
+      sectionById,
+      {
+        cacheDir: '/runtime/cache',
+        createSearchEngine,
+      },
+    );
+
+    await expect(session.search('first', 7, 0.4)).resolves.toEqual({
+      query: 'first',
+      matches: [{ section, reason: 'semantic match', score: 0.8 }],
+    });
+    await session.search('second', 3);
+    await session.close();
+    await session.close();
+
+    expect(mocks.openDb).toHaveBeenCalledOnce();
+    expect(mocks.openDb).toHaveBeenCalledWith(
+      '/project/lat.md',
+      '/runtime/cache',
+    );
+    expect(mocks.embedderForIndex).toHaveBeenCalledOnce();
+    expect(mocks.embedderForIndex).toHaveBeenCalledWith(
+      'local:test:1',
+      '/project/lat.md',
+      createSearchEngine,
+    );
+    expect(mocks.ensureSectionsSchema).toHaveBeenCalledWith(
+      expect.anything(),
+      1,
+    );
+    expect(mocks.searchSections).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      'first',
+      expect.anything(),
+      7,
+      0.4,
+    );
+    expect(mocks.searchSections).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      'second',
+      expect.anything(),
+      3,
+      undefined,
+    );
+    expect(mocks.closeDb).toHaveBeenCalledOnce();
+  });
+
+  // @lat: [[tests/search#RAG Tests#Skips an unbuilt search index]]
+  it('returns no matches without loading an embedder for an unbuilt index', async () => {
+    mocks.getStoredModel.mockResolvedValue(null);
+    const session = await openIndexedSearchSession(
+      '/project/lat.md',
+      new Map([[section.id.toLowerCase(), section]]),
+    );
+
+    await expect(session.search('query', 5)).resolves.toEqual({
+      query: 'query',
+      matches: [],
+    });
+    await session.close();
+
+    expect(mocks.embedderForIndex).not.toHaveBeenCalled();
+    expect(mocks.ensureSectionsSchema).not.toHaveBeenCalled();
+    expect(mocks.searchSections).not.toHaveBeenCalled();
+    expect(mocks.closeDb).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Open a semantic-search index once and reuse its database handle and embedder across queries.

- Add a reusable indexed-search session with explicit close semantics.
- Keep result mapping, thresholds, limits, and missing-model behavior in the shared search layer.
- Make the CLI delegate to the same session implementation used by long-lived UI runtimes.
- Cover warm reuse, option forwarding, result mapping, no-model behavior, and idempotent shutdown directly.

## Stack

1. **#133 — Reuse indexed semantic search sessions**
2. #134 — Make embedding assets traceable
3. #132 — Build portable Lat UI sites
4. #135 — Build Lat UI for Vercel
5. #136 — Build deployable site previews in CI
6. #137 — Allow hosted documentation badges in Lat UI
7. #129 — Reorganize the Lat vault as the public site