### PR TITLE
Build Lat UI for Vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ lat.md/.cache
 .codex
 .cursor/hooks.json
 .cursor
+.vercel

--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -96,6 +96,12 @@ The build creates the semantic index once and serializes the flat section metada
 
 Static client configuration treats search as an independent capability: pure static builds omit the control and route, while server builds point the same client at their configured search endpoint. Documents, source views, externals, and the graph remain static in both targets.
 
+### Vercel server export
+
+[[src/view/vercel-server-build.ts#buildVercelServerView]] implements `--target vercel` by composing the portable Node builder with [[src/view/vercel-build.ts#buildVercelOutput]].
+
+It defaults to `.vercel/output/`, builds the Node artifact in temporary sibling staging, and installs its production dependency graph without lifecycle scripts. Node File Trace can then follow the real Express, search, WASM, model, manifest, and index imports while public files move only into the CDN static tree. The staging artifact is removed after success or failure.
+
 ## Live Markdown editing
 
 Live local documents can switch between the rendered tree and an editable Markdown source while static and external documents remain read-only.

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -69,9 +69,27 @@ The Node-target regression test builds a complete portable artifact, loads its g
 
 It verifies the document shell, immutable JavaScript and CSS assets, and semantic results from the real local embedding model and built SQLite index. The test therefore covers the generated application contract rather than substituting a fake search handler.
 
+## Selects server deployment targets
+
+`lat ui build server [output] --target node|vercel` keeps Node as the portable default while making platform packaging explicit.
+
+The `node` target defaults to `.lat-build/server/`. The `vercel` target defaults to `.vercel/output/`, builds the same Node artifact in temporary staging, installs production dependencies without lifecycle scripts, converts it into Build Output API v3, and removes staging. Output, base, force, and logo options apply to both.
+
+## Builds Vercel output directly
+
+The public Vercel target and repository preview convert an installed portable server artifact into Build Output API v3 without recursively invoking Vercel CLI.
+
+`web/public/` becomes the CDN `static/` tree. Vercel's Node File Trace selects the entrypoint, server manifest, vector index, runtime packages, WASM engine, and model weights for one base-path-specific search function without copying public content into it.
+
+Every runtime asset is reachable through a static import or `new URL(relativePath, import.meta.url)`. The embedding loader owns WASM initialization rather than relying on generated CommonJS glue to perform an opaque filesystem read.
+
+The generated configuration applies the shared security policy, gives content-addressed JSON and Vite assets immutable caching, resolves functions and exact static files first, and maps extensionless routes to their physical `index.html` files.
+
 ## Keeps build-only packages out of runtime dependencies
 
 The published CLI declares browser renderer inputs and test-only serializers as development dependencies because consumers execute prebuilt artifacts and should not install redundant source trees.
+
+Node File Trace remains a runtime dependency because the installed CLI invokes it when users select the Vercel server target; the Vercel CLI itself is not required.
 
 ## Renders canonical document trees
 

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@libsql/client": "^0.17.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@repomix/tree-sitter-wasms": "^0.1.17",
+    "@vercel/nft": "^1.10.0",
     "commander": "^14.0.3",
     "diff": "^8.0.4",
     "express": "^5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@repomix/tree-sitter-wasms':
         specifier: ^0.1.17
         version: 0.1.17
+      '@vercel/nft':
+        specifier: ^1.10.0
+        version: 1.11.0(rollup@4.59.0)
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -811,6 +814,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -914,6 +921,11 @@ packages:
   '@mapbox/jsonlint-lines-primitives@2.0.3':
     resolution: {integrity: sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==}
     engines: {node: '>= 22'}
+
+  '@mapbox/node-pre-gyp@2.0.3':
+    resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@mapbox/point-geometry@1.1.0':
     resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
@@ -1026,6 +1038,15 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -1412,6 +1433,11 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vercel/nft@1.11.0':
+    resolution: {integrity: sha512-m1QFg+U+3yPOnP1xSYJ73UIRxLOXdts1JOhiOiyPYqEsALgrXFFINvgUaD6R6iNvaBFAjHllBCbkfx4FuOdpaA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1447,13 +1473,31 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  abbrev@3.0.1:
+    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   add-filename-increment@1.0.0:
     resolution: {integrity: sha512-pFV8VZX8jxuVMIycKvGZkWF/ihnUubu9lbQVnOnZWp7noVxbKQTNj7zG2y9fXdPcuZ6lAN3Drr517HaivGCjdQ==}
     engines: {node: '>=8'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1470,6 +1514,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  async-sema@3.1.1:
+    resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -1484,6 +1531,9 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -1541,6 +1591,10 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -1561,6 +1615,10 @@ packages:
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -1888,6 +1946,9 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1952,6 +2013,9 @@ packages:
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -2001,9 +2065,16 @@ packages:
   gl-matrix@3.4.4:
     resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   graphology-types@0.24.8:
     resolution: {integrity: sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==}
@@ -2096,6 +2167,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -2405,6 +2480,14 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2463,9 +2546,18 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
     engines: {node: '>=18'}
+
+  nopt@8.1.0:
+    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2508,6 +2600,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
@@ -2535,6 +2631,10 @@ packages:
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
 
   pkce-challenge@5.0.1:
@@ -2663,6 +2763,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -2814,6 +2918,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
+    engines: {node: '>=18'}
 
   three@0.185.1:
     resolution: {integrity: sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==}
@@ -3118,6 +3226,10 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
@@ -3595,6 +3707,10 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3715,6 +3831,19 @@ snapshots:
 
   '@mapbox/jsonlint-lines-primitives@2.0.3': {}
 
+  '@mapbox/node-pre-gyp@2.0.3':
+    dependencies:
+      consola: 3.4.2
+      detect-libc: 2.1.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 2.7.0
+      nopt: 8.1.0
+      semver: 7.8.5
+      tar: 7.5.22
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@mapbox/point-geometry@1.1.0': {}
 
   '@mapbox/tiny-sdf@2.2.0': {}
@@ -3813,6 +3942,14 @@ snapshots:
   '@repomix/tree-sitter-wasms@0.1.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rollup/pluginutils@5.4.0(rollup@4.59.0)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.7
+    optionalDependencies:
+      rollup: 4.59.0
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -4197,6 +4334,25 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vercel/nft@1.11.0(rollup@4.59.0)':
+    dependencies:
+      '@mapbox/node-pre-gyp': 2.0.3
+      '@rollup/pluginutils': 5.4.0(rollup@4.59.0)
+      acorn: 8.18.0
+      acorn-import-attributes: 1.9.5(acorn@8.18.0)
+      async-sema: 3.1.1
+      bindings: 1.5.0
+      estree-walker: 2.0.2
+      glob: 13.0.6
+      graceful-fs: 4.2.11
+      node-gyp-build: 4.8.4
+      picomatch: 4.0.7
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
   '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@25.3.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.7
@@ -4251,14 +4407,24 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  abbrev@3.0.1: {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn-import-attributes@1.9.5(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
+  acorn@8.18.0: {}
+
   add-filename-increment@1.0.0:
     dependencies:
       strip-filename-increment: 2.0.1
+
+  agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -4273,6 +4439,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  async-sema@3.1.1: {}
+
   bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -4282,6 +4450,10 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
 
   body-parser@2.2.2:
     dependencies:
@@ -4345,6 +4517,8 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chownr@3.0.0: {}
+
   client-only@0.0.1: {}
 
   comma-separated-tokens@2.0.3: {}
@@ -4356,6 +4530,8 @@ snapshots:
   commander@7.2.0: {}
 
   commander@8.3.0: {}
+
+  consola@3.4.2: {}
 
   content-disposition@1.0.1: {}
 
@@ -4618,8 +4794,7 @@ snapshots:
 
   detect-libc@2.0.2: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   devlop@1.1.0:
     dependencies:
@@ -4700,6 +4875,8 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -4779,6 +4956,8 @@ snapshots:
 
   fflate@0.8.3: {}
 
+  file-uri-to-path@1.0.0: {}
+
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -4833,7 +5012,15 @@ snapshots:
 
   gl-matrix@3.4.4: {}
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
 
   graphology-types@0.24.8: {}
 
@@ -4989,6 +5176,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   iconv-lite@0.6.3:
     dependencies:
@@ -5512,6 +5706,12 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   ms@2.1.3: {}
 
   murmurhash-js@1.0.0: {}
@@ -5562,7 +5762,13 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
+  node-gyp-build@4.8.4: {}
+
   node-releases@2.0.53: {}
+
+  nopt@8.1.0:
+    dependencies:
+      abbrev: 3.0.1
 
   object-assign@4.1.1: {}
 
@@ -5600,6 +5806,11 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
+
   path-to-regexp@8.3.0: {}
 
   pathe@2.0.3: {}
@@ -5619,6 +5830,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.7: {}
 
   pkce-challenge@5.0.1: {}
 
@@ -5785,6 +5998,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-from@5.0.0: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   resolve-protobuf-schema@2.1.0:
@@ -5858,8 +6073,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.8.5:
-    optional: true
+  semver@7.8.5: {}
 
   send@1.2.1:
     dependencies:
@@ -6013,6 +6227,14 @@ snapshots:
   stylis@4.4.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tar@7.5.22:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   three@0.185.1: {}
 
@@ -6299,6 +6521,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  yallist@5.0.0: {}
 
   yaml@2.8.2: {}
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,6 +38,15 @@ type UiRunOptions = {
   port?: number;
 };
 
+type UiServerBuildTarget = 'node' | 'vercel';
+
+function parseUiServerBuildTarget(value: string): UiServerBuildTarget {
+  if (value !== 'node' && value !== 'vercel') {
+    throw new InvalidArgumentError('target must be node or vercel');
+  }
+  return value;
+}
+
 function configureUiRun(command: Command): Command {
   return command
     .option('--logo-text <text>', 'top-left logo text')
@@ -208,19 +217,25 @@ uiBuild
   .description('Build a static Lat UI with a portable search server')
   .argument(
     '[output]',
-    'output directory relative to the project (default: .lat-build/server)',
-    '.lat-build/server',
+    'output directory (default: .lat-build/server for node, .vercel/output for vercel)',
   )
   .option('--base <path>', 'deployment base path', '/')
   .option('--force', 'replace an existing output path')
   .option('--logo-text <text>', 'top-left logo text')
+  .option(
+    '--target <target>',
+    'deployment target: node or vercel',
+    parseUiServerBuildTarget,
+    'node',
+  )
   .action(
     async (
-      output: string,
+      output: string | undefined,
       opts: {
         base: string;
         force?: boolean;
         logoText?: string;
+        target: UiServerBuildTarget;
       },
     ) => {
       const ctx = resolveContext(program.opts());
@@ -231,6 +246,7 @@ uiBuild
           force: opts.force,
           logoText:
             opts.logoText ?? (ui.opts() as { logoText?: string }).logoText,
+          target: opts.target,
         }),
       );
     },

--- a/src/cli/ui-build-server.ts
+++ b/src/cli/ui-build-server.ts
@@ -2,29 +2,50 @@ import type { CmdContext, CmdResult } from '../context.js';
 import {
   buildServerView,
   type ServerViewBuildOptions,
+  type ServerViewBuildResult,
 } from '../view/server-build.js';
 
-export type UiBuildServerOptions = ServerViewBuildOptions;
+export type ServerViewBuildTarget = 'node' | 'vercel';
+
+export type UiBuildServerOptions = ServerViewBuildOptions & {
+  target?: ServerViewBuildTarget;
+};
 
 export type UiBuildServerDependencies = {
   buildNode: typeof buildServerView;
+  buildVercel?: (
+    ctx: CmdContext,
+    output: string,
+    options: ServerViewBuildOptions,
+  ) => Promise<ServerViewBuildResult>;
 };
 
 const defaultDependencies: UiBuildServerDependencies = {
   buildNode: buildServerView,
 };
 
-/** Export immutable UI data with a portable Node semantic-search service. */
+/** Export immutable UI data with a Node or Vercel semantic-search service. */
 export async function uiBuildServerCommand(
   ctx: CmdContext,
-  output = '.lat-build/server',
+  output: string | undefined,
   options: UiBuildServerOptions = {},
   dependencies: UiBuildServerDependencies = defaultDependencies,
 ): Promise<CmdResult> {
   try {
-    const result = await dependencies.buildNode(ctx, output, options);
+    const { target = 'node', ...buildOptions } = options;
+    const resolvedOutput =
+      output ?? (target === 'vercel' ? '.vercel/output' : '.lat-build/server');
+    let result: ServerViewBuildResult;
+    if (target === 'vercel') {
+      const buildVercel =
+        dependencies.buildVercel ??
+        (await import('../view/vercel-server-build.js')).buildVercelServerView;
+      result = await buildVercel(ctx, resolvedOutput, buildOptions);
+    } else {
+      result = await dependencies.buildNode(ctx, resolvedOutput, buildOptions);
+    }
     return {
-      output: `Built ${result.documents} documents and ${result.sources} source views for node at ${result.outputDir}`,
+      output: `Built ${result.documents} documents and ${result.sources} source views for ${target} at ${result.outputDir}`,
     };
   } catch (error) {
     return { output: (error as Error).message, isError: true };

--- a/src/view/vercel-build.ts
+++ b/src/view/vercel-build.ts
@@ -1,0 +1,201 @@
+import {
+  cp,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { nodeFileTrace } from '@vercel/nft';
+import { LAT_UI_CONTENT_SECURITY_POLICY } from '@lat.md/server';
+
+type FileTraceResult = {
+  fileList: Set<string>;
+  warnings: Set<Error>;
+};
+
+export type VercelBuildDependencies = {
+  traceFiles: (
+    files: string[],
+    options: {
+      base: string;
+      conditions: string[];
+      exportsOnly: boolean;
+      processCwd: string;
+    },
+  ) => Promise<FileTraceResult>;
+};
+
+export type VercelBuildOptions = {
+  force?: boolean;
+  warn?: (message: string) => void;
+};
+
+export type VercelBuildResult = {
+  files: number;
+  functionPath: string;
+  outputDir: string;
+};
+
+const defaultDependencies: VercelBuildDependencies = {
+  traceFiles: nodeFileTrace,
+};
+
+function json(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function basePathSegments(basePath: string): string[] {
+  const parsed = new URL(basePath, 'http://lat.local');
+  if (
+    parsed.origin !== 'http://lat.local' ||
+    parsed.search ||
+    parsed.hash ||
+    !basePath.startsWith('/')
+  ) {
+    throw new Error(`Invalid Lat UI server base path: ${basePath}`);
+  }
+  return parsed.pathname
+    .split('/')
+    .filter(Boolean)
+    .map((part) => {
+      const decoded = decodeURIComponent(part);
+      if (
+        decoded === '.' ||
+        decoded === '..' ||
+        decoded.includes('/') ||
+        decoded.includes('\\')
+      ) {
+        throw new Error(`Invalid Lat UI server base path: ${basePath}`);
+      }
+      return decoded;
+    });
+}
+
+function safeTracePath(path: string): string {
+  if (
+    isAbsolute(path) ||
+    path === '..' ||
+    path.startsWith(`..${sep}`) ||
+    path.split(/[\\/]/).includes('..')
+  ) {
+    throw new Error(`Node file trace escaped the server artifact: ${path}`);
+  }
+  return path;
+}
+
+function outputConfig(): unknown {
+  const securityHeaders = {
+    'Content-Security-Policy': LAT_UI_CONTENT_SECURITY_POLICY,
+    'Referrer-Policy': 'no-referrer',
+    'X-Content-Type-Options': 'nosniff',
+  };
+  const immutableHeaders = {
+    'Cache-Control': 'public, max-age=31536000, immutable',
+  };
+  return {
+    version: 3,
+    routes: [
+      { src: '/(.*)', headers: securityHeaders, continue: true },
+      {
+        src: '/(?:.*?/)?assets/.*',
+        headers: immutableHeaders,
+        continue: true,
+      },
+      {
+        src: '/(?:.*?/)?data/[^/]+/[a-f0-9]{20}\\.json',
+        headers: immutableHeaders,
+        continue: true,
+      },
+      { handle: 'filesystem' },
+      { src: '/', dest: '/index.html' },
+      { src: '/(.*)/', dest: '/$1/index.html' },
+      { src: '/(.*)', dest: '/$1/index.html' },
+    ],
+  };
+}
+
+/** Convert an installed portable Lat UI server into Vercel Build Output API v3. */
+export async function buildVercelOutput(
+  requestedArtifact: string,
+  requestedOutput = '.vercel/output',
+  options: VercelBuildOptions = {},
+  dependencies: VercelBuildDependencies = defaultDependencies,
+): Promise<VercelBuildResult> {
+  const artifactDir = resolve(requestedArtifact);
+  const outputDir = resolve(requestedOutput);
+  if (!options.force) {
+    try {
+      await lstat(outputDir);
+      throw new Error(
+        `Vercel build output already exists: ${outputDir}. Use force to replace it.`,
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+  const manifestFile = join(artifactDir, 'server-data', 'server.json');
+  const manifest = JSON.parse(await readFile(manifestFile, 'utf8')) as {
+    basePath?: unknown;
+  };
+  if (typeof manifest.basePath !== 'string') {
+    throw new Error(`Invalid Lat UI server manifest: ${manifestFile}`);
+  }
+
+  const entrypoint = join(artifactDir, 'app.mjs');
+  const trace = await dependencies.traceFiles([entrypoint], {
+    base: artifactDir,
+    conditions: ['node', 'production'],
+    exportsOnly: true,
+    processCwd: artifactDir,
+  });
+  for (const warning of trace.warnings) {
+    options.warn?.(`Node file trace: ${warning.message}`);
+  }
+
+  await mkdir(dirname(outputDir), { recursive: true });
+  const stagingDir = await mkdtemp(
+    join(dirname(outputDir), '.lat-vercel-staging-'),
+  );
+  try {
+    const staticDir = join(stagingDir, 'static');
+    const functionPath = join(
+      'functions',
+      ...basePathSegments(manifest.basePath),
+      'api',
+      'search.func',
+    );
+    const functionDir = join(stagingDir, functionPath);
+    await cp(join(artifactDir, 'public'), staticDir, { recursive: true });
+
+    for (const traced of trace.fileList) {
+      const path = safeTracePath(traced);
+      const destination = join(functionDir, path);
+      await mkdir(dirname(destination), { recursive: true });
+      await cp(join(artifactDir, path), destination, {
+        dereference: true,
+        recursive: true,
+      });
+    }
+    await writeFile(
+      join(functionDir, '.vc-config.json'),
+      json({
+        runtime: 'nodejs22.x',
+        handler: 'app.mjs',
+        launcherType: 'Nodejs',
+        shouldAddHelpers: true,
+      }),
+    );
+    await writeFile(join(stagingDir, 'config.json'), json(outputConfig()));
+
+    if (options.force) await rm(outputDir, { recursive: true, force: true });
+    await rename(stagingDir, outputDir);
+    return { files: trace.fileList.size, functionPath, outputDir };
+  } catch (error) {
+    await rm(stagingDir, { recursive: true, force: true });
+    throw error;
+  }
+}

--- a/src/view/vercel-server-build.ts
+++ b/src/view/vercel-server-build.ts
@@ -1,0 +1,99 @@
+import { spawn } from 'node:child_process';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import type { CmdContext } from '../context.js';
+import {
+  buildServerView,
+  type ServerViewBuildOptions,
+  type ServerViewBuildResult,
+} from './server-build.js';
+import { validateViewBuildOutput } from './static-build.js';
+import {
+  buildVercelOutput,
+  type VercelBuildOptions,
+  type VercelBuildResult,
+} from './vercel-build.js';
+
+export type VercelServerBuildDependencies = {
+  buildNode: typeof buildServerView;
+  buildOutput: (
+    artifact: string,
+    output: string,
+    options: VercelBuildOptions,
+  ) => Promise<VercelBuildResult>;
+  installDependencies: (artifact: string) => Promise<void>;
+};
+
+function installServerDependencies(artifact: string): Promise<void> {
+  const executable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const args = [
+    'install',
+    '--ignore-scripts',
+    '--no-package-lock',
+    '--omit=dev',
+    '--no-audit',
+    '--no-fund',
+  ];
+  return new Promise((resolveInstall, reject) => {
+    const child = spawn(executable, args, { cwd: artifact, stdio: 'inherit' });
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolveInstall();
+        return;
+      }
+      reject(
+        new Error(
+          `npm install failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`,
+        ),
+      );
+    });
+  });
+}
+
+const defaultDependencies: VercelServerBuildDependencies = {
+  buildNode: buildServerView,
+  buildOutput: buildVercelOutput,
+  installDependencies: installServerDependencies,
+};
+
+/** Build the portable server in staging, install it, then emit Vercel v3 output. */
+export async function buildVercelServerView(
+  ctx: CmdContext,
+  requestedOutput: string,
+  options: ServerViewBuildOptions = {},
+  dependencies: VercelServerBuildDependencies = defaultDependencies,
+): Promise<ServerViewBuildResult> {
+  const outputDir = resolve(ctx.projectRoot, requestedOutput);
+  await validateViewBuildOutput(
+    outputDir,
+    ctx.projectRoot,
+    'Vercel',
+    options.force,
+  );
+  await mkdir(dirname(outputDir), { recursive: true });
+  const stagingDir = await mkdtemp(
+    join(dirname(outputDir), '.lat-vercel-server-'),
+  );
+  const nodeArtifact = join(stagingDir, 'node');
+
+  try {
+    const result = await dependencies.buildNode(ctx, nodeArtifact, {
+      ...options,
+      force: false,
+    });
+    await dependencies.installDependencies(nodeArtifact);
+    await dependencies.buildOutput(nodeArtifact, outputDir, {
+      force: options.force,
+      warn: (message) => console.warn(message),
+    });
+    return { ...result, outputDir };
+  } finally {
+    await rm(stagingDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 150,
+    });
+  }
+}

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -128,8 +128,21 @@ describe('cli command surface', () => {
     expect(serverBuild.exitCode).toBe(0);
     expect(serverBuild.stdout).toContain('Usage: lat ui build server');
     expect(serverBuild.stdout).toContain('.lat-build/server');
+    expect(serverBuild.stdout).toContain('.vercel/output');
     expect(serverBuild.stdout).toContain('--force');
     expect(serverBuild.stdout).toContain('--logo-text <text>');
+    expect(serverBuild.stdout).toContain('--target <target>');
+    expect(serverBuild.stdout).toContain('node or vercel');
+
+    const invalidTarget = runCli('basic-project', [
+      'ui',
+      'build',
+      'server',
+      '--target',
+      'edge',
+    ]);
+    expect(invalidTarget.exitCode).toBe(1);
+    expect(invalidTarget.stderr).toContain('target must be node or vercel');
 
     const existingOutput = runCli('basic-project', [
       'ui',

--- a/tests/vercel-build.test.ts
+++ b/tests/vercel-build.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { uiBuildServerCommand } from '../src/cli/ui-build-server.js';
+import { plainStyler, type CmdContext } from '../src/context.js';
+import { buildVercelOutput } from '../src/view/vercel-build.js';
+import { buildVercelServerView } from '../src/view/vercel-server-build.js';
+
+function testContext(projectRoot = process.cwd()): CmdContext {
+  return {
+    latDir: join(projectRoot, 'lat.md'),
+    projectRoot,
+    styler: plainStyler,
+    mode: 'cli',
+  };
+}
+
+describe('Vercel UI builds', () => {
+  // @lat: [[lat.md/view/specs#View Tests#Selects server deployment targets]]
+  it('selects node and Vercel server build targets', async () => {
+    const buildNode = vi.fn(async (_ctx: CmdContext, output: string) => ({
+      documents: 2,
+      outputDir: output,
+      sources: 3,
+    }));
+    const buildVercel = vi.fn(async (_ctx: CmdContext, output: string) => ({
+      documents: 5,
+      outputDir: output,
+      sources: 7,
+    }));
+    const dependencies = { buildNode, buildVercel };
+
+    await expect(
+      uiBuildServerCommand(testContext(), undefined, {}, dependencies),
+    ).resolves.toEqual({
+      output:
+        'Built 2 documents and 3 source views for node at .lat-build/server',
+    });
+    expect(buildNode).toHaveBeenCalledWith(
+      expect.anything(),
+      '.lat-build/server',
+      {},
+    );
+    expect(buildVercel).not.toHaveBeenCalled();
+
+    await expect(
+      uiBuildServerCommand(
+        testContext(),
+        undefined,
+        { target: 'vercel' },
+        dependencies,
+      ),
+    ).resolves.toEqual({
+      output:
+        'Built 5 documents and 7 source views for vercel at .vercel/output',
+    });
+    expect(buildVercel).toHaveBeenCalledWith(
+      expect.anything(),
+      '.vercel/output',
+      {},
+    );
+  });
+
+  // @lat: [[lat.md/view/specs#View Tests#Builds Vercel output directly]]
+  it('separates CDN files from the traced Vercel search function', async () => {
+    const buildRoot = mkdtempSync(join(tmpdir(), 'lat-ui-vercel-test-'));
+    const artifactDir = join(buildRoot, 'web');
+    const outputDir = join(buildRoot, '.vercel', 'output');
+    const publicDir = join(artifactDir, 'public', 'project');
+    const dataDir = join(artifactDir, 'server-data');
+    const dependencyFile = join(
+      artifactDir,
+      'node_modules',
+      'example',
+      'index.js',
+    );
+    mkdirSync(publicDir, { recursive: true });
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(join(artifactDir, 'node_modules', 'example'), {
+      recursive: true,
+    });
+    writeFileSync(join(publicDir, 'index.html'), 'project shell');
+    writeFileSync(join(artifactDir, 'public', 'index.html'), 'root shell');
+    writeFileSync(join(artifactDir, 'app.mjs'), 'export default () => {}');
+    writeFileSync(
+      join(dataDir, 'server.json'),
+      JSON.stringify({ version: 1, basePath: '/project/', sections: [] }),
+    );
+    writeFileSync(join(dataDir, 'vectors.db'), 'vectors');
+    writeFileSync(dependencyFile, 'export default true');
+
+    const traced = [
+      'app.mjs',
+      'server-data/server.json',
+      'server-data/vectors.db',
+      'node_modules/example/index.js',
+    ];
+    try {
+      const result = await buildVercelOutput(
+        artifactDir,
+        outputDir,
+        {},
+        {
+          async traceFiles(files, options) {
+            expect(files).toEqual([join(artifactDir, 'app.mjs')]);
+            expect(options).toMatchObject({
+              base: artifactDir,
+              processCwd: artifactDir,
+              exportsOnly: true,
+              conditions: ['node', 'production'],
+            });
+            return { fileList: new Set(traced), warnings: new Set() };
+          },
+        },
+      );
+      expect(result.files).toBe(traced.length);
+      expect(result.functionPath).toBe(
+        join('functions', 'project', 'api', 'search.func'),
+      );
+      expect(
+        readFileSync(
+          join(outputDir, 'static', 'project', 'index.html'),
+          'utf8',
+        ),
+      ).toBe('project shell');
+      expect(existsSync(join(outputDir, 'static', 'index.html'))).toBe(true);
+
+      const functionDir = join(outputDir, result.functionPath);
+      expect(readFileSync(join(functionDir, 'app.mjs'), 'utf8')).toContain(
+        'export default',
+      );
+      expect(
+        readFileSync(join(functionDir, 'server-data', 'vectors.db'), 'utf8'),
+      ).toBe('vectors');
+      expect(
+        readFileSync(
+          join(functionDir, 'node_modules', 'example', 'index.js'),
+          'utf8',
+        ),
+      ).toContain('export default true');
+      expect(existsSync(join(functionDir, 'public'))).toBe(false);
+      expect(
+        JSON.parse(readFileSync(join(functionDir, '.vc-config.json'), 'utf8')),
+      ).toEqual({
+        runtime: 'nodejs22.x',
+        handler: 'app.mjs',
+        launcherType: 'Nodejs',
+        shouldAddHelpers: true,
+      });
+
+      const config = JSON.parse(
+        readFileSync(join(outputDir, 'config.json'), 'utf8'),
+      ) as { version: number; routes: unknown[] };
+      expect(config.version).toBe(3);
+      expect(config.routes).toContainEqual({ handle: 'filesystem' });
+      expect(config.routes).toContainEqual({
+        src: '/',
+        dest: '/index.html',
+      });
+      expect(config.routes).toContainEqual({
+        src: '/(?:.*?/)?assets/.*',
+        headers: {
+          'Cache-Control': 'public, max-age=31536000, immutable',
+        },
+        continue: true,
+      });
+
+      const targetOutput = join(buildRoot, 'target-output');
+      let nodeArtifact = '';
+      const targetResult = await buildVercelServerView(
+        {
+          ...testContext(),
+          projectRoot: buildRoot,
+          latDir: join(buildRoot, 'lat.md'),
+        },
+        targetOutput,
+        { basePath: '/project' },
+        {
+          async buildNode(_ctx, output, options) {
+            nodeArtifact = output;
+            expect(options).toMatchObject({
+              basePath: '/project',
+              force: false,
+            });
+            mkdirSync(output, { recursive: true });
+            writeFileSync(join(output, 'app.mjs'), 'portable app');
+            return { documents: 4, outputDir: output, sources: 6 };
+          },
+          async installDependencies(artifact) {
+            expect(artifact).toBe(nodeArtifact);
+            mkdirSync(join(artifact, 'node_modules'), { recursive: true });
+            writeFileSync(join(artifact, 'node_modules', 'installed'), 'yes');
+          },
+          async buildOutput(artifact, output, options) {
+            expect(artifact).toBe(nodeArtifact);
+            expect(
+              readFileSync(join(artifact, 'node_modules', 'installed'), 'utf8'),
+            ).toBe('yes');
+            expect(output).toBe(targetOutput);
+            expect(options.force).toBeUndefined();
+            mkdirSync(output, { recursive: true });
+            writeFileSync(join(output, 'config.json'), '{"version":3}');
+            return {
+              files: 10,
+              functionPath: join('functions', 'api', 'search.func'),
+              outputDir: output,
+            };
+          },
+        },
+      );
+      expect(targetResult).toEqual({
+        documents: 4,
+        outputDir: targetOutput,
+        sources: 6,
+      });
+      expect(existsSync(join(targetOutput, 'config.json'))).toBe(true);
+      expect(existsSync(nodeArtifact)).toBe(false);
+      expect(
+        readdirSync(buildRoot).some((name) =>
+          name.startsWith('.lat-vercel-server-'),
+        ),
+      ).toBe(false);
+
+      await expect(
+        buildVercelOutput(
+          artifactDir,
+          outputDir,
+          {},
+          {
+            async traceFiles() {
+              throw new Error('existing output should fail before tracing');
+            },
+          },
+        ),
+      ).rejects.toThrow(
+        `Vercel build output already exists: ${outputDir}. Use force to replace it.`,
+      );
+    } finally {
+      rmSync(buildRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Package the portable Node UI artifact as Vercel Build Output API v3.

- Add an explicit `lat ui build server --target node|vercel` switch.
- Stage and install the ordinary Node artifact before tracing its real runtime graph.
- Put public files only in the CDN static tree, not in the search function.
- Carry security and immutable-cache headers into generated routes.
- Reject escaped trace paths and clean staging on success or failure.
- Test target selection and the complete generated output layout in a focused file.

## Stack

1. #133 — Reuse indexed semantic search sessions
2. #134 — Make embedding assets traceable
3. #132 — Build portable Lat UI sites
4. **#135 — Build Lat UI for Vercel**
5. #136 — Build deployable site previews in CI
6. #137 — Allow hosted documentation badges in Lat UI
7. #129 — Reorganize the Lat vault as the public site