### PR TITLE
Publish a minimal llms.txt for the Lat website

### DIFF
--- a/lat.md/dev-process.md
+++ b/lat.md/dev-process.md
@@ -115,6 +115,8 @@ The repository's site project exports the root vault through `lat ui build serve
 
 `pnpm build:site` compiles the shared server, downloads the exact published WASM and model artifacts matching this checkout, builds Lat, and writes the server artifact to `.lat-build/server/`.
 
+Both `build:site` and `build:site:source` copy the curated repository-root [[llms.txt]] into the artifact's `public/` directory through [[scripts/copy-site-assets.mjs]]. The Vercel build carries it into static output at `/llms.txt`. This is specific to Lat's own site; ordinary user exports do not include it.
+
 ```bash
 pnpm install --frozen-lockfile
 pnpm build:site

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -101,6 +101,10 @@ The Vercel build vendors this branch's `lat.md` and `@lat.md/*` packages into th
 
 Hosted previews intentionally use published embedding packages. `pnpm build:site:source` validates local engine or model changes, which cannot appear in a hosted preview until their package versions are published.
 
+## Publishes the website's agent guide
+
+The website build copies the repository-root `llms.txt` unchanged into public output. It explains installation and points to the homepage without deep documentation links; the general-purpose exporter remains unchanged.
+
 ## Keeps build-only packages out of runtime dependencies
 
 The published CLI declares browser renderer inputs and test-only serializers as development dependencies because consumers execute prebuilt artifacts and should not install redundant source trees.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,15 @@
+# Lat
+
+> Lat is a knowledge graph for your codebase, written in Markdown. It connects architecture, design decisions, and test specifications to source code.
+
+Install the `lat.md` npm package globally:
+
+```sh
+npm install -g lat.md
+```
+
+Then run `lat init` from your project's root to set up Lat and your coding agents.
+
+## Documentation
+
+- [Lat website](https://lat.md/): Browse the site for current documentation, usage guides, and examples.

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "scripts": {
     "build": "tsc && pnpm build:view",
     "build:view": "vite build --config view/vite.config.ts && vite build --config view/highlight.vite.config.ts",
-    "build:site": "pnpm --filter @lat.md/server build && node scripts/prepare-site-packages.mjs && pnpm build && node dist/src/cli/index.js ui build server --force",
+    "build:site": "pnpm --filter @lat.md/server build && node scripts/prepare-site-packages.mjs && pnpm build && node dist/src/cli/index.js ui build server --force && node scripts/copy-site-assets.mjs",
     "build:site:vercel": "pnpm build:site && node scripts/vendor-site-packages.mjs && npm install --prefix .lat-build/server --ignore-scripts --no-package-lock && node scripts/build-vercel-output.mjs",
-    "build:site:source": "pnpm buildall && node dist/src/cli/index.js ui build server --force",
+    "build:site:source": "pnpm buildall && node dist/src/cli/index.js ui build server --force && node scripts/copy-site-assets.mjs",
     "buildall": "pnpm build:packages && pnpm build",
     "setup:rust": "pnpm --filter @lat.md/embed setup:rust",
     "build:wasm": "pnpm --filter @lat.md/embed build:wasm",

--- a/scripts/copy-site-assets.mjs
+++ b/scripts/copy-site-assets.mjs
@@ -1,0 +1,9 @@
+import { copyFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+// Website-owned files are not part of the general-purpose Lat exporter.
+const publicDir = resolve(process.argv[2] ?? '.lat-build/server/public');
+await copyFile(
+  new URL('../llms.txt', import.meta.url),
+  resolve(publicDir, 'llms.txt'),
+);

--- a/tests/site-build.test.ts
+++ b/tests/site-build.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const repositoryRoot = join(import.meta.dirname, '..');
@@ -11,13 +13,13 @@ describe('repository site build', () => {
       readFileSync(join(repositoryRoot, 'package.json'), 'utf8'),
     ) as { scripts: Record<string, string> };
     expect(rootPackage.scripts['build:site']).toBe(
-      'pnpm --filter @lat.md/server build && node scripts/prepare-site-packages.mjs && pnpm build && node dist/src/cli/index.js ui build server --force',
+      'pnpm --filter @lat.md/server build && node scripts/prepare-site-packages.mjs && pnpm build && node dist/src/cli/index.js ui build server --force && node scripts/copy-site-assets.mjs',
     );
     expect(rootPackage.scripts['build:site:vercel']).toBe(
       'pnpm build:site && node scripts/vendor-site-packages.mjs && npm install --prefix .lat-build/server --ignore-scripts --no-package-lock && node scripts/build-vercel-output.mjs',
     );
     expect(rootPackage.scripts['build:site:source']).toBe(
-      'pnpm buildall && node dist/src/cli/index.js ui build server --force',
+      'pnpm buildall && node dist/src/cli/index.js ui build server --force && node scripts/copy-site-assets.mjs',
     );
 
     const vercelBuild = readFileSync(
@@ -40,5 +42,26 @@ describe('repository site build', () => {
     ).split('\n');
     expect(gitIgnore).toContain('.lat-build');
     expect(gitIgnore).not.toContain('web');
+  });
+
+  // @lat: [[lat.md/view/specs#View Tests#Publishes the website's agent guide]]
+  it('copies the minimal root llms.txt unchanged without deep documentation links', () => {
+    const output = mkdtempSync(join(tmpdir(), 'lat-site-assets-'));
+    try {
+      execFileSync(
+        process.execPath,
+        [join(repositoryRoot, 'scripts', 'copy-site-assets.mjs'), output],
+        { cwd: output },
+      );
+      const source = readFileSync(join(repositoryRoot, 'llms.txt'), 'utf8');
+      expect(readFileSync(join(output, 'llms.txt'), 'utf8')).toBe(source);
+      expect(source).toMatch(/^# Lat\n/);
+      expect(source).toContain('npm install -g lat.md');
+      expect(source).toContain('lat init');
+      expect(source).toContain('[Lat website](https://lat.md/)');
+      expect(source).not.toContain('/docs/');
+    } finally {
+      rmSync(output, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Add a minimal repository-root `llms.txt` introducing Lat, explaining installation and `lat init`, and directing agents to browse the homepage for current documentation. No deep documentation links while content is being updated.
- Copy the file unchanged into `.lat-build/server/public/` from both website build commands; Vercel's existing packaging carries it into static output at `/llms.txt`.
- Keep this specific to Lat's website: no changes to the general-purpose exporter or user-generated sites.
- Update documentation and add a regression test for the copy step and minimal contents.

## Validation

- `pnpm buildall`
- `pnpm test` — 322 tests
- `node dist/src/cli/index.js check`
- Byte-for-byte comparison of root `llms.txt` with the copied website artifact
