### PR TITLE
Follow directory index order in the sidebar

### DIFF
--- a/lat.md/tests/check-index.md
+++ b/lat.md/tests/check-index.md
@@ -18,6 +18,10 @@ Given a `lat.md/` directory whose index file lists all visible entries with desc
 
 Given an index file that lists a file which does not exist on disk, `checkIndex` reports it as a stale entry.
 
+## Detects missing entries
+
+Existing root and subdirectory indexes must list every visible Markdown child. Files omitted from those lists fail validation with the missing link entries, even though the UI keeps them navigable during editing.
+
 ## Detects missing subdirectory index file
 
 Given a `lat.md/` directory with a subdirectory containing files but no index file for that subdirectory, `checkIndex` reports a missing-index error with a snippet listing the subdirectory's entries.

--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -172,7 +172,11 @@ Wide layouts give the sticky TOC a fixed 286px column and the available viewport
 
 A moving end-of-page activation line makes short final sections reachable.
 
-The sidebar is a natural-order file tree. Root `lat.md` and each `name/name.md` directory index stay first; selecting a directory opens its index and expands the directory. When external files are referenced, an `External sources` label separates source-handle folders from the local tree.
+The sidebar follows the page and subdirectory order authored in each directory's index list, with the index page pinned first. Selecting a directory opens its index and expands it. An `External sources` label separates referenced source-handle folders from the local tree.
+
+The view store projects cached Markdown `indexEntries` into [[src/view/protocol.ts#ViewIndex]] for the shared browser tree; live refreshes and exported sites use the same order without parsing Markdown again. External sources retain natural sorting.
+
+[[cli#check#index]] requires every visible Markdown page and directory to be listed. While editing an invalid vault, the sidebar keeps unlisted entries visible after listed ones in natural order; missing or stale entries remain validation errors.
 
 Every section heading exposes a burger-icon action menu, with a numeric badge only when references exist. It shows incoming Markdown, wiki, and `@lat:` locations or an empty state, followed by stacked muted actions that copy the navigated URL or canonical section ID.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -287,9 +287,19 @@ Supported languages, including Dart and Java, become structured line trees witho
 
 ## Builds a nested file tree
 
-Vault paths form a natural-order hierarchy with root and directory index files pinned first and complete paths retained for navigation.
+Vault paths form a hierarchy with root and directory index files pinned first and complete paths retained for navigation. Natural sorting provides a fallback while an index is missing or incomplete.
 
 Selecting a directory opens its `name/name.md` index and keeps the directory expanded.
+
+### Uses authored index order
+
+Each directory lists its pages and child directories in the order of its index entries, after the pinned index page. Aliases and optional file extensions preserve the order; stale links do not create sidebar entries.
+
+In an invalid working tree, unlisted files remain visible after listed entries in natural order so authors can repair their indexes. This fallback does not permit orphan pages to pass validation. External files keep their natural order.
+
+### Shares directory order across live and exported views
+
+The sidebar consumes directory order from cached Markdown analysis through the shared UI index. Reordering an index updates live navigation, and static exports carry the same order without additional document requests.
 
 ## Stabilizes fragment navigation immediately
 

--- a/src/view/protocol.ts
+++ b/src/view/protocol.ts
@@ -12,6 +12,8 @@ export type ViewExternalFile = {
 
 export type ViewIndex = {
   files: string[];
+  /** Authored directory-index entries, keyed by vault-relative directory ('' at root). */
+  directoryOrder: Record<string, string[]>;
   externalFiles: ViewExternalFile[];
   entry: string;
   errorCounts: Record<string, number>;

--- a/src/view/store.ts
+++ b/src/view/store.ts
@@ -213,13 +213,13 @@ async function scanCodeState(
 
 function viewIndex(
   latDir: string,
-  paths: string[],
+  markdownFiles: ReadonlyMap<string, ViewParsedMarkdownFile>,
   diagnostics: ReadonlyMap<string, readonly ViewDocumentError[]>,
   git: ViewGitSnapshot,
   references: ViewReferenceIndex,
   external: ExternalResolver,
 ): ViewIndex {
-  const files = [...paths].sort();
+  const files = [...markdownFiles.keys()].sort();
   const externalFiles = new Map<string, ViewExternalFile>();
   for (const target of references.externalByTarget.keys()) {
     try {
@@ -241,8 +241,19 @@ function viewIndex(
   const indexName = directoryName.endsWith('.md')
     ? directoryName
     : `${directoryName}.md`;
+  const directoryOrder = Object.fromEntries(
+    [...markdownFiles].flatMap(([path, file]) => {
+      const separator = path.lastIndexOf('/');
+      const directory = separator === -1 ? '' : path.slice(0, separator);
+      const name = directory ? basename(directory) : directoryName;
+      const filename = name.endsWith('.md') ? name : `${name}.md`;
+      if (path.slice(separator + 1) !== filename) return [];
+      return [[directory, file.indexEntries]];
+    }),
+  );
   return {
     files,
+    directoryOrder,
     externalFiles: [...externalFiles.values()].sort(
       (left, right) =>
         left.handle.localeCompare(right.handle) ||
@@ -321,14 +332,7 @@ async function buildSnapshot(
     ),
     diagnostics,
     git,
-    index: viewIndex(
-      latDir,
-      [...files.keys()],
-      diagnostics,
-      git,
-      references,
-      external,
-    ),
+    index: viewIndex(latDir, files, diagnostics, git, references, external),
     external,
   };
 }

--- a/tests/view-navigation.test.ts
+++ b/tests/view-navigation.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { checkIndex } from '../src/cli/check.js';
+import { plainStyler } from '../src/context.js';
+import { buildStaticView } from '../src/view/static-build.js';
+import type { ViewStaticManifest } from '../src/view/static-protocol.js';
+import { createViewStore, type ViewStore } from '../src/view/store.js';
+import { FileTree } from '../view/src/FileTree.js';
+import { buildFileTree, type FileTreeNode } from '../view/src/file-tree.js';
+import { rmDirBestEffort } from './util.js';
+
+function paths(nodes: FileTreeNode[]): string[] {
+  return nodes.flatMap((node) => [
+    node.path,
+    ...(node.kind === 'directory' ? paths(node.children) : []),
+  ]);
+}
+
+describe('sidebar directory order', () => {
+  // @lat: [[lat.md/view/specs#View Tests#Builds a nested file tree#Uses authored index order]]
+  it('orders pages and folders by their index and preserves incomplete entries', () => {
+    const files = [
+      'handbook.md',
+      'aaa.md',
+      'chapter10.md',
+      'Chapter2.md',
+      'zebra.md',
+      'docs/docs.md',
+      'docs/api.md',
+      'docs/start.md',
+      'docs/next.md',
+      'docs/nested/nested.md',
+      'docs/nested/z.md',
+      'docs/nested/a.md',
+      'constructor/page.md',
+    ];
+    const tree = buildFileTree(
+      files,
+      {
+        '': ['docs', 'zebra', 'aaa', 'docs', 'missing'],
+        docs: ['start.md', 'nested', 'api', 'start'],
+        'docs/nested': ['z', 'a'],
+      },
+      'handbook.md',
+    );
+    expect(paths(tree)).toEqual([
+      'handbook.md',
+      'docs',
+      'docs/docs.md',
+      'docs/start.md',
+      'docs/nested',
+      'docs/nested/nested.md',
+      'docs/nested/z.md',
+      'docs/nested/a.md',
+      'docs/api.md',
+      'docs/next.md',
+      'zebra.md',
+      'aaa.md',
+      'Chapter2.md',
+      'chapter10.md',
+      'constructor',
+      'constructor/page.md',
+    ]);
+    expect(files[0]).toBe('handbook.md');
+  });
+});
+
+describe('directory index navigation', () => {
+  let projectRoot: string;
+  let latDir: string;
+  let store: ViewStore | undefined;
+
+  function writeDocument(path: string, content: string): void {
+    const absolute = join(latDir, path);
+    mkdirSync(dirname(absolute), { recursive: true });
+    writeFileSync(absolute, content);
+  }
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'lat-view-navigation-'));
+    latDir = join(projectRoot, 'lat.md');
+    writeDocument(
+      'lat.md',
+      '# Index\n\nAn early inline [[alpha]] link does not order the listing.\n\n- [[zeta|First page]] — Start here.\n- [[docs]] — Guides.\n- [[alpha]] — Reference.\n',
+    );
+    writeDocument('alpha.md', '# Alpha\n\nReference details.\n');
+    writeDocument('zeta.md', '# Zeta\n\nGetting started.\n');
+    writeDocument(
+      'docs/docs.md',
+      '# Docs\n\nDocumentation overview.\n\n- [[setup]] — Installation.\n- [[api]] — API reference.\n',
+    );
+    writeDocument('docs/setup.md', '# Setup\n\nInstall the project.\n');
+    writeDocument(
+      'docs/api.md',
+      '# API\n\nAPI details.\n\n- [[alpha]] — A list in an ordinary page.\n',
+    );
+  });
+
+  afterEach(async () => {
+    await store?.close();
+    store = undefined;
+    rmDirBestEffort(projectRoot);
+  });
+
+  // @lat: [[lat.md/view/specs#View Tests#Builds a nested file tree#Shares directory order across live and exported views]]
+  it('shares parsed index order with the sidebar, live refresh, and static export', async () => {
+    store = await createViewStore(latDir, projectRoot, {
+      git: false,
+      watch: false,
+    });
+    const initial = store.getIndex();
+    expect(initial.directoryOrder).toEqual({
+      '': ['zeta', 'docs', 'alpha'],
+      docs: ['setup', 'api'],
+    });
+    expect(paths(buildFileTree(initial.files, initial.directoryOrder))).toEqual(
+      [
+        'lat.md',
+        'zeta.md',
+        'docs',
+        'docs/docs.md',
+        'docs/setup.md',
+        'docs/api.md',
+        'alpha.md',
+      ],
+    );
+    const html = renderToStaticMarkup(
+      createElement(FileTree, {
+        activePath: 'lat.md',
+        activeExternalTarget: null,
+        errorCounts: initial.errorCounts,
+        externalFiles: initial.externalFiles,
+        files: initial.files,
+        directoryOrder: initial.directoryOrder,
+        entry: initial.entry,
+        gitFiles: {},
+        onNavigate: () => {},
+      }),
+    );
+    expect(
+      [...html.matchAll(/href="([^"]+)"/g)].map((match) => match[1]),
+    ).toEqual([
+      '/docs/lat',
+      '/docs/zeta',
+      '/docs/docs/docs',
+      '/docs/docs/docs',
+      '/docs/docs/setup',
+      '/docs/docs/api',
+      '/docs/alpha',
+    ]);
+    expect(await checkIndex(latDir)).toEqual([]);
+
+    const unchanged = store.snapshot.files.get('alpha.md');
+    writeDocument(
+      'lat.md',
+      '# Index\n\nProject overview.\n\n- [[alpha]] — Reference.\n- [[docs]] — Guides.\n- [[zeta]] — Getting started.\n',
+    );
+    writeDocument(
+      'docs/docs.md',
+      '# Docs\n\nDocumentation overview.\n\n- [[api]] — API reference.\n- [[setup]] — Installation.\n',
+    );
+    await store.refresh(['lat.md/lat.md', 'lat.md/docs/docs.md']);
+    expect(store.snapshot.files.get('alpha.md')).toBe(unchanged);
+    const updated = store.getIndex();
+    expect(updated.directoryOrder).toEqual({
+      '': ['alpha', 'docs', 'zeta'],
+      docs: ['api', 'setup'],
+    });
+    const expected = [
+      'lat.md',
+      'alpha.md',
+      'docs',
+      'docs/docs.md',
+      'docs/api.md',
+      'docs/setup.md',
+      'zeta.md',
+    ];
+    expect(paths(buildFileTree(updated.files, updated.directoryOrder))).toEqual(
+      expected,
+    );
+
+    const clientDir = join(projectRoot, 'client');
+    mkdirSync(clientDir);
+    writeFileSync(
+      join(clientDir, 'index.html'),
+      '<!doctype html><html><head></head><body></body></html>',
+    );
+    const output = join(projectRoot, 'site');
+    await buildStaticView(
+      { latDir, projectRoot, styler: plainStyler, mode: 'cli' },
+      output,
+      { clientDir },
+    );
+    const manifest = JSON.parse(
+      readFileSync(join(output, 'data', 'manifest.json'), 'utf8'),
+    ) as ViewStaticManifest;
+    expect(manifest.index.directoryOrder).toEqual(updated.directoryOrder);
+    expect(
+      paths(buildFileTree(manifest.index.files, manifest.index.directoryOrder)),
+    ).toEqual(expected);
+  });
+
+  // @lat: [[tests/check-index#Check Index#Detects missing entries]]
+  it('rejects orphan pages omitted from root and subdirectory indexes', async () => {
+    writeDocument(
+      'lat.md',
+      '# Index\n\nProject overview.\n\n- [[docs]] — Guides.\n- [[alpha]] — Reference.\n',
+    );
+    writeDocument(
+      'docs/docs.md',
+      '# Docs\n\nDocumentation overview.\n\n- [[api]] — API reference.\n',
+    );
+    const errors = await checkIndex(latDir);
+    expect(errors).toHaveLength(2);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          dir: 'lat.md/',
+          message: expect.stringContaining('missing entries'),
+          snippet: expect.stringContaining('[[zeta]]'),
+        }),
+        expect.objectContaining({
+          dir: 'docs/',
+          message: expect.stringContaining('missing entries'),
+          snippet: expect.stringContaining('[[setup]]'),
+        }),
+      ]),
+    );
+  });
+});

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -235,6 +235,7 @@ describe('lat ui', () => {
     expect(indexResponse.status).toBe(200);
     expect((await indexResponse.json()) as ViewIndex).toEqual({
       files: ['guide.md', 'lat.md'],
+      directoryOrder: { '': ['guide'] },
       externalFiles: [],
       entry: 'lat.md',
       errorCounts: {},
@@ -418,6 +419,7 @@ describe('lat ui', () => {
       expect(manifest.version).toBe(1);
       expect(manifest.index).toEqual({
         files: ['guide.md', 'lat.md'],
+        directoryOrder: { '': ['guide'] },
         externalFiles: [],
         entry: 'lat.md',
         errorCounts: {},

--- a/view/src/App.tsx
+++ b/view/src/App.tsx
@@ -959,6 +959,8 @@ export function App() {
               errorCounts={index.errorCounts}
               externalFiles={index.externalFiles}
               files={index.files}
+              directoryOrder={index.directoryOrder}
+              entry={index.entry}
               gitFiles={
                 gitEnabled ? (index.git?.files ?? NO_GIT_FILES) : NO_GIT_FILES
               }

--- a/view/src/FileTree.tsx
+++ b/view/src/FileTree.tsx
@@ -11,6 +11,7 @@ import {
 import type {
   ViewExternalFile,
   ViewGitFileStatus,
+  ViewIndex,
 } from '../../src/view/protocol';
 import { documentUrl, externalUrl } from './navigation';
 
@@ -20,6 +21,8 @@ type FileTreeProps = {
   errorCounts: Record<string, number>;
   externalFiles: ViewExternalFile[];
   files: string[];
+  directoryOrder: ViewIndex['directoryOrder'];
+  entry: string;
   gitFiles: Record<string, ViewGitFileStatus>;
   onNavigate: (event: MouseEvent<HTMLAnchorElement>) => void;
 };
@@ -175,10 +178,15 @@ export function FileTree({
   errorCounts,
   externalFiles,
   files,
+  directoryOrder,
+  entry,
   gitFiles,
   onNavigate,
 }: FileTreeProps) {
-  const tree = useMemo(() => buildFileTree(files), [files]);
+  const tree = useMemo(
+    () => buildFileTree(files, directoryOrder, entry),
+    [files, directoryOrder, entry],
+  );
   const externalTree = useMemo(
     () => buildExternalFileTree(externalFiles),
     [externalFiles],

--- a/view/src/file-tree.ts
+++ b/view/src/file-tree.ts
@@ -1,6 +1,7 @@
 import type {
   ViewExternalFile,
   ViewGitFileStatus,
+  ViewIndex,
 } from '../../src/view/protocol';
 
 export type FileTreeNode =
@@ -35,7 +36,23 @@ const finderCollator = new Intl.Collator(undefined, {
 function sortedChildren(
   children: Map<string, MutableNode>,
   indexPath: string | null,
+  directoryOrder: ViewIndex['directoryOrder'],
+  directory = '',
 ): FileTreeNode[] {
+  const ranks = new Map<string, number>();
+  const entries = Object.hasOwn(directoryOrder, directory)
+    ? directoryOrder[directory]
+    : [];
+  for (const [rank, name] of entries.entries()) {
+    if (!ranks.has(name)) ranks.set(name, rank);
+  }
+  const rank = (node: MutableNode): number =>
+    Math.min(
+      ranks.get(node.name) ?? Infinity,
+      node.kind === 'file'
+        ? (ranks.get(node.name.replace(/\.md$/i, '')) ?? Infinity)
+        : Infinity,
+    );
   return [...children.values()]
     .sort((a, b) => {
       if (indexPath) {
@@ -43,6 +60,9 @@ function sortedChildren(
         const bIsIndex = b.kind === 'file' && b.path === indexPath;
         if (aIsIndex !== bIsIndex) return aIsIndex ? -1 : 1;
       }
+      const aRank = rank(a);
+      const bRank = rank(b);
+      if (aRank !== bRank) return aRank - bRank;
       return (
         finderCollator.compare(a.name, b.name) || a.name.localeCompare(b.name)
       );
@@ -54,6 +74,8 @@ function sortedChildren(
             children: sortedChildren(
               node.children,
               `${node.path}/${node.name}.md`,
+              directoryOrder,
+              node.path,
             ),
           }
         : node,
@@ -111,6 +133,8 @@ function buildTree(
     externalTarget?: string;
     externalPathTarget?: string;
   }>,
+  directoryOrder: ViewIndex['directoryOrder'] = {},
+  entry = 'lat.md',
 ): FileTreeNode[] {
   const root = new Map<string, MutableNode>();
 
@@ -147,12 +171,20 @@ function buildTree(
     });
   }
 
-  return sortedChildren(root, 'lat.md');
+  return sortedChildren(root, entry, directoryOrder);
 }
 
 /** Convert vault-relative file paths into the hierarchy shown in the sidebar. */
-export function buildFileTree(files: string[]): FileTreeNode[] {
-  return buildTree(files.map((path) => ({ path })));
+export function buildFileTree(
+  files: string[],
+  directoryOrder: ViewIndex['directoryOrder'] = {},
+  entry = 'lat.md',
+): FileTreeNode[] {
+  return buildTree(
+    files.map((path) => ({ path })),
+    directoryOrder,
+    entry,
+  );
 }
 
 /** Group referenced external files into source-handle roots for the sidebar. */


### PR DESCRIPTION
The sidebar currently sorts pages alphabetically, so a directory index listing Getting started before API reference produces a different navigation order. Make each sidebar level follow the entries authored in that directory's index page, with the index page itself first.

Reuse `MarkdownFileAnalysis.indexEntries` through the shared `ViewIndex`. The browser receives the order with its existing index request; edits update live navigation, and static and server exports inherit the same data without another Markdown parse. External sources retain natural sorting.

Every visible Markdown page and subdirectory still has to be listed: `lat check` rejects missing entries. During editing, unlisted pages remain navigable after listed entries in natural order so an invalid vault can be repaired. Stale index links never create phantom sidebar entries.

Validation: eight focused tests pass, including nested ordering, rendered sidebar links, incremental index edits, static export, and rejection of orphan pages in root and subdirectory indexes. Typechecking and `lat check` pass.
