### PR TITLE
Add raw Markdown link to section menu

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -176,6 +176,8 @@ The sidebar is a natural-order file tree. Root `lat.md` and each `name/name.md` 
 
 Every section heading exposes a burger-icon action menu, with a numeric badge only when references exist. It shows incoming Markdown, wiki, and `@lat:` locations or an empty state, followed by stacked muted actions that copy the navigated URL or canonical section ID.
 
+The topmost section menu in a local Markdown document links to the raw `.md` route. External documents and document previews outside their normal local route omit this action.
+
 In live views, the menu can invoke [[src/cli/section.ts#sectionCommand|the shared `lat section` command path]] with plain styling. Its modal defaults to the React projection of the shared document tree and can switch to raw output; static exports omit only this execution action.
 
 ## Responsive layout

--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -98,6 +98,8 @@ The build creates the semantic index once and serializes the flat section metada
 
 Static client configuration treats search as an independent capability: pure static builds omit the control and route, while server builds point the same client at their configured search endpoint. Documents, source views, externals, and the graph remain static in both targets.
 
+Shutdown retries deletion of its owned temporary index. Persistent Windows native-file locks may leave that disposable OS-temp copy behind without failing shutdown; caller-provided caches and deployed indexes are never removed.
+
 ### Vercel server export
 
 [[src/view/vercel-server-build.ts#buildVercelServerView]] implements `--target vercel` by composing the portable Node builder with [[src/view/vercel-build.ts#buildVercelOutput]].

--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -92,6 +92,8 @@ Framework-aware hosts can serve `public/` from a CDN and route remaining request
 
 The build creates the semantic index once and serializes the flat section metadata required to turn index ids into browser results. [[src/view/preindexed-search.ts#createPreindexedViewSearch]] queries that copied index without importing indexing or Markdown parsers, then hydrates its storage-level rows through the same resolver as other search callers.
 
+[[src/view/server-build.ts#buildServerSearchIndex]] indexes the analyzed snapshot in a child process and waits for its exit before publishing staging. Process exit releases native database handles that can otherwise prevent directory renames on Windows.
+
 [[src/view/server-deployment.ts#createServerViewApp]] consumes the explicit manifest and index paths, derives static fallback content from the artifact layout, copies the immutable database into a writable runtime cache, and registers only the search API on the supplied Express app. Each server instance opens that copy and resolves its injected local embedder once; hosted keys do not alter the prebuilt index's model. The local model initializes on the first query and remains available for later warm queries. Shutdown closes the database before removing temporary storage. Git, editing, events, and repository reads remain absent.
 
 Static client configuration treats search as an independent capability: pure static builds omit the control and route, while server builds point the same client at their configured search endpoint. Documents, source views, externals, and the graph remain static in both targets.

--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -178,6 +178,8 @@ Every section heading exposes a burger-icon action menu, with a numeric badge on
 
 The topmost section menu in a local Markdown document links to the raw `.md` route. External documents and document previews outside their normal local route omit this action.
 
+Raw-file links preserve the deployment base and `/docs/` source path in live, static, and server builds. An exported homepage at `/` still links to its `/docs/<file>.md` source rather than appending `.md` to the homepage URL.
+
 In live views, the menu can invoke [[src/cli/section.ts#sectionCommand|the shared `lat section` command path]] with plain styling. Its modal defaults to the React projection of the shared document tree and can switch to raw output; static exports omit only this execution action.
 
 ## Responsive layout

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -229,6 +229,8 @@ Every section exposes a burger-icon menu with a count only when references exist
 
 Muted actions stack below the references and can copy the URL or canonical ID accepted by `lat section`. The topmost local Markdown section also links to the raw `.md` file, while external documents omit that action.
 
+Following the menu link returns the exact source from both the live UI and generated Node server. Exported homepages retain their `/docs/<file>.md` source route, and nested deployments preserve their base path.
+
 In live views, the output modal defaults to the shared React tree renderer and offers a raw-text toggle; static exports omit this runtime-only action.
 
 ## Updates long-running views incrementally

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -69,6 +69,8 @@ The Node-target regression test builds a complete portable artifact, loads its g
 
 Indexing runs in a child process that exits before staging is renamed, releasing native SQLite handles on Windows. The existing analyzed snapshot crosses the process boundary intact, and indexing errors reject the build before publication.
 
+Shutdown closes search and retries removal of its owned runtime cache. Persistent Windows lock errors on that disposable copy do not fail shutdown; other cleanup errors still surface.
+
 It verifies the document shell, immutable JavaScript and CSS assets, and semantic results from the real local embedding model and built SQLite index. The test therefore covers the generated application contract rather than substituting a fake search handler.
 
 ## Selects server deployment targets

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -227,7 +227,9 @@ Source links preserve their originating section and line so the code view can re
 
 Every section exposes a burger-icon menu with a count only when references exist. It lists distinct Markdown and code back-references or an empty state, and can navigate to and copy the section URL.
 
-Muted actions stack below the references and can copy the URL or canonical ID accepted by `lat section`. In live views, the output modal defaults to the shared React tree renderer and offers a raw-text toggle; static exports omit this runtime-only action.
+Muted actions stack below the references and can copy the URL or canonical ID accepted by `lat section`. The topmost local Markdown section also links to the raw `.md` file, while external documents omit that action.
+
+In live views, the output modal defaults to the shared React tree renderer and offers a raw-text toggle; static exports omit this runtime-only action.
 
 ## Updates long-running views incrementally
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -67,6 +67,8 @@ The static client exposes Search only when the build advertises an endpoint. Edi
 
 The Node-target regression test builds a complete portable artifact, loads its generated entrypoint against installed workspace packages, and serves it over loopback HTTP.
 
+Indexing runs in a child process that exits before staging is renamed, releasing native SQLite handles on Windows. The existing analyzed snapshot crosses the process boundary intact, and indexing errors reject the build before publication.
+
 It verifies the document shell, immutable JavaScript and CSS assets, and semantic results from the real local embedding model and built SQLite index. The test therefore covers the generated application contract rather than substituting a fake search handler.
 
 ## Selects server deployment targets

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -227,7 +227,7 @@ Source links preserve their originating section and line so the code view can re
 
 Every section exposes a burger-icon menu with a count only when references exist. It lists distinct Markdown and code back-references or an empty state, and can navigate to and copy the section URL.
 
-Muted actions stack below the references and can copy the URL or canonical ID accepted by `lat section`. The topmost local Markdown section also links to the raw `.md` file, while external documents omit that action.
+Muted actions stack below the references with “Copy link to the section” first. They can also copy the canonical ID accepted by `lat section`. The topmost local Markdown section links to the raw `.md` file, while external documents omit that action.
 
 Following the menu link returns the exact source from both the live UI and generated Node server. Exported homepages retain their `/docs/<file>.md` source route, and nested deployments preserve their base path.
 

--- a/src/view/server-build.ts
+++ b/src/view/server-build.ts
@@ -1,11 +1,15 @@
 import { readFileSync } from 'node:fs';
+import { fork } from 'node:child_process';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getLatServerVersion } from '@lat.md/server';
 import type { CmdContext } from '../context.js';
-import { analyzeMarkdownProject } from '../project-analysis.js';
-import { runIndex } from '../cli/search.js';
+import {
+  analyzeMarkdownProject,
+  type MarkdownProjectAnalysis,
+} from '../project-analysis.js';
+import type { ServerIndexRequest } from './server-index-worker.js';
 import { getLocalVersion } from '../version.js';
 import { toPosix } from '../path.js';
 import {
@@ -33,7 +37,7 @@ export type ServerViewBuildDependencies = {
   getLocalVersion: typeof getLocalVersion;
   getLatServerVersion: typeof getLatServerVersion;
   getPackageVersion: typeof getPackageVersion;
-  runIndex: typeof runIndex;
+  buildSearchIndex: typeof buildServerSearchIndex;
 };
 
 const defaultDependencies: ServerViewBuildDependencies = {
@@ -42,8 +46,58 @@ const defaultDependencies: ServerViewBuildDependencies = {
   getLocalVersion,
   getLatServerVersion,
   getPackageVersion,
-  runIndex,
+  buildSearchIndex: buildServerSearchIndex,
 };
+
+/** Wait for the index process to exit so native handles cannot lock staging. */
+export function buildServerSearchIndex(
+  latDir: string,
+  project: MarkdownProjectAnalysis,
+  cacheDir: string,
+): Promise<void> {
+  const sourceRuntime = import.meta.url.endsWith('.ts');
+  const child = fork(
+    new URL(
+      sourceRuntime ? './server-index-worker.ts' : './server-index-worker.js',
+      import.meta.url,
+    ),
+    [],
+    {
+      execArgv: sourceRuntime ? ['--import', 'tsx'] : [],
+      serialization: 'advanced',
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+    },
+  );
+  return new Promise((resolveIndex, reject) => {
+    let stderr = '';
+    let sendError: Error | null = null;
+    child.stderr!.setEncoding('utf8');
+    child.stderr!.on('data', (chunk: string) => {
+      stderr = (stderr + chunk).slice(-64_000);
+    });
+    child.once('error', reject);
+    child.once('close', (code, signal) => {
+      if (sendError) reject(sendError);
+      else if (code === 0) resolveIndex();
+      else {
+        reject(
+          new Error(
+            `Server search indexing failed (${signal ?? code}): ${stderr.trim()}`,
+          ),
+        );
+      }
+    });
+    child.send(
+      { latDir, project, cacheDir } satisfies ServerIndexRequest,
+      (error) => {
+        if (error) {
+          sendError = error;
+          child.kill();
+        }
+      },
+    );
+  });
+}
 
 function getPackageVersion(name: string): string {
   let directory = dirname(fileURLToPath(import.meta.resolve(name)));
@@ -140,9 +194,7 @@ export async function buildServerView(
       ctx.projectRoot,
       { executor: 'auto' },
     );
-    await dependencies.runIndex(ctx.latDir, undefined, project, {
-      cacheDir: dataDir,
-    });
+    await dependencies.buildSearchIndex(ctx.latDir, project, dataDir);
     const sections: ServerViewSection[] = project.sections.map(
       ({ children: _children, ...section }) => ({
         ...section,

--- a/src/view/server-deployment.ts
+++ b/src/view/server-deployment.ts
@@ -81,6 +81,28 @@ type PreparedServerView = {
   close: () => Promise<void>;
 };
 
+/** Native SQLite handles may outlive close until the Windows process exits. */
+async function removeRuntimeCache(path: string): Promise<void> {
+  try {
+    await rm(path, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 150,
+    });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (
+      process.platform !== 'win32' ||
+      (code !== 'EBUSY' && code !== 'EPERM' && code !== 'ENOTEMPTY')
+    ) {
+      throw error;
+    }
+    // This is an owned OS-temp copy, never the deployed index or user data.
+    // A lingering native lock must not fail otherwise successful shutdown.
+  }
+}
+
 async function prepareServerView(
   options: ServerViewAppOptions,
   manifestFile: string,
@@ -101,7 +123,7 @@ async function prepareServerView(
       await copyFile(indexFile, join(runtimeCacheDir, 'vectors.db'));
     } catch (error) {
       if (ownsCache) {
-        await rm(runtimeCacheDir, { recursive: true, force: true });
+        await removeRuntimeCache(runtimeCacheDir);
       }
       throw error;
     }
@@ -131,8 +153,7 @@ async function prepareServerView(
       try {
         await ownedSearch?.close();
       } finally {
-        if (ownsCache)
-          await rm(runtimeCacheDir, { recursive: true, force: true });
+        if (ownsCache) await removeRuntimeCache(runtimeCacheDir);
       }
     },
   };

--- a/src/view/server-index-worker.ts
+++ b/src/view/server-index-worker.ts
@@ -1,0 +1,21 @@
+import { runIndex } from '../cli/search.js';
+import type { MarkdownProjectAnalysis } from '../project-analysis.js';
+
+export type ServerIndexRequest = {
+  latDir: string;
+  project: MarkdownProjectAnalysis;
+  cacheDir: string;
+};
+
+process.once('message', async (request: ServerIndexRequest) => {
+  try {
+    await runIndex(request.latDir, undefined, request.project, {
+      cacheDir: request.cacheDir,
+    });
+    // Process exit releases native libsql handles before staging is renamed.
+    process.exit(0);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+});

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -385,6 +385,10 @@ describe('lat ui', () => {
       expect(viewPathname('/project/index.html')).toBe('/docs/lat');
       expect(viewPathname('/project/')).toBe('/docs/lat');
       expect(staticViewRoute('docs/lat')).toBe('/project/');
+      expect(rawDocumentUrl('lat.md')).toBe('/project/docs/lat.md');
+      expect(rawDocumentUrl('nested/my guide.md')).toBe(
+        '/project/docs/nested/my%20guide.md',
+      );
     } finally {
       vi.unstubAllGlobals();
     }
@@ -959,7 +963,51 @@ describe('lat ui', () => {
 
       const document = await fetch(`${origin}/project/`);
       expect(document.status).toBe(200);
-      expect(await document.text()).toContain('lat ui shell');
+      const shell = await document.text();
+      expect(shell).toContain('lat ui shell');
+
+      const staticConfig = shell.match(
+        /<meta name="lat-static-view" content="([^"]+)"/,
+      )?.[1];
+      expect(staticConfig).toBeDefined();
+      vi.stubGlobal('document', {
+        querySelector: () => ({ content: staticConfig }),
+      });
+      try {
+        const manifest = (await (
+          await fetch(`${origin}/project/data/manifest.json`)
+        ).json()) as ViewStaticManifest;
+        for (const path of ['lat.md', 'guide.md']) {
+          const model = (await (
+            await fetch(`${origin}/project/${manifest.documents[path]}`)
+          ).json()) as ViewDocument;
+          const rendered = renderToStaticMarkup(
+            createElement(MarkdownContent, {
+              backReferences: model.backReferences,
+              tree: model.tree,
+              sectionOutputEnabled: false,
+              viewMarkdownUrl: rawDocumentUrl(model.path),
+            }),
+          );
+          const links = [
+            ...rendered.matchAll(
+              /<a class="section-back-reference-action" href="([^"]+)">View Markdown file<\/a>/g,
+            ),
+          ];
+          expect(links).toHaveLength(1);
+          const href = links[0][1];
+          expect(href).toBe(`/project/docs/${path}`);
+          expect(documentPath(new URL(href, origin).pathname)).toBeNull();
+          const raw = await fetch(new URL(href, origin));
+          expect(raw.status).toBe(200);
+          expect(raw.headers.get('content-type')).toContain('text/markdown');
+          expect(await raw.text()).toBe(
+            readFileSync(join(serverProjectRoot, 'lat.md', path), 'utf8'),
+          );
+        }
+      } finally {
+        vi.unstubAllGlobals();
+      }
 
       for (const asset of ['app.js', 'app.css']) {
         const response = await fetch(`${origin}/project/assets/${asset}`);
@@ -2037,7 +2085,7 @@ describe('lat ui', () => {
       createElement(MarkdownContent, {
         backReferences: document.backReferences,
         tree: document.tree,
-        viewMarkdownUrl: '/docs/guide.md',
+        viewMarkdownUrl: rawDocumentUrl(document.path),
       }),
     );
     expect(rendered).toContain('aria-label="Section menu, 5 references"');
@@ -2049,6 +2097,15 @@ describe('lat ui', () => {
     expect(rendered).toContain('Copy section ID');
     expect(rendered).toContain('href="/docs/guide.md"');
     expect(rendered.match(/View Markdown file/g)).toHaveLength(1);
+    const rawHref = rendered.match(
+      /<a class="section-back-reference-action" href="([^"]+)">View Markdown file<\/a>/,
+    )?.[1];
+    expect(rawHref).toBe('/docs/guide.md');
+    const raw = await fetch(new URL(rawHref!, view.url));
+    expect(raw.status).toBe(200);
+    expect(await raw.text()).toBe(
+      readFileSync(join(latDir, document.path), 'utf8'),
+    );
     expect(rendered).toContain('Show <code>lat section</code> output');
     expect(rendered).toContain('section-back-reference-breadcrumb');
     expect(rendered).toContain('section-back-reference-breadcrumb-label');

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -25,7 +25,6 @@ import { setRepoEmbedding } from '../src/config.js';
 import { uiCommand } from '../src/cli/ui.js';
 import { uiBuildCommand } from '../src/cli/ui-build.js';
 import { uiBuildServerCommand } from '../src/cli/ui-build-server.js';
-import { runIndex as buildSearchIndex } from '../src/cli/search.js';
 import { analyzeMarkdownFile } from '../src/markdown-analysis.js';
 import {
   DEFAULT_VIEW_PORT,
@@ -38,7 +37,10 @@ import {
   normalizeStaticViewBasePath,
   staticViewUrl,
 } from '../src/view/static-build.js';
-import { buildServerView } from '../src/view/server-build.js';
+import {
+  buildServerSearchIndex,
+  buildServerView,
+} from '../src/view/server-build.js';
 import {
   createServerViewApp,
   type ServerViewManifest,
@@ -655,8 +657,7 @@ describe('lat ui', () => {
               express: '5.2.1',
             }[name]!;
           },
-          async runIndex(_latDir, _progress, _project, options) {
-            const cacheDir = options!.cacheDir!;
+          async buildSearchIndex(_latDir, _project, cacheDir) {
             mkdirSync(cacheDir, { recursive: true });
             writeFileSync(join(cacheDir, 'vectors.db'), 'index');
           },
@@ -924,7 +925,7 @@ describe('lat ui', () => {
               ),
             ).version as string;
           },
-          runIndex: buildSearchIndex,
+          buildSearchIndex: buildServerSearchIndex,
         },
       );
 

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -99,6 +99,7 @@ import {
   historyStateWithScroll,
   isSameRenderedDocument,
   externalUrl,
+  rawDocumentUrl,
   readGraphMode,
   scrollToDocumentLocation,
   searchButtonAction,
@@ -2036,6 +2037,7 @@ describe('lat ui', () => {
       createElement(MarkdownContent, {
         backReferences: document.backReferences,
         tree: document.tree,
+        viewMarkdownUrl: '/docs/guide.md',
       }),
     );
     expect(rendered).toContain('aria-label="Section menu, 5 references"');
@@ -2045,6 +2047,8 @@ describe('lat ui', () => {
     expect(rendered).toContain('id="section-back-references-1"');
     expect(rendered).toContain('Copy link to the section');
     expect(rendered).toContain('Copy section ID');
+    expect(rendered).toContain('href="/docs/guide.md"');
+    expect(rendered.match(/View Markdown file/g)).toHaveLength(1);
     expect(rendered).toContain('Show <code>lat section</code> output');
     expect(rendered).toContain('section-back-reference-breadcrumb');
     expect(rendered).toContain('section-back-reference-breadcrumb-label');
@@ -2103,6 +2107,7 @@ describe('lat ui', () => {
     expect(emptyRendered).not.toContain('section-back-reference-count');
     expect(emptyRendered).toContain('Copy link to the section');
     expect(emptyRendered).toContain('Copy section ID');
+    expect(emptyRendered).not.toContain('View Markdown file');
     expect(emptyRendered).toContain('Show <code>lat section</code> output');
 
     const staticRendered = renderToStaticMarkup(
@@ -2380,6 +2385,9 @@ describe('lat ui', () => {
     expect(scrollIntoView).not.toHaveBeenCalled();
 
     expect(documentUrl('nested/my guide.md')).toBe('/docs/nested/my%20guide');
+    expect(rawDocumentUrl('nested/my guide.md')).toBe(
+      '/docs/nested/my%20guide.md',
+    );
     expect(documentPath('/docs/nested/my%20guide')).toBe('nested/my guide.md');
     expect(documentPath('/docs/nested/my%20guide.md')).toBeNull();
 

--- a/view/src/App.tsx
+++ b/view/src/App.tsx
@@ -35,6 +35,7 @@ import {
   historyScrollPosition,
   historyStateWithScroll,
   isSameRenderedDocument,
+  rawDocumentUrl,
   readGraphMode,
   searchButtonAction,
   searchHistoryState,
@@ -1087,6 +1088,11 @@ export function App() {
                   onShowSectionOutput={setSectionOutputId}
                   sectionOutputEnabled={!staticView}
                   tree={documentTree}
+                  viewMarkdownUrl={
+                    route?.kind === 'markdown'
+                      ? rawDocumentUrl(route.path)
+                      : undefined
+                  }
                 />
               )}
             </div>

--- a/view/src/MarkdownContent.tsx
+++ b/view/src/MarkdownContent.tsx
@@ -263,11 +263,6 @@ function SectionMenu({
           </div>
         )}
         <div className="section-back-reference-actions">
-          {index === 0 && viewMarkdownUrl && (
-            <a className="section-back-reference-action" href={viewMarkdownUrl}>
-              View Markdown file
-            </a>
-          )}
           <button
             className="section-back-reference-action"
             onClick={stop(() => onCopySectionLink?.(section.headingId))}
@@ -275,6 +270,11 @@ function SectionMenu({
           >
             Copy link to the section
           </button>
+          {index === 0 && viewMarkdownUrl && (
+            <a className="section-back-reference-action" href={viewMarkdownUrl}>
+              View Markdown file
+            </a>
+          )}
           <button
             className="section-back-reference-action"
             onClick={stop(() =>

--- a/view/src/MarkdownContent.tsx
+++ b/view/src/MarkdownContent.tsx
@@ -187,6 +187,7 @@ function SectionMenu({
   onShowSectionOutput,
   section,
   sectionOutputEnabled,
+  viewMarkdownUrl,
 }: {
   heading: {
     children: ReactNode[] | undefined;
@@ -198,6 +199,7 @@ function SectionMenu({
   onShowSectionOutput?: (sectionId: string) => void;
   section: ViewSectionBackReferences;
   sectionOutputEnabled: boolean;
+  viewMarkdownUrl?: string;
 }) {
   const [open, setOpen] = useState(false);
   const count = section.references.length;
@@ -261,6 +263,11 @@ function SectionMenu({
           </div>
         )}
         <div className="section-back-reference-actions">
+          {index === 0 && viewMarkdownUrl && (
+            <a className="section-back-reference-action" href={viewMarkdownUrl}>
+              View Markdown file
+            </a>
+          )}
           <button
             className="section-back-reference-action"
             onClick={stop(() => onCopySectionLink?.(section.headingId))}
@@ -300,6 +307,7 @@ type RenderContext = {
   sectionOutputEnabled: boolean;
   onCopySectionLink?: (headingId: string) => void;
   onShowSectionOutput?: (sectionId: string) => void;
+  viewMarkdownUrl?: string;
 };
 
 function DocumentElement({
@@ -345,6 +353,7 @@ function DocumentElement({
       onShowSectionOutput={context?.onShowSectionOutput}
       section={backReferences.section}
       sectionOutputEnabled={context?.sectionOutputEnabled ?? true}
+      viewMarkdownUrl={context?.viewMarkdownUrl}
     />
   );
 }
@@ -375,6 +384,7 @@ export function MarkdownContent({
   onShowSectionOutput,
   sectionOutputEnabled = true,
   tree,
+  viewMarkdownUrl,
 }: {
   backReferences?: ViewSectionBackReferences[];
   onClick?: (event: MouseEvent<HTMLElement>) => void;
@@ -382,6 +392,7 @@ export function MarkdownContent({
   onShowSectionOutput?: (sectionId: string) => void;
   sectionOutputEnabled?: boolean;
   tree: ViewDocumentTree;
+  viewMarkdownUrl?: string;
 }) {
   const context: RenderContext = {
     sections: new Map(
@@ -393,6 +404,7 @@ export function MarkdownContent({
     sectionOutputEnabled,
     onCopySectionLink,
     onShowSectionOutput,
+    viewMarkdownUrl,
   };
 
   return (

--- a/view/src/navigation.ts
+++ b/view/src/navigation.ts
@@ -25,6 +25,11 @@ export function documentPath(pathname: string): string | null {
   return routeDocumentPath(viewPathname(pathname));
 }
 
+/** Build the raw Markdown URL paired with a local rendered document route. */
+export function rawDocumentUrl(path: string): string {
+  return `${documentUrl(path)}.md`;
+}
+
 /** Build the browser route for one canonical external target. */
 export function externalUrl(target: string): string {
   const colon = target.indexOf(':');

--- a/view/src/navigation.ts
+++ b/view/src/navigation.ts
@@ -27,7 +27,8 @@ export function documentPath(pathname: string): string | null {
 
 /** Build the raw Markdown URL paired with a local rendered document route. */
 export function rawDocumentUrl(path: string): string {
-  return `${documentUrl(path)}.md`;
+  const route = `${routeDocumentUrl(path)}.md`;
+  return staticViewRoute(route.slice(1)) ?? route;
 }
 
 /** Build the browser route for one canonical external target. */

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -1392,6 +1392,10 @@ a {
   border: 0;
 }
 
+.markdown .section-back-reference-action {
+  text-decoration: none;
+}
+
 .section-back-reference-action:hover {
   color: color-mix(in srgb, var(--muted) 82%, white);
 }


### PR DESCRIPTION
Adds “View Markdown file” to the topmost section menu for local Markdown documents. It opens the exact source file in locally run UIs, static exports, and server exports; external documents, lower sections, and graph previews omit the action.

Raw links preserve the deployment base and source path. For example, an exported homepage at `/project/` opens `/project/docs/lat.md`, while `/project/docs/guide` opens `/project/docs/guide.md`.

“Copy link to the section” remains the first menu action.

Server builds index the analyzed snapshot in a child process and wait for it to exit before publishing staging. This releases native SQLite handles that caused Windows CI to fail with `EPERM` when renaming the generated artifact.

Server shutdown retries removal of its owned temporary search cache and tolerates persistent Windows lock errors on that disposable copy. Deployed indexes and caller-provided caches are never removed.

Validated with `pnpm buildall`, all 318 tests, TypeScript checks, formatting, and `lat check`. Regression coverage follows the rendered menu link through the live UI and generated Node server and compares the HTTP response with the original Markdown.
