### PR TITLE
Restore the solid-cell UI header logo

### DIFF
--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -15,7 +15,7 @@ Requesting the same route with `.md` returns the exact known vault file as `text
 
 Relative images and other non-Markdown files resolve through vault-contained resource routes. Missing files, directories, and paths that escape through traversal or symlinks remain unavailable.
 
-By default the header renders the bundled Lat wordmark. `lat ui --logo-text <text>` replaces it with safely rendered plain text.
+By default the header renders the compact, solid-cell Lat wordmark bundled in [[view/src/logo.svg]], without shaded cells. This asset is independent of logos embedded in Markdown content. `lat ui --logo-text <text>` replaces it with safely rendered plain text.
 
 The browser shell keeps a default-self Content Security Policy while allowing OpenFreeMap tiles, GitHub-hosted images, Shields badges, and data-backed renderer fonts.
 

--- a/view/src/logo.svg
+++ b/view/src/logo.svg
@@ -1,182 +1,149 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 73224 16688" fill="#ddd">
   <defs>
-    <path id="g2588" d="M-20 -512V1576H1253V-512Z"/>
-    <path id="g2591" d="M934 -512V-251H1094V-512ZM298 -512V-251H457V-512ZM616 -147V114H775V-147ZM-20 -147V114H138V-147ZM934 219V480H1094V219ZM298 219V480H457V219ZM616 584V845H775V584ZM-20 584V845H138V584ZM934 950V1211H1094V950ZM298 950V1211H457V950ZM616 1315V1576H775V1315ZM-20 1315V1576H138V1315Z"/>
+    <rect id="solid-square" x="-20" y="325" width="1273" height="2088"/>
   </defs>
-  <use href="#g2591" transform="translate(0,0) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(1356,0) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(2712,0) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(21696,0) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(23052,0) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(24408,0) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(69156,0) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(70512,0) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(71868,0) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(0,2384) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(1356,2384) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(2712,2384) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(21696,2384) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(23052,2384) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(24408,2384) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(69156,2384) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(70512,2384) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(71868,2384) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(0,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(1356,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(2712,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(6780,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(8136,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(9492,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(10848,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(12204,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(13560,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(14916,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(18984,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(20340,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(21696,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(23052,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(24408,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(25764,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(27120,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(37968,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(39324,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(40680,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(42036,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(43392,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(44748,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(46104,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(47460,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(48816,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(50172,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(51528,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(52884,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(54240,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(55596,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(61020,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(62376,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(63732,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(65088,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(66444,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(67800,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(69156,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(70512,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(71868,4768) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(0,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(1356,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(2712,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(13560,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(14916,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(16272,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(21696,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(23052,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(24408,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(37968,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(39324,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(40680,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(46104,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(47460,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(48816,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(54240,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(55596,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(56952,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(59664,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(61020,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(62376,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(69156,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(70512,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(71868,7152) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(0,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(1356,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(2712,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(6780,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(8136,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(9492,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(10848,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(12204,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(13560,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(14916,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(16272,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(21696,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(23052,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(24408,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(37968,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(39324,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(40680,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(46104,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(47460,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(48816,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(54240,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(55596,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(56952,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(59664,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(61020,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(62376,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(69156,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(70512,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(71868,9536) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(0,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(1356,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(2712,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(5424,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(6780,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(8136,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(13560,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(14916,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(16272,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(21696,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(23052,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(24408,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(37968,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(39324,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(40680,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(46104,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(47460,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(48816,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(54240,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(55596,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(56952,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(59664,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(61020,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(62376,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(67800,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(69156,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(70512,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(71868,11920) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(0,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(1356,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(2712,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(6780,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(8136,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(9492,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(10848,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(12204,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(13560,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(14916,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(16272,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(17628,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(23052,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(24408,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(25764,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(27120,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(31188,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(32544,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(33900,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(37968,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(39324,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(40680,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(46104,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(47460,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(48816,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(54240,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(55596,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(56952,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(61020,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(62376,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(63732,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(65088,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(66444,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(67800,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2591" transform="translate(69156,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(70512,14304) scale(1,-1) translate(0,-1901)"/>
-  <use href="#g2588" transform="translate(71868,14304) scale(1,-1) translate(0,-1901)"/>
+  <g>
+    <use href="#solid-square" x="1356"/>
+    <use href="#solid-square" x="2712"/>
+    <use href="#solid-square" x="23052"/>
+    <use href="#solid-square" x="24408"/>
+    <use href="#solid-square" x="70512"/>
+    <use href="#solid-square" x="71868"/>
+  </g>
+  <g transform="translate(0 2384)">
+    <use href="#solid-square" x="1356"/>
+    <use href="#solid-square" x="2712"/>
+    <use href="#solid-square" x="23052"/>
+    <use href="#solid-square" x="24408"/>
+    <use href="#solid-square" x="70512"/>
+    <use href="#solid-square" x="71868"/>
+  </g>
+  <g transform="translate(0 4768)">
+    <use href="#solid-square" x="1356"/>
+    <use href="#solid-square" x="2712"/>
+    <use href="#solid-square" x="8136"/>
+    <use href="#solid-square" x="9492"/>
+    <use href="#solid-square" x="10848"/>
+    <use href="#solid-square" x="12204"/>
+    <use href="#solid-square" x="13560"/>
+    <use href="#solid-square" x="14916"/>
+    <use href="#solid-square" x="20340"/>
+    <use href="#solid-square" x="21696"/>
+    <use href="#solid-square" x="23052"/>
+    <use href="#solid-square" x="24408"/>
+    <use href="#solid-square" x="25764"/>
+    <use href="#solid-square" x="27120"/>
+    <use href="#solid-square" x="39324"/>
+    <use href="#solid-square" x="40680"/>
+    <use href="#solid-square" x="42036"/>
+    <use href="#solid-square" x="43392"/>
+    <use href="#solid-square" x="44748"/>
+    <use href="#solid-square" x="46104"/>
+    <use href="#solid-square" x="47460"/>
+    <use href="#solid-square" x="48816"/>
+    <use href="#solid-square" x="50172"/>
+    <use href="#solid-square" x="51528"/>
+    <use href="#solid-square" x="52884"/>
+    <use href="#solid-square" x="54240"/>
+    <use href="#solid-square" x="55596"/>
+    <use href="#solid-square" x="62376"/>
+    <use href="#solid-square" x="63732"/>
+    <use href="#solid-square" x="65088"/>
+    <use href="#solid-square" x="66444"/>
+    <use href="#solid-square" x="67800"/>
+    <use href="#solid-square" x="69156"/>
+    <use href="#solid-square" x="70512"/>
+    <use href="#solid-square" x="71868"/>
+  </g>
+  <g transform="translate(0 7152)">
+    <use href="#solid-square" x="1356"/>
+    <use href="#solid-square" x="2712"/>
+    <use href="#solid-square" x="14916"/>
+    <use href="#solid-square" x="16272"/>
+    <use href="#solid-square" x="23052"/>
+    <use href="#solid-square" x="24408"/>
+    <use href="#solid-square" x="39324"/>
+    <use href="#solid-square" x="40680"/>
+    <use href="#solid-square" x="47460"/>
+    <use href="#solid-square" x="48816"/>
+    <use href="#solid-square" x="55596"/>
+    <use href="#solid-square" x="56952"/>
+    <use href="#solid-square" x="61020"/>
+    <use href="#solid-square" x="62376"/>
+    <use href="#solid-square" x="70512"/>
+    <use href="#solid-square" x="71868"/>
+  </g>
+  <g transform="translate(0 9536)">
+    <use href="#solid-square" x="1356"/>
+    <use href="#solid-square" x="2712"/>
+    <use href="#solid-square" x="8136"/>
+    <use href="#solid-square" x="9492"/>
+    <use href="#solid-square" x="10848"/>
+    <use href="#solid-square" x="12204"/>
+    <use href="#solid-square" x="13560"/>
+    <use href="#solid-square" x="14916"/>
+    <use href="#solid-square" x="16272"/>
+    <use href="#solid-square" x="23052"/>
+    <use href="#solid-square" x="24408"/>
+    <use href="#solid-square" x="39324"/>
+    <use href="#solid-square" x="40680"/>
+    <use href="#solid-square" x="47460"/>
+    <use href="#solid-square" x="48816"/>
+    <use href="#solid-square" x="55596"/>
+    <use href="#solid-square" x="56952"/>
+    <use href="#solid-square" x="61020"/>
+    <use href="#solid-square" x="62376"/>
+    <use href="#solid-square" x="70512"/>
+    <use href="#solid-square" x="71868"/>
+  </g>
+  <g transform="translate(0 11920)">
+    <use href="#solid-square" x="1356"/>
+    <use href="#solid-square" x="2712"/>
+    <use href="#solid-square" x="6780"/>
+    <use href="#solid-square" x="8136"/>
+    <use href="#solid-square" x="14916"/>
+    <use href="#solid-square" x="16272"/>
+    <use href="#solid-square" x="23052"/>
+    <use href="#solid-square" x="24408"/>
+    <use href="#solid-square" x="39324"/>
+    <use href="#solid-square" x="40680"/>
+    <use href="#solid-square" x="47460"/>
+    <use href="#solid-square" x="48816"/>
+    <use href="#solid-square" x="55596"/>
+    <use href="#solid-square" x="56952"/>
+    <use href="#solid-square" x="61020"/>
+    <use href="#solid-square" x="62376"/>
+    <use href="#solid-square" x="69156"/>
+    <use href="#solid-square" x="70512"/>
+    <use href="#solid-square" x="71868"/>
+  </g>
+  <g transform="translate(0 14304)">
+    <use href="#solid-square" x="1356"/>
+    <use href="#solid-square" x="2712"/>
+    <use href="#solid-square" x="8136"/>
+    <use href="#solid-square" x="9492"/>
+    <use href="#solid-square" x="10848"/>
+    <use href="#solid-square" x="12204"/>
+    <use href="#solid-square" x="13560"/>
+    <use href="#solid-square" x="16272"/>
+    <use href="#solid-square" x="17628"/>
+    <use href="#solid-square" x="24408"/>
+    <use href="#solid-square" x="25764"/>
+    <use href="#solid-square" x="27120"/>
+    <use href="#solid-square" x="32544"/>
+    <use href="#solid-square" x="33900"/>
+    <use href="#solid-square" x="39324"/>
+    <use href="#solid-square" x="40680"/>
+    <use href="#solid-square" x="47460"/>
+    <use href="#solid-square" x="48816"/>
+    <use href="#solid-square" x="55596"/>
+    <use href="#solid-square" x="56952"/>
+    <use href="#solid-square" x="62376"/>
+    <use href="#solid-square" x="63732"/>
+    <use href="#solid-square" x="65088"/>
+    <use href="#solid-square" x="66444"/>
+    <use href="#solid-square" x="67800"/>
+    <use href="#solid-square" x="70512"/>
+    <use href="#solid-square" x="71868"/>
+  </g>
 </svg>


### PR DESCRIPTION
Restore the compact solid-cell header logo introduced in #123. When #132 moved the header asset out of `website/` and into `view/src/`, it copied the older shaded wordmark, bringing the shaded cells back into the UI.

Replace `view/src/logo.svg` with the exact original solid-cell asset while keeping it owned by the UI. Logos embedded in Markdown content retain their own design. Document that distinction in the browser-shell specification.

Validation: the SVG's Git blob hash matches the original from #123; the existing browser-shell test and `lat check` pass.
