### PR TITLE
Add copy-to-clipboard controls to code blocks

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -46,6 +46,8 @@ Rich fences remain `pre` and `code` elements with inert text children in the con
 
 Source and fenced-code highlighting starts as Lowlight HAST and becomes document-tree nodes without HTML serialization. Multiline tokens are split structurally into independently renderable lines. Raw reStructuredText and AsciiDoc pass-through content remains inert text.
 
+Rendered `pre` blocks use [[view/src/CodeBlock.tsx#CodeBlock]] for a clipboard button outside the horizontally scrolling code. It copies plain text with whitespace intact, reports success or failure, and appears on hover or keyboard focus; touch devices always show it. The shared renderer covers live, static, external, and formatted section-output documents, including rich-fence source fallbacks.
+
 Static export traverses tree properties to discover linked source and external targets and to rewrite route URLs. It does not parse or edit serialized markup.
 
 ## Build targets

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -117,6 +117,18 @@ External-document repository links resolve against the document's source path. F
 
 Static export discovers and rewrites links by traversing node properties while retaining the same document-tree payload as the live server.
 
+## Copies code blocks
+
+Code-block clipboard controls sit outside the scrollable source, appear on hover or keyboard focus, and remain visible on touch devices without changing the code's content or highlighting.
+
+### Copies plain and highlighted text
+
+Each rendered `pre` copies its own plain text with indentation, special characters, and trailing newlines intact. Inline code has no button, success is announced temporarily, and static views retain the action.
+
+### Reports clipboard failures
+
+Missing clipboard APIs or denied permissions show a retryable failure rather than false success. Retrying can succeed without replacing the code or navigating the page.
+
 ## Renders Markdown with navigable local links
 
 Markdown normalizes into a safe tree with GitHub-style heading ids and intact relative destinations. HTTP(S) and protocol-relative links gain decorative external-site icons in documents and reference contexts.

--- a/tests/markdown-content.test.ts
+++ b/tests/markdown-content.test.ts
@@ -41,6 +41,111 @@ describe('MarkdownContent', () => {
   afterEach(async () => {
     await act(async () => root.unmount());
     container.remove();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  const codeText = 'const value = "<hello>";\n\tconsole.log(value);\n';
+  const codeTree: ViewDocumentTree = {
+    version: 1,
+    type: 'root',
+    children: [
+      {
+        type: 'element',
+        tagName: 'pre',
+        properties: { className: ['example'] },
+        children: [
+          {
+            type: 'element',
+            tagName: 'code',
+            properties: { className: ['language-js'] },
+            children: [
+              {
+                type: 'element',
+                tagName: 'span',
+                properties: { className: ['hljs-keyword'] },
+                children: [{ type: 'text', value: 'const' }],
+              },
+              { type: 'text', value: codeText.slice(5) },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'element',
+        tagName: 'pre',
+        properties: {},
+        children: [{ type: 'text', value: 'plain\ntext\n' }],
+      },
+      {
+        type: 'element',
+        tagName: 'code',
+        properties: {},
+        children: [{ type: 'text', value: 'inline' }],
+      },
+    ],
+  };
+
+  // @lat: [[lat.md/view/specs#View Tests#Copies code blocks#Copies plain and highlighted text]]
+  it('copies exact code text independently of highlighting and UI labels', async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    const onClick = vi.fn();
+    await act(async () =>
+      root.render(
+        createElement(MarkdownContent, {
+          tree: codeTree,
+          onClick,
+          sectionOutputEnabled: false,
+        }),
+      ),
+    );
+    const buttons =
+      container.querySelectorAll<HTMLButtonElement>('.code-block-copy');
+    expect(buttons).toHaveLength(2);
+    expect(
+      container.querySelector('pre.example .hljs-keyword')?.textContent,
+    ).toBe('const');
+    expect(container.querySelector('pre')?.textContent).toBe(codeText);
+    await act(async () => buttons[0].click());
+    expect(writeText).toHaveBeenLastCalledWith(codeText);
+    expect(buttons[0].textContent).toBe('Copied!');
+    expect(buttons[1].textContent).toBe('Copy');
+    expect(onClick).not.toHaveBeenCalled();
+    expect(container.querySelector('[role="status"]')?.textContent).toBe(
+      'Copied!',
+    );
+    await act(async () => vi.advanceTimersByTime(2500));
+    expect(buttons[0].getAttribute('aria-label')).toBe('Copy code');
+    await act(async () => buttons[1].click());
+    expect(writeText).toHaveBeenLastCalledWith('plain\ntext\n');
+    expect(container.querySelector('pre')?.textContent).toBe(codeText);
+  });
+
+  // @lat: [[lat.md/view/specs#View Tests#Copies code blocks#Reports clipboard failures]]
+  it('reports unavailable or rejected clipboard access and allows retry', async () => {
+    vi.stubGlobal('navigator', {});
+    await act(async () =>
+      root.render(createElement(MarkdownContent, { tree: codeTree })),
+    );
+    const button =
+      container.querySelector<HTMLButtonElement>('.code-block-copy')!;
+    await act(async () => button.click());
+    expect(button.textContent).toBe('Retry copy');
+    expect(container.querySelector('[role="status"]')?.textContent).toBe(
+      'Copy failed. Try again.',
+    );
+    const writeText = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Permission denied'))
+      .mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    await act(async () => button.click());
+    expect(button.textContent).toBe('Retry copy');
+    await act(async () => button.click());
+    expect(button.textContent).toBe('Copied!');
+    expect(writeText).toHaveBeenLastCalledWith(codeText);
   });
 
   // @lat: [[lat.md/view/specs#View Tests#Stabilizes fragment navigation immediately#Preserves rich renderers]]

--- a/view/src/CodeBlock.tsx
+++ b/view/src/CodeBlock.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState, type ReactNode } from 'react';
+
+/** Keep clipboard controls outside the code and its horizontal scroll area. */
+export function CodeBlock({
+  children,
+  text,
+}: {
+  children: ReactNode;
+  text: string;
+}) {
+  const [result, setResult] = useState<{
+    text: string;
+    copied: boolean;
+  } | null>(null);
+  const currentResult = result?.text === text ? result : null;
+  useEffect(() => {
+    if (!result) return;
+    const timeout = window.setTimeout(() => setResult(null), 2500);
+    return () => window.clearTimeout(timeout);
+  }, [result]);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(text);
+      setResult({ text, copied: true });
+    } catch {
+      setResult({ text, copied: false });
+    }
+  }
+
+  const label = currentResult
+    ? currentResult.copied
+      ? 'Copied!'
+      : 'Copy failed. Try again.'
+    : 'Copy code';
+  return (
+    <div className="code-block">
+      {children}
+      <button
+        aria-label={label}
+        className="code-block-copy"
+        onClick={(event) => {
+          event.stopPropagation();
+          void copy();
+        }}
+        title={label}
+        type="button"
+      >
+        <svg aria-hidden="true" viewBox="0 0 16 16">
+          {currentResult?.copied ? (
+            <path d="m3 8 3 3 7-7" />
+          ) : (
+            <>
+              <rect x="5.5" y="5.5" width="8" height="8" rx="1.5" />
+              <path d="M10.5 3.5v-1h-8v8h1" />
+            </>
+          )}
+        </svg>
+        <span>
+          {currentResult
+            ? currentResult.copied
+              ? 'Copied!'
+              : 'Retry copy'
+            : 'Copy'}
+        </span>
+      </button>
+      <span className="code-block-status" role="status">
+        {currentResult ? label : ''}
+      </span>
+    </div>
+  );
+}

--- a/view/src/MarkdownContent.tsx
+++ b/view/src/MarkdownContent.tsx
@@ -19,6 +19,7 @@ import {
   type MarkdownRichFenceKind,
 } from './MarkdownRichFence';
 import { copySectionId } from './section-back-references';
+import { CodeBlock } from './CodeBlock';
 
 const VOID_ELEMENTS = new Set([
   'area',
@@ -326,10 +327,17 @@ function DocumentElement({
         documentNode(child, `${path}.${index}`, context),
       );
   const fenceKind = richFenceKind(node);
+  const element = createElement(node.tagName, properties, children);
+  const content =
+    node.tagName === 'pre' ? (
+      <CodeBlock text={documentNodeText(node)}>{element}</CodeBlock>
+    ) : (
+      element
+    );
   if (fenceKind) {
     return (
       <MarkdownRichFence
-        fallback={createElement(node.tagName, properties, children)}
+        fallback={content}
         key={path}
         kind={fenceKind}
         source={node.children.map(documentNodeText).join('')}
@@ -342,7 +350,7 @@ function DocumentElement({
       : null;
   const backReferences = headingId ? context?.sections.get(headingId) : null;
   if (!backReferences) {
-    return createElement(node.tagName, properties, children);
+    return content;
   }
   return (
     <SectionMenu

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -2100,6 +2100,86 @@ a.wiki-link-active {
   background: transparent;
 }
 
+.code-block {
+  position: relative;
+  min-width: 0;
+  margin: 0 0 1.25em;
+}
+
+.markdown .code-block > pre {
+  margin: 0;
+  padding-right: 104px;
+}
+
+.code-block-copy {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 32px;
+  padding: 6px 8px;
+  color: var(--muted);
+  font: inherit;
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  background: var(--code);
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+}
+
+.code-block-copy svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.code-block-copy:hover {
+  color: var(--text);
+  background: var(--reference-control-hover);
+}
+
+.code-block-copy:focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
+}
+
+.code-block-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .code-block-copy {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .code-block:hover > .code-block-copy,
+  .code-block:focus-within > .code-block-copy {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+@media (any-pointer: coarse) {
+  .code-block-copy {
+    min-height: 44px;
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 .markdown .markdown-diagram {
   padding: 18px;
   margin: 0 0 1.25em;


### PR DESCRIPTION
## Summary

- Add a top-right copy button to rendered code/pre blocks, visible on desktop hover or keyboard focus and always visible on touch devices.
- Copy plain text with whitespace preserved, without syntax-highlighting markup or control labels. Show temporary success feedback and retryable clipboard failures.
- Keep controls outside horizontal code scrolling. Use the shared document renderer for local, server, static, external, and formatted section-output views, including rich-fence source fallbacks.
- Update behavior documentation and regression tests.

## Validation

- `pnpm buildall`
- `pnpm test` — 323 tests passed
- `node dist/src/cli/index.js check`
- Browser checks: desktop hidden/hover/focus behavior, exact copied text, success feedback, and touch visibility with a 44px target (browser-local clipboard stub).
