### PR TITLE
Build the repository site for Vercel

### DIFF
--- a/lat.md/dev-process.md
+++ b/lat.md/dev-process.md
@@ -71,6 +71,7 @@ The root scripts provide focused checks and builds as well as the complete CI-eq
 - `pnpm format` — format `src/**/*.ts`
 - `pnpm format:check` — check source formatting
 - `pnpm build` — compile the root TypeScript package only
+- `pnpm build:site` — export this repository's vault as a portable UI server
 - `pnpm setup:rust` — prepare the Rust target and project-local build tools
 - `pnpm build:wasm` — rebuild the Rust/WASM engine only
 - `pnpm build:weights` — rebuild or reuse the MiniLM model package
@@ -108,17 +109,22 @@ The separate graph-validation workflow installs and builds the workspace, then r
 
 Cross-platform correctness relies on two conventions: stored paths are always POSIX ([[src/path.ts#toPosix]]), and a repo-root `.gitattributes` (`eol=lf`) keeps Windows checkouts from rewriting line endings and breaking the markdown roundtrip. Functional init tests run the built CLI and database seeding in child processes so native libsql handles close before temp cleanup. Lower-level tests that retain handles or spawn a fake `git` use [[tests/util.ts#rmDirBestEffort]].
 
-## Website Development
+## Site Development
 
-The [[website]] is a root pnpm workspace package because its build compiles Lat and exports the repository vault before Next.js runs.
+The repository's site project exports the root vault through `lat ui build server`, exercising the same portable artifact users deploy.
 
-Website builds resolve the embedding engine and model from pinned npm releases through a dedicated TypeScript config. They compile the current CLI and UI without running the workspace Rust, WASM, or model builders.
+`pnpm build:site` compiles the shared server, downloads the exact published WASM and model artifacts matching this checkout, builds Lat, and writes the server artifact to `.lat-build/server/`.
 
 ```bash
 pnpm install --frozen-lockfile
-pnpm --filter lat-md-website dev
-pnpm --filter lat-md-website build
+pnpm build:site
 ```
+
+The separate Vercel site project uses `pnpm build:site:vercel` as its only build command. It vendors the current workspace packages, installs the generated artifact, and emits Vercel Build Output API v3 in `.vercel/output`; Vercel's Git integration owns preview deployments without a duplicate GitHub Actions build.
+
+Hosted previews intentionally hydrate the published embedding engine and model matching the checkout's package versions. Changes to those packages require local validation with `pnpm build:site:source` and appear in hosted previews only after publication.
+
+The legacy production project and domain remain outside this deployment path until the generated site is ready to replace them. The legacy `website/` workspace remains in the checkout but is not built by the new project.
 
 ## File Walking
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -85,6 +85,18 @@ Every runtime asset is reachable through a static import or `new URL(relativePat
 
 The generated configuration applies the shared security policy, gives content-addressed JSON and Vite assets immutable caching, resolves functions and exact static files first, and maps extensionless routes to their physical `index.html` files.
 
+## Builds this repository's site directly
+
+The repository's separate site project builds the same portable server artifact exposed by the CLI, with no deployment-only application wrapper or duplicate GitHub Actions build.
+
+`pnpm build:site` hydrates version-matched published embedding artifacts, builds the shared server and browser, then invokes `lat ui build server` with its default `.lat-build/server/` output.
+
+The Vercel build vendors this branch's `lat.md` and `@lat.md/*` packages into the artifact under content-addressed archive names, so the deployment installs the pull request rather than released npm packages.
+
+`pnpm build:site:vercel` is the project's sole build command. It installs that artifact without lifecycle scripts and writes `.vercel/output` directly; the repository requires no Vercel manifest, root Express app, nested Vercel CLI build, or artifact handoff between CI systems.
+
+Hosted previews intentionally use published embedding packages. `pnpm build:site:source` validates local engine or model changes, which cannot appear in a hosted preview until their package versions are published.
+
 ## Keeps build-only packages out of runtime dependencies
 
 The published CLI declares browser renderer inputs and test-only serializers as development dependencies because consumers execute prebuilt artifacts and should not install redundant source trees.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   "scripts": {
     "build": "tsc && pnpm build:view",
     "build:view": "vite build --config view/vite.config.ts && vite build --config view/highlight.vite.config.ts",
+    "build:site": "pnpm --filter @lat.md/server build && node scripts/prepare-site-packages.mjs && pnpm build && node dist/src/cli/index.js ui build server --force",
+    "build:site:vercel": "pnpm build:site && node scripts/vendor-site-packages.mjs && npm install --prefix .lat-build/server --ignore-scripts --no-package-lock && node scripts/build-vercel-output.mjs",
+    "build:site:source": "pnpm buildall && node dist/src/cli/index.js ui build server --force",
     "buildall": "pnpm build:packages && pnpm build",
     "setup:rust": "pnpm --filter @lat.md/embed setup:rust",
     "build:wasm": "pnpm --filter @lat.md/embed build:wasm",

--- a/scripts/build-vercel-output.mjs
+++ b/scripts/build-vercel-output.mjs
@@ -1,0 +1,10 @@
+import { buildVercelOutput } from '../dist/src/view/vercel-build.js';
+
+const result = await buildVercelOutput(
+  process.argv[2] ?? '.lat-build/server',
+  process.argv[3] ?? '.vercel/output',
+  { force: true, warn: console.warn },
+);
+console.log(
+  `Built ${result.files} traced files at ${result.outputDir} (${result.functionPath})`,
+);

--- a/scripts/prepare-site-packages.mjs
+++ b/scripts/prepare-site-packages.mjs
@@ -1,0 +1,126 @@
+import { spawn } from 'node:child_process';
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { patchNodeGlueFile } from '../packages/embed/scripts/patch-node-glue.mjs';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(scriptDir, '..');
+const packages = [
+  {
+    name: '@lat.md/embed',
+    directory: join(projectRoot, 'packages', 'embed'),
+    outputs: ['dist'],
+  },
+  {
+    name: '@lat.md/embed-minilm-fp16',
+    directory: join(projectRoot, 'packages', 'embed-minilm-fp16'),
+    outputs: ['dist', 'model'],
+  },
+];
+
+function run(command, args, cwd) {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(command, args, { cwd, stdio: 'inherit' });
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolveRun();
+        return;
+      }
+      reject(
+        new Error(
+          `${command} ${args.join(' ')} failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`,
+        ),
+      );
+    });
+  });
+}
+
+async function readManifest(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+const dependencies = {};
+for (const packageInfo of packages) {
+  const manifest = await readManifest(
+    join(packageInfo.directory, 'package.json'),
+  );
+  if (
+    manifest.name !== packageInfo.name ||
+    typeof manifest.version !== 'string'
+  ) {
+    throw new Error(
+      `Invalid workspace package manifest: ${packageInfo.directory}`,
+    );
+  }
+  packageInfo.version = manifest.version;
+  dependencies[packageInfo.name] = manifest.version;
+}
+
+const packageManager = process.env.npm_execpath;
+const pnpm = packageManager
+  ? { command: process.execPath, args: [packageManager] }
+  : {
+      command: process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm',
+      args: [],
+    };
+const stagingDir = await mkdtemp(join(tmpdir(), 'lat-site-packages-'));
+
+try {
+  await writeFile(
+    join(stagingDir, 'package.json'),
+    `${JSON.stringify({ private: true, dependencies }, null, 2)}\n`,
+  );
+  console.log(
+    `Downloading prebuilt site packages: ${packages.map(({ name, version }) => `${name}@${version}`).join(', ')}`,
+  );
+  await run(
+    pnpm.command,
+    [
+      ...pnpm.args,
+      'install',
+      '--dir',
+      stagingDir,
+      '--ignore-scripts',
+      '--lockfile=false',
+      '--prefer-offline',
+    ],
+    projectRoot,
+  );
+
+  for (const packageInfo of packages) {
+    const installedDir = join(
+      stagingDir,
+      'node_modules',
+      ...packageInfo.name.split('/'),
+    );
+    const installed = await readManifest(join(installedDir, 'package.json'));
+    if (
+      installed.name !== packageInfo.name ||
+      installed.version !== packageInfo.version
+    ) {
+      throw new Error(
+        `Expected ${packageInfo.name}@${packageInfo.version}, received ${installed.name}@${installed.version}`,
+      );
+    }
+    for (const output of packageInfo.outputs) {
+      const destination = join(packageInfo.directory, output);
+      await rm(destination, { recursive: true, force: true });
+      await cp(join(installedDir, output), destination, { recursive: true });
+    }
+  }
+  await patchNodeGlueFile(
+    join(projectRoot, 'packages', 'embed', 'dist', 'engine.cjs'),
+  );
+  for (const packageInfo of packages) {
+    await run(
+      pnpm.command,
+      [...pnpm.args, '--filter', packageInfo.name, 'exec', 'tsc'],
+      projectRoot,
+    );
+  }
+} finally {
+  await rm(stagingDir, { recursive: true, force: true });
+}

--- a/scripts/vendor-site-packages.mjs
+++ b/scripts/vendor-site-packages.mjs
@@ -1,0 +1,107 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(scriptDir, '..');
+const outputDir = resolve(projectRoot, process.argv[2] ?? '.lat-build/server');
+const vendorDir = join(outputDir, 'vendor');
+const packages = [
+  { name: 'lat.md', directory: projectRoot, file: 'lat.md' },
+  {
+    name: '@lat.md/embed',
+    directory: join(projectRoot, 'packages', 'embed'),
+    file: 'embed',
+  },
+  {
+    name: '@lat.md/embed-minilm-fp16',
+    directory: join(projectRoot, 'packages', 'embed-minilm-fp16'),
+    file: 'embed-minilm-fp16',
+  },
+  {
+    name: '@lat.md/server',
+    directory: join(projectRoot, 'packages', 'server'),
+    file: 'server',
+  },
+];
+
+function run(command, args, cwd) {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ['ignore', 'ignore', 'inherit'],
+    });
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolveRun();
+        return;
+      }
+      reject(
+        new Error(
+          `${command} ${args.join(' ')} failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`,
+        ),
+      );
+    });
+  });
+}
+
+const packageManager = process.env.npm_execpath;
+const pnpm = packageManager
+  ? { command: process.execPath, args: [packageManager] }
+  : {
+      command: process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm',
+      args: [],
+    };
+
+const manifestPath = join(outputDir, 'package.json');
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+if (manifest.name !== 'lat-ui-server' || !manifest.dependencies) {
+  throw new Error(`Not a Lat UI server artifact: ${outputDir}`);
+}
+
+await rm(vendorDir, { recursive: true, force: true });
+await mkdir(vendorDir, { recursive: true });
+
+for (const packageInfo of packages) {
+  const stagingDir = await mkdtemp(join(tmpdir(), 'lat-site-package-'));
+  try {
+    await run(
+      pnpm.command,
+      [...pnpm.args, 'pack', '--pack-destination', stagingDir],
+      packageInfo.directory,
+    );
+    const archives = (await readdir(stagingDir)).filter((file) =>
+      file.endsWith('.tgz'),
+    );
+    if (archives.length !== 1) {
+      throw new Error(
+        `Expected one package archive for ${packageInfo.name}, received ${archives.length}`,
+      );
+    }
+    const archivePath = join(stagingDir, archives[0]);
+    const digest = createHash('sha256')
+      .update(await readFile(archivePath))
+      .digest('hex')
+      .slice(0, 20);
+    const vendoredFile = `${packageInfo.file}-${digest}.tgz`;
+    await copyFile(archivePath, join(vendorDir, vendoredFile));
+    manifest.dependencies[packageInfo.name] = `file:vendor/${vendoredFile}`;
+  } finally {
+    await rm(stagingDir, { recursive: true, force: true });
+  }
+}
+
+await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(`Vendored workspace packages into ${vendorDir}`);

--- a/tests/site-build.test.ts
+++ b/tests/site-build.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repositoryRoot = join(import.meta.dirname, '..');
+
+describe('repository site build', () => {
+  // @lat: [[lat.md/view/specs#View Tests#Builds this repository's site directly]]
+  it('uses the ignored default server artifact for one Vercel build', () => {
+    const rootPackage = JSON.parse(
+      readFileSync(join(repositoryRoot, 'package.json'), 'utf8'),
+    ) as { scripts: Record<string, string> };
+    expect(rootPackage.scripts['build:site']).toBe(
+      'pnpm --filter @lat.md/server build && node scripts/prepare-site-packages.mjs && pnpm build && node dist/src/cli/index.js ui build server --force',
+    );
+    expect(rootPackage.scripts['build:site:vercel']).toBe(
+      'pnpm build:site && node scripts/vendor-site-packages.mjs && npm install --prefix .lat-build/server --ignore-scripts --no-package-lock && node scripts/build-vercel-output.mjs',
+    );
+    expect(rootPackage.scripts['build:site:source']).toBe(
+      'pnpm buildall && node dist/src/cli/index.js ui build server --force',
+    );
+
+    const vercelBuild = readFileSync(
+      join(repositoryRoot, 'scripts', 'build-vercel-output.mjs'),
+      'utf8',
+    );
+    expect(vercelBuild).toContain('buildVercelOutput');
+    expect(vercelBuild).toContain("process.argv[2] ?? '.lat-build/server'");
+
+    const vendorBuild = readFileSync(
+      join(repositoryRoot, 'scripts', 'vendor-site-packages.mjs'),
+      'utf8',
+    );
+    expect(vendorBuild).toContain("process.argv[2] ?? '.lat-build/server'");
+    expect(vendorBuild).toContain("createHash('sha256')");
+
+    const gitIgnore = readFileSync(
+      join(repositoryRoot, '.gitignore'),
+      'utf8',
+    ).split('\n');
+    expect(gitIgnore).toContain('.lat-build');
+    expect(gitIgnore).not.toContain('web');
+  });
+});


### PR DESCRIPTION
Build this repository's documentation site through the same portable Lat UI server artifact users deploy. A separate Vercel project runs `pnpm build:site:vercel` through Git integration for site builds and previews.

- Generate the intermediate server artifact in the CLI's default, ignored `.lat-build/server/` directory, then emit `.vercel/output`.
- Download version-matched published WASM and model assets while compiling this checkout's TypeScript and browser code.
- Package the current workspace packages as content-addressed archives so previews include the branch's changes.
- Keep GitHub Actions unchanged. The legacy production project and domain remain disconnected from this deployment path.

Hosted builds use published WASM/model assets. Changes to those assets require `pnpm build:site:source` for local validation and publication before they appear in hosted previews.

## Deployment

Configure the separate Vercel project with the repository root, the Other preset, `pnpm build:site:vercel` as its build command, and no output-directory override. Vercel consumes the generated Build Output API v3 artifact.

## Validation

- Full `pnpm build:site:vercel` completed and generated the Vercel artifact.
- Typechecking and 17 focused site-build, Vercel-build, and parser tests passed.
- `lat check` passed on the rebased stack.

## Stack

#132 and #135 are merged. This PR targets `main`; #137 (hosted documentation badges) and #129 (vault reorganization) remain stacked above it.
