### PR TITLE
Make embedding assets traceable

### DIFF
--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -392,7 +392,7 @@ All embedding generation is isolated in the `@lat.md/embed` package, exposed thr
 [[packages/embed/src/index.ts#createEmbedder]] entry point returning an `Embedder`
 (`{ name, dimensions, embed() }`). Two backends:
 
-- **local** — a candle (Rust) BERT engine compiled to WebAssembly ([[packages/embed/src/local.ts#createLocalEmbedder]]), driven by a `ModelManifest` from a weights package (`@lat.md/embed-minilm-fp16`, fp16 weights up-cast to fp32 at load). Pure WASM, no native binaries; masked-mean pooling + L2 normalize, matching `sentence-transformers`. Texts are embedded one at a time (the engine is single-threaded with no batch speedup, and padding a batch to its longest item wastes work); large jobs fan out across `worker_threads` (one engine per CPU, [[packages/embed/src/worker.ts]]) while small jobs run inline.
+- **local** — a candle (Rust) BERT engine compiled to WebAssembly ([[packages/embed/src/local.ts#createLocalEmbedder]]), driven by a `ModelManifest` from a weights package (`@lat.md/embed-minilm-fp16`, fp16 weights up-cast to fp32 at load). Pure WASM, no native binaries; the ESM loader reads its binary through a module-relative URL and initializes generated glue explicitly so deployment tracers retain the asset. Masked-mean pooling + L2 normalization matches `sentence-transformers`. Texts are embedded one at a time; large jobs fan out across `worker_threads` (one engine per CPU, [[packages/embed/src/worker.ts]]) while small jobs run inline.
 - **remote** — direct `fetch()` to an OpenAI-compatible `/v1/embeddings` endpoint, batching up to 2048 texts per request ([[packages/embed/src/remote.ts#detectProvider]]).
 
 ### Storage

--- a/lat.md/tests/search.md
+++ b/lat.md/tests/search.md
@@ -95,3 +95,11 @@ An indexed search session opens its database and embedder once, applies each que
 ### Skips an unbuilt search index
 
 Opening a query-only session before an index exists returns no matches without loading an embedder, while still closing the database cleanly.
+
+### Patches generated WASM loading explicitly
+
+The package build replaces wasm-bindgen's opaque filesystem loader with an explicit byte initializer that is idempotent and discoverable by deployment tracers.
+
+### Rejects unknown generated WASM glue
+
+The package build fails clearly when generated wasm-bindgen output no longer contains the loader shape Lat knows how to replace.

--- a/packages/embed-minilm-fp16/src/index.ts
+++ b/packages/embed-minilm-fp16/src/index.ts
@@ -3,11 +3,8 @@
  * The engine up-casts the fp16 weights to fp32 at load, so output quality matches
  * fp32 while the download is ~half the size.
  */
-import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { ModelManifest } from '@lat.md/embed';
-
-const modelDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'model');
 
 const manifest: ModelManifest = {
   id: 'minilm-l6-v2',
@@ -15,9 +12,13 @@ const manifest: ModelManifest = {
   maxTokens: 256,
   pooling: 'mean',
   normalize: true,
-  weightsPath: join(modelDir, 'model.fp16.safetensors'),
-  tokenizerPath: join(modelDir, 'tokenizer.json'),
-  configPath: join(modelDir, 'config.json'),
+  weightsPath: fileURLToPath(
+    new URL('../model/model.fp16.safetensors', import.meta.url),
+  ),
+  tokenizerPath: fileURLToPath(
+    new URL('../model/tokenizer.json', import.meta.url),
+  ),
+  configPath: fileURLToPath(new URL('../model/config.json', import.meta.url)),
 };
 
 export default manifest;

--- a/packages/embed/scripts/copy-wasm.mjs
+++ b/packages/embed/scripts/copy-wasm.mjs
@@ -1,11 +1,19 @@
 /**
  * Copy the built WASM engine into dist/ next to the compiled TS.
  * The CJS glue is renamed engine.js → engine.cjs so it is treated as CommonJS
- * inside this `type: module` package; wasm-loader.ts loads it via createRequire.
+ * inside this `type: module` package. Its self-loading footer is replaced so
+ * wasm-loader.ts can initialize it from an analyzable module-relative URL.
  */
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { patchNodeGlue } from './patch-node-glue.mjs';
 
 const pkgDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const src = join(pkgDir, 'wasm-dist');
@@ -20,6 +28,9 @@ if (!existsSync(glue) || !existsSync(wasm)) {
 }
 
 mkdirSync(dist, { recursive: true });
-copyFileSync(glue, join(dist, 'engine.cjs'));
+writeFileSync(
+  join(dist, 'engine.cjs'),
+  patchNodeGlue(readFileSync(glue, 'utf8')),
+);
 copyFileSync(wasm, join(dist, 'engine_bg.wasm'));
 console.log('Copied WASM engine → dist/');

--- a/packages/embed/scripts/patch-node-glue.mjs
+++ b/packages/embed/scripts/patch-node-glue.mjs
@@ -1,0 +1,29 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+const generatedLoader = `const wasmPath = \`\${__dirname}/engine_bg.wasm\`;
+const wasmBytes = require('fs').readFileSync(wasmPath);
+const wasmModule = new WebAssembly.Module(wasmBytes);
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasm = wasmInstance.exports;
+wasm.__wbindgen_start();`;
+
+const injectedLoader = `let wasm;
+exports.__initialize = function(wasmBytes) {
+    const wasmModule = new WebAssembly.Module(wasmBytes);
+    const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+    wasm = wasmInstance.exports;
+    wasm.__wbindgen_start();
+};`;
+
+export function patchNodeGlue(source) {
+  if (source.includes(injectedLoader)) return source;
+  if (!source.includes(generatedLoader)) {
+    throw new Error('Could not find the wasm-bindgen Node loader');
+  }
+  return source.replace(generatedLoader, injectedLoader);
+}
+
+export async function patchNodeGlueFile(path) {
+  const source = await readFile(path, 'utf8');
+  await writeFile(path, patchNodeGlue(source));
+}

--- a/packages/embed/src/wasm-loader.ts
+++ b/packages/embed/src/wasm-loader.ts
@@ -4,9 +4,8 @@
  * (the same pattern lat.md uses for tree-sitter WASM in `src/source-parser.ts`).
  */
 
+import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
 
 export interface WasmEngine {
   embed(texts: string[]): number[][];
@@ -15,6 +14,7 @@ export interface WasmEngine {
 }
 
 export interface WasmModule {
+  __initialize(bytes: Uint8Array): void;
   Embedder: new (
     weights: Uint8Array,
     tokenizer: Uint8Array,
@@ -28,7 +28,10 @@ let cached: WasmModule | null = null;
 export function loadWasmEngine(): WasmModule {
   if (cached) return cached;
   const require = createRequire(import.meta.url);
-  const here = dirname(fileURLToPath(import.meta.url)); // dist/
-  cached = require(join(here, 'engine.cjs')) as WasmModule;
+  const engine = require('./engine.cjs') as WasmModule;
+  engine.__initialize(
+    new Uint8Array(readFileSync(new URL('./engine_bg.wasm', import.meta.url))),
+  );
+  cached = engine;
   return cached;
 }

--- a/packages/embed/src/worker.ts
+++ b/packages/embed/src/worker.ts
@@ -8,20 +8,9 @@
  */
 import { parentPort, workerData } from 'node:worker_threads';
 import { readFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { loadWasmEngine } from './wasm-loader.js';
 
-const require = createRequire(import.meta.url);
-const enginePath = join(dirname(fileURLToPath(import.meta.url)), 'engine.cjs');
-const { Embedder } = require(enginePath) as {
-  Embedder: new (
-    w: Uint8Array,
-    t: Uint8Array,
-    c: Uint8Array,
-    maxTokens: number,
-  ) => { embed(texts: string[]): number[][] };
-};
+const { Embedder } = loadWasmEngine();
 
 const { weightsPath, tokenizerPath, configPath, maxTokens } = workerData as {
   weightsPath: string;

--- a/tests/embed-assets.test.ts
+++ b/tests/embed-assets.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error Build helpers are plain JavaScript so they can run before TypeScript compilation.
+import { patchNodeGlue } from '../packages/embed/scripts/patch-node-glue.mjs';
+
+const generatedLoader = `const wasmPath = \`${'${__dirname}'}/engine_bg.wasm\`;
+const wasmBytes = require('fs').readFileSync(wasmPath);
+const wasmModule = new WebAssembly.Module(wasmBytes);
+let wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+let wasm = wasmInstance.exports;
+wasm.__wbindgen_start();`;
+
+describe('embedding runtime assets', () => {
+  // @lat: [[tests/search#RAG Tests#Patches generated WASM loading explicitly]]
+  it('replaces wasm-bindgen filesystem loading with explicit initialization', () => {
+    const patched = patchNodeGlue(`before\n${generatedLoader}\nafter`);
+
+    expect(patched).not.toContain("require('fs').readFileSync");
+    expect(patched).toContain('exports.__initialize = function(wasmBytes)');
+    expect(patched).toContain('wasm.__wbindgen_start()');
+    expect(patchNodeGlue(patched)).toBe(patched);
+  });
+
+  // @lat: [[tests/search#RAG Tests#Rejects unknown generated WASM glue]]
+  it('fails when wasm-bindgen changes the loader shape', () => {
+    expect(() => patchNodeGlue('unexpected generated output')).toThrow(
+      'Could not find the wasm-bindgen Node loader',
+    );
+  });
+});


### PR DESCRIPTION
Make the local embedding engine's runtime files discoverable through ordinary module imports and module-relative URLs.

- Export the MiniLM model's exact files through a static descriptor.
- Load the WASM binary through `new URL(..., import.meta.url)`.
- Patch generated Node glue into an explicit initializer instead of an opaque filesystem side effect.
- Fail clearly if upstream wasm-bindgen output changes shape.
- Test patching, repeatability, and failure behavior directly.

This keeps package-owned assets portable for Node file tracers without deployment-specific include globs or no-op references.

## Stack

1. #133 — Reuse indexed semantic search sessions
2. **#134 — Make embedding assets traceable**
3. #132 — Build portable Lat UI sites
4. #135 — Build Lat UI for Vercel
5. #136 — Build deployable site previews in CI
6. #137 — Allow hosted documentation badges in Lat UI
7. #129 — Reorganize the Lat vault as the public site