### PR TITLE
Remember agent selections across lat init runs

### DIFF
--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -184,6 +184,10 @@ Steps:
 
 Initialization also adds `.lat-build` to the project-level `.gitignore`, keeping Lat's default static and Node-server outputs out of version control. Platform-specific output remains the project's responsibility.
 
+Completed interactive setup stores selected agent IDs under `init.agents` in the ignored `lat.md/config.local.yaml`. Subsequent checklists preselect those agents; unknown IDs are ignored. An explicitly empty selection is saved, while canceled setup and non-interactive runs leave preferences unchanged. Deselecting an agent does not uninstall its existing integration.
+
+[[src/cli/init-preferences.ts]] updates only this preference, preserving external-source overrides, unrelated settings, and YAML comments. Invalid YAML or preference shapes produce an error instead of overwriting the file. Existing setups without a saved selection start unchecked.
+
 At the very end, after all steps complete, init checks whether ripgrep (`rg`) is available. If missing, prints a tip suggesting the user install it for faster code scanning, with a link to the ripgrep installation guide.
 
 At the very start, before any steps, init prints the ASCII `lat.md` logo (cyan, matching the website) followed by "Checking latest version..." and awaits [[src/version.ts#fetchLatestVersion]] (3s timeout). If a newer version exists, prints an update notice so the user can upgrade before proceeding. If the fetch fails or the version matches, the message is cleared silently.

--- a/lat.md/tests/init.md
+++ b/lat.md/tests/init.md
@@ -53,6 +53,30 @@ A current-version non-interactive init with a configured key neither displays a 
 
 A non-interactive init with a configured backend that differs from the stored index prints the exact reindex command without starting an expensive rebuild.
 
+## Agent preferences
+
+Interactive setup remembers machine-local agent selections without changing unrelated configuration or treating unattended runs as user choices.
+
+### Remembers completed selections
+
+Completed setup saves selected agents in ignored local YAML, preserves external-source settings and comments, and supplies those defaults on the next run. Confirming no agents replaces the saved selection with an empty list.
+
+### Checklist restores editable defaults
+
+The checklist renders saved agents checked, ignores unknown or duplicate IDs, and allows users to toggle the defaults. Non-TTY operation still returns no selection.
+
+### Non-interactive runs preserve preferences
+
+Unattended initialization neither creates nor erases agent preferences, and does not install agents merely because they were selected during an earlier interactive run.
+
+### Aborted setup preserves preferences
+
+Canceling the command-style prompt leaves the previous selection untouched because agent setup did not complete.
+
+### Rejects invalid local preferences
+
+Malformed YAML, non-mapping configuration, and incorrectly typed preferences produce an actionable file-specific error without overwriting local configuration.
+
 ## Generated instructions
 
 Generated agent guidance must remain valid Markdown wherever project layouts expose it to Lat's graph scanner.

--- a/src/cli/checklist-menu.ts
+++ b/src/cli/checklist-menu.ts
@@ -8,6 +8,7 @@ export interface ChecklistOption {
 /**
  * Display an interactive multi-select checklist with arrow-key navigation.
  * Returns an array of checked values.
+ * Known initial values start checked; unknown values are ignored.
  *
  * Keys: Up/Down (j/k) to move, Space to toggle, Enter to confirm, Ctrl+C to exit.
  * Non-TTY fallback: returns [].
@@ -15,13 +16,18 @@ export interface ChecklistOption {
 export async function checklistMenu(
   options: ChecklistOption[],
   prompt?: string,
+  initialValues: readonly string[] = [],
 ): Promise<string[]> {
   if (options.length === 0) return [];
   if (!process.stdin.isTTY) return [];
 
   return new Promise((resolve) => {
     let cursor = 0;
-    const checked = new Set<number>();
+    const checked = new Set(
+      options.flatMap((option, index) =>
+        initialValues.includes(option.value) ? [index] : [],
+      ),
+    );
     const stdin = process.stdin;
 
     const wasRaw = stdin.isRaw;

--- a/src/cli/init-preferences.ts
+++ b/src/cli/init-preferences.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { isMap, parseDocument } from 'yaml';
+
+function readPreferences(latDir: string) {
+  const path = join(latDir, 'config.local.yaml');
+  const document = parseDocument(
+    existsSync(path) ? readFileSync(path, 'utf8') : '',
+  );
+  if (document.errors.length > 0) {
+    throw new Error(`Cannot parse ${path}: ${document.errors[0].message}`);
+  }
+  if (document.contents !== null && !isMap(document.contents)) {
+    throw new Error(`${path} must be a mapping`);
+  }
+  if (document.has('init') && !isMap(document.get('init', true))) {
+    throw new Error(`${path}: init must be a mapping`);
+  }
+  return { path, document };
+}
+
+/** Read machine-local checklist defaults without inferring installed agents. */
+export function readInitAgents(latDir: string): string[] {
+  const { path, document } = readPreferences(latDir);
+  const agents: unknown = document.toJS()?.init?.agents;
+  if (agents === undefined) return [];
+  if (
+    !Array.isArray(agents) ||
+    agents.some((agent) => typeof agent !== 'string')
+  ) {
+    throw new Error(`${path}: init.agents must be a list of strings`);
+  }
+  return agents;
+}
+
+/** Update just the confirmed selection, preserving other YAML and comments. */
+export function writeInitAgents(latDir: string, agents: string[]): void {
+  const { path, document } = readPreferences(latDir);
+  document.setIn(['init', 'agents'], agents);
+  writeFileSync(path, document.toString());
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -33,6 +33,7 @@ import {
 import { getLocalVersion, fetchLatestVersion } from '../version.js';
 import { selectMenu, type SelectOption } from './select-menu.js';
 import { checklistMenu } from './checklist-menu.js';
+import { readInitAgents, writeInitAgents } from './init-preferences.js';
 
 async function confirm(
   rl: ReturnType<typeof createInterface>,
@@ -1433,6 +1434,7 @@ export async function initCmd(targetDir?: string): Promise<void> {
     const selectedAgents = await checklistMenu(
       allAgents,
       'Which coding agents do you use?',
+      readInitAgents(latDir),
     );
 
     const useClaudeCode = selectedAgents.includes('claude');
@@ -1487,6 +1489,7 @@ export async function initCmd(targetDir?: string): Promise<void> {
       // agent. Stamp the version so future non-interactive runs do not reapply
       // fresh/outdated defaults and overwrite the chosen backend.
       writeInitMeta(latDir, {});
+      if (interactive) writeInitAgents(latDir, selectedAgents);
       console.log('');
       console.log(
         styleText('dim', 'No agents selected. You can re-run') +
@@ -1553,6 +1556,7 @@ export async function initCmd(targetDir?: string): Promise<void> {
 
     // Record init version and file hashes so `lat check` can detect stale setups
     writeInitMeta(latDir, fileHashes);
+    if (interactive) writeInitAgents(latDir, selectedAgents);
 
     console.log('');
     console.log(

--- a/tests/checklist-menu.test.ts
+++ b/tests/checklist-menu.test.ts
@@ -1,0 +1,46 @@
+import { PassThrough } from 'node:stream';
+import { afterEach, expect, it, vi } from 'vitest';
+import { checklistMenu } from '../src/cli/checklist-menu.js';
+
+const stdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin')!;
+afterEach(() => {
+  Object.defineProperty(process, 'stdin', stdinDescriptor);
+  vi.restoreAllMocks();
+});
+
+// @lat: [[init#Agent preferences#Checklist restores editable defaults]]
+it('renders saved known agents checked, allows toggling, and ignores stale values', async () => {
+  const stdin = Object.assign(new PassThrough(), {
+    isTTY: true,
+    isRaw: false,
+    setRawMode: vi.fn(),
+  });
+  Object.defineProperty(process, 'stdin', { configurable: true, value: stdin });
+  const output = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => true);
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  const options = [
+    { label: 'Claude Code', value: 'claude' },
+    { label: 'Codex', value: 'codex' },
+  ];
+  const result = checklistMenu(options, 'Agents?', [
+    'codex',
+    'removed',
+    'codex',
+  ]);
+  const rendered = output.mock.calls.map(([text]) => String(text)).join('');
+  expect(rendered).toMatch(/\[x\].*Codex/);
+  expect(rendered).toMatch(/\[ \].*Claude Code/);
+  stdin.emit('data', ' ');
+  stdin.emit('data', 'j');
+  stdin.emit('data', ' ');
+  stdin.emit('data', '\r');
+  expect(await result).toEqual(['claude']);
+  expect(stdin.listenerCount('data')).toBe(0);
+  expect(stdin.setRawMode).toHaveBeenLastCalledWith(false);
+
+  stdin.isTTY = false;
+  expect(await checklistMenu(options, 'Agents?', ['codex'])).toEqual([]);
+  stdin.destroy();
+});

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -12,6 +12,8 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import xdg from '@folder/xdg';
+import { parse as parseYaml } from 'yaml';
+import { checklistMenu } from '../src/cli/checklist-menu.js';
 import {
   INIT_VERSION,
   readInitVersion,
@@ -72,6 +74,12 @@ vi.mock('../src/cli/checklist-menu.js', () => ({
   checklistMenu: vi.fn(async () => []),
 }));
 vi.mock('../src/cli/select-menu.js', () => ({ selectMenu }));
+vi.mock('node:readline/promises', () => ({
+  createInterface: vi.fn(() => ({
+    question: vi.fn(async () => 'n'),
+    close: vi.fn(),
+  })),
+}));
 vi.mock('../src/cli/reindex.js', () => ({ reindexCommand }));
 vi.mock('../src/search/db.js', () => ({
   closeDb,
@@ -227,6 +235,8 @@ describe('lat init embedding setup', () => {
     reindexCommand.mockReset();
     reindexCommand.mockResolvedValue({ output: 'Reindexed.' });
     selectMenu.mockReset();
+    vi.mocked(checklistMenu).mockReset();
+    vi.mocked(checklistMenu).mockResolvedValue([]);
     setRepoEmbedding.mockClear();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -241,6 +251,89 @@ describe('lat init embedding setup', () => {
       delete (process.stdin as { isTTY?: boolean }).isTTY;
     }
     rmSync(root, { recursive: true, force: true });
+  });
+
+  // @lat: [[init#Agent preferences#Remembers completed selections]]
+  it('persists selected agents locally and restores them on the next init', async () => {
+    createLatDir();
+    setInteractive(true);
+    const path = join(latDir(), 'config.local.yaml');
+    writeFileSync(
+      path,
+      '# My checkout\nexternal-sources:\n  docs:\n    local-path: ../docs\n',
+    );
+    vi.mocked(checklistMenu).mockResolvedValueOnce(['codex', 'cursor']);
+    selectMenu.mockResolvedValue('global');
+
+    await initCmd(root);
+
+    const saved = readFileSync(path, 'utf8');
+    expect(saved).toContain('# My checkout');
+    expect(parseYaml(saved)).toEqual({
+      'external-sources': { docs: { 'local-path': '../docs' } },
+      init: { agents: ['codex', 'cursor'] },
+    });
+    expect(readFileSync(join(latDir(), '.gitignore'), 'utf8')).toContain(
+      'config.local.yaml',
+    );
+    expect(existsSync(join(root, '.codex', 'hooks.json'))).toBe(true);
+
+    await initCmd(root);
+
+    expect(checklistMenu).toHaveBeenLastCalledWith(
+      expect.any(Array),
+      'Which coding agents do you use?',
+      ['codex', 'cursor'],
+    );
+    expect(parseYaml(readFileSync(path, 'utf8')).init.agents).toEqual([]);
+  });
+
+  // @lat: [[init#Agent preferences#Non-interactive runs preserve preferences]]
+  it('does not create or erase agent preferences without a TTY', async () => {
+    createLatDir();
+    const path = join(latDir(), 'config.local.yaml');
+    await initCmd(root);
+    expect(existsSync(path)).toBe(false);
+    const original = 'init:\n  agents: [codex]\n';
+    writeFileSync(path, original);
+
+    expectSuccess(runInit());
+
+    expect(readFileSync(path, 'utf8')).toBe(original);
+    expect(existsSync(join(root, '.codex'))).toBe(false);
+  });
+
+  // @lat: [[init#Agent preferences#Aborted setup preserves preferences]]
+  it('does not save a selection when the command-style prompt is canceled', async () => {
+    createLatDir();
+    setInteractive(true);
+    const path = join(latDir(), 'config.local.yaml');
+    const original = 'init:\n  agents: [cursor]\n';
+    writeFileSync(path, original);
+    vi.mocked(checklistMenu).mockResolvedValue(['codex']);
+    selectMenu.mockResolvedValue(null);
+
+    await initCmd(root);
+
+    expect(readFileSync(path, 'utf8')).toBe(original);
+  });
+
+  // @lat: [[init#Agent preferences#Rejects invalid local preferences]]
+  it('reports invalid YAML or preference shapes without overwriting them', async () => {
+    createLatDir();
+    setInteractive(true);
+    const path = join(latDir(), 'config.local.yaml');
+    for (const original of [
+      'init: [',
+      '- codex\n',
+      'init: false\n',
+      'init:\n  agents: codex\n',
+    ]) {
+      writeFileSync(path, original);
+      await expect(initCmd(root)).rejects.toThrow('config.local.yaml');
+      expect(readFileSync(path, 'utf8')).toBe(original);
+    }
+    expect(checklistMenu).not.toHaveBeenCalled();
   });
 
   // @lat: [[init#Embedding setup#Fresh init pins local embeddings]]


### PR DESCRIPTION
## Summary

- Remember completed interactive agent selections under `init.agents` in ignored `lat.md/config.local.yaml`, and precheck them on subsequent `lat init` runs.
- Preserve unrelated YAML settings and comments; explicitly clearing the checklist saves an empty selection. Non-interactive and canceled setup leave preferences unchanged.
- Add regression tests and document the behavior. Existing setups without saved preferences remain unchecked until their next completed interactive run.

## Validation

- `pnpm buildall`
- `pnpm test` (326 tests)
- `node dist/src/cli/index.js check`
