### PR TITLE
Allow hosted documentation badges in Lat UI

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -24,7 +24,7 @@ The graph renderer and graph projection stay out of ordinary document startup. O
 
 Map fences lazily request OpenFreeMap's hosted OpenStreetMap vector style through MapLibre. The authored GeoJSON or converted TopoJSON remains interactive over a local fallback when the basemap cannot load.
 
-The live server's default-self Content Security Policy explicitly permits only OpenFreeMap tile connections, GitHub custom emoji images, and bundled data fonts needed by those supported renderers.
+The live server's default-self Content Security Policy permits OpenFreeMap tile connections, GitHub-hosted images, Shields badges, and bundled data fonts used by supported content and renderers.
 
 Read APIs accept only walked vault files or supported project source paths and reject traversal and escaping symlinks.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -17,7 +17,7 @@ Relative images and other non-Markdown files resolve through vault-contained res
 
 By default the header renders the bundled Lat wordmark. `lat ui --logo-text <text>` replaces it with safely rendered plain text.
 
-The browser shell keeps a default-self Content Security Policy while allowing the OpenFreeMap tile endpoint, GitHub's custom emoji image host, and data-backed renderer fonts.
+The browser shell keeps a default-self Content Security Policy while allowing OpenFreeMap tiles, GitHub-hosted images, Shields badges, and data-backed renderer fonts.
 
 The server anchors Vite's relative entry assets at `/assets/`, so every live document, source, search, and graph route loads the same production shell.
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -10,7 +10,7 @@ import type { AddressInfo } from 'node:net';
 import express, { type Express, type Response } from 'express';
 
 export const LAT_UI_CONTENT_SECURITY_POLICY =
-  "default-src 'self'; connect-src 'self' https://tiles.openfreemap.org; font-src 'self' data:; img-src 'self' data: https://github.githubassets.com; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'";
+  "default-src 'self'; connect-src 'self' https://tiles.openfreemap.org; font-src 'self' data:; img-src 'self' data: https://github.com https://github.githubassets.com https://img.shields.io; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'";
 
 export type LatServerAppOptions = {
   /** Handle dynamic routes before immutable files and fallback handlers. */

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -262,7 +262,7 @@ describe('lat ui', () => {
     );
     expect(contentSecurityPolicy).toContain("font-src 'self' data:");
     expect(contentSecurityPolicy).toContain(
-      "img-src 'self' data: https://github.githubassets.com",
+      "img-src 'self' data: https://github.com https://github.githubassets.com https://img.shields.io",
     );
 
     const rawResponse = await fetch(new URL('/docs/guide.md', view.url));


### PR DESCRIPTION
Allow the public documentation's CI and stars badges without broadening any other resource class.

The shared UI Content Security Policy adds only GitHub-hosted images and `img.shields.io`. Live UI, portable Node builds, and Vercel output continue to consume the same policy constant, and the exact image allowlist remains covered by the server test.

## Stack

1. #133 — Reuse indexed semantic search sessions
2. #134 — Make embedding assets traceable
3. #132 — Build portable Lat UI sites
4. #135 — Build Lat UI for Vercel
5. #136 — Build deployable site previews in CI
6. **#137 — Allow hosted documentation badges in Lat UI**
7. #129 — Reorganize the Lat vault as the public site