### PR TITLE
Refine UI styling and graph presentation

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -14,9 +14,13 @@ The bundled Lat wordmark is the default top-left brand in both clients. Vite emi
 
 The browser uses a monochrome visual system: pure black or white foundations, neutral surfaces and borders, and restrained controls. Color is reserved for links, graph categories, syntax, and semantic Git or diagnostic state.
 
+The shared client uses Geist typography and system-selected light/dark themes. Geist Sans and Geist Mono ship as self-hosted Vite assets in live, static, and server deployments, including nested bases. Controls retain visible keyboard focus.
+
 The installed runtime uses Node HTTP and prebuilt Vite assets. Browser renderer inputs remain development dependencies because Vite emits their code, styles, and fonts into the published lazy assets instead of making npm consumers install redundant source packages.
 
 The server highlighter similarly bundles Lowlight with only Lat's supported Highlight.js grammars, keeping the full language set out of production dependencies.
+
+Code fences, source views, and the Markdown editor share syntax color roles in both themes while retaining their own tokenizers. Parameters, variables, and properties stay neutral rather than inheriting enclosing function colors.
 
 Rich Markdown fences keep authored source as inert text nodes in document payloads. React-owned Mermaid, map, and 3D components lazily load browser-only renderers, so live and static documents degrade to readable code when a renderer cannot load or rejects input.
 
@@ -164,7 +168,7 @@ Whenever cached changes exist, the toggle keeps an orange notification dot wheth
 
 Generated document links omit `.md`; the same route with `.md` is deliberately left to the browser as raw source. Relative links authored with `.md` are normalized to the extensionless UI route before rendering.
 
-Markdown and source metadata rows align with the sidebar header, while source metadata retains clear space before the code panel.
+Desktop sidebar controls, document metadata, presentation switches, and TOC titles align vertically. Source metadata retains clear space before the code panel.
 
 Rendered sections use heading scale and whitespace without horizontal separators between headings.
 
@@ -200,7 +204,7 @@ Below 64rem, the browser replaces desktop navigation rails with a persistent, to
 
 The first row keeps the logo and Git, Search, and Graph actions. A second row shows the current route and opens the file tree as an independently scrolling viewport overlay; navigation, Escape, or returning to desktop closes it and restores document scrolling.
 
-Mobile content uses narrower gutters, fixed heading metrics, wrapped links, and horizontally scrollable code instead of shrinking text. The desktop TOC collapses into a sticky `On this page` row with its own scrollable list and preserved section state.
+Mobile navigation, document text, and `On This Page` share a consistent left gutter across tablet and phone widths. Long text, inline code, and error messages wrap without widening the viewport; code blocks scroll locally. The TOC becomes a sticky row with its own scrollable list.
 
 Selecting a collapsed TOC entry closes the list before positioning the heading. Its sticky-header offset keeps direct fragments visible below both mobile navigation rows and the TOC trigger.
 
@@ -232,4 +236,4 @@ Escape clears a non-empty query, then returns to the page that opened search. Cl
 
 [[graph#Graph View]] projects cached documents, source targets, and code mentions into a stable directed graph without rescanning at request time. Resolved section relationships roll up to their owning documents.
 
-The client preloads the graph projection, ships its WebGL renderer in the main UI, and uses deterministic document/code clusters so the persisted presentation mode switches without I/O or layout work. Normal document/source URLs own selection and history; the embedding filter reuses `/api/search` and propagates cosine scores into result sizing.
+The graph renderer and projection load on demand; deterministic document/code clusters avoid force simulation. Normal document/source URLs own selection and history; the embedding filter reuses `/api/search` and propagates cosine scores into result sizing.

--- a/lat.md/view/graph.md
+++ b/lat.md/view/graph.md
@@ -10,7 +10,7 @@ The first version adopts the useful interaction model of Obsidian's graph while 
 
 [Sigma.js](https://www.sigmajs.org/docs/) renders the graph with WebGL, Graphology supplies the graph model, and typed [node events](https://www.sigmajs.org/docs/advanced/events/) cover hover and click selection. A custom D3 canvas would make Lat own rendering, labels, hit testing, and camera controls.
 
-Lat uses `sigma` and `graphology` directly as development dependencies. The renderer ships with the main client and the graph payload is prefetched after startup, so switching modes does not wait for a chunk, request, or force simulation.
+Lat bundles `sigma` and `graphology` from development dependencies and loads the renderer and graph payload on demand, keeping ordinary document startup independent of graph rendering.
 
 ## Product shape
 
@@ -22,6 +22,7 @@ Graph mode replaces the document layout with a full-viewport graph workspace whi
 - The browser URL always remains the exact document, section, source, or code-line target. Node and inspector navigation use ordinary history entries, so reload, copied URLs, Back, and Forward retain their normal meaning while Graph stays active.
 - The graph icon only toggles a namespaced `localStorage` presentation setting; it does not rewrite history. Disabling Graph reveals the same selected target in the file/source layout immediately, and the persisted setting restores Graph after reload.
 - Narrow screens stack a bounded graph above the inspector instead of forcing two narrow columns.
+- Switching modes preserves the logo and toolbar's vertical position at every breakpoint.
 
 ```text
 ┌ lat.md  Git  Search  Graph  Filter…         │ selected node    ┐
@@ -46,6 +47,8 @@ Documents form the graph backbone, while code nodes appear when source definitio
 
 Each node includes `id`, `kind`, `label`, canonical `url`, breadcrumbs, reference counts, and optional Git state, error count, source signature, or snippet. Node radius grows logarithmically with incoming references, so backlinks—not outgoing links—determine prominence.
 
+A local document's incoming count sums the displayed direct backlink counts for its root and every nested section. Repeated links from one paragraph to the same section count once; links to different sections count separately. Same-document references and code mentions contribute too. Other nodes use incoming edge occurrence weights.
+
 ### Edges
 
 Edges preserve direction and provenance while collapsing duplicate visual lines.
@@ -54,7 +57,7 @@ Edges preserve direction and provenance while collapsing duplicate visual lines.
 - Source wiki links connect their containing document to a source node.
 - `@lat:` mentions connect a code-reference node to the target section's owning document.
 - Collapse equal `from`, `to`, and `kind` triples into one edge with an occurrence weight. Keep `wiki`, `markdown`, `source`, and `code-mention` kinds so filters and styling remain possible.
-- Omit unresolved and ambiguous targets, plus links whose endpoints collapse into the same document. Section resolution preserves authored meaning without adding section or containment nodes that make the graph dense or inflating backlinks with self-links.
+- Omit unresolved and ambiguous targets, plus visible edges whose endpoints collapse into the same document. Same-document references still contribute to the page's section backlink total without drawing self-loops.
 
 ## Server projection
 
@@ -70,9 +73,13 @@ Whenever [[src/view/store.ts#createViewStore]] replaces its snapshot, it rebuild
 
 The graph canvas and inspector share route state but keep rendering responsibilities separate.
 
-The client prefetches the graph projection after startup and includes `GraphView` in its main bundle. A deterministic linear-time layout places documents on a ring and clusters code around its strongest document neighbor, so Sigma can paint immediately without physics or animation.
+The client caches the on-demand graph projection. A deterministic linear-time layout places documents on a ring and clusters code around its strongest document neighbor, without physics or animation.
 
 Sigma reducers dim unrelated nodes and edges on hover, emphasize immediate neighbors, render documents in Vercel blue and code in warm orange, and keep the selected node labeled. Every visible label uses white text and shadow on an 80%-opaque black plate; highly referenced nodes receive default labels.
+
+Outlined, translucent nodes remain distinguishable when overlapping. The circle shader premultiplies alpha for Sigma's blending mode but keeps picking IDs opaque. Edges and muted nodes use renderer-safe hex colors rather than CSS border tokens.
+
+The selected node keeps a stronger fill, visible label, and foreground position even while another node is hovered. Unrelated connections stay visible rather than disappearing during selection.
 
 With no semantic filter, node radius reflects incoming references. Search preserves each hit's cosine score, rolls a document's strongest section hit into its graph node, gives adjacent code that score, and normalizes visible radii across the current result set.
 
@@ -86,7 +93,7 @@ The graph pane remains fixed while the inspector scrolls from the top edge. The 
 
 The initial workspace favors direct exploration over a large settings surface.
 
-It includes pan, zoom, node drag, hover-neighbor highlighting, click selection, fit/reset, kind toggles for documents and code, embedding search, and directed edge arrows.
+It includes pan, zoom, hover-neighbor highlighting, click selection, fit/reset, kind toggles for documents and code, embedding search, and directed edge arrows. Individual nodes cannot be dragged; their layout stays stable while dragging pans the graph.
 
 The text input follows the app buttons and debounces through the same indexed embedding search as `lat search`. Matching sections map to their document nodes and adjacent code nodes, filtering only the canvas with no result list or dropdown.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -177,6 +177,10 @@ Markdown documents expose their H1 plus nested subsection headings in a sticky r
 
 The fixed-width desktop rail fills the available viewport height without programmatic resizing. Its list stays content-height when short and scrolls without a visible scrollbar when long; fixed link metrics never compress, and short final sections activate in sequence.
 
+The active indicator stays within the desktop rail; dropdowns omit it. The compact dropdown and expanded list align with the reading column's right edge, and its trigger matches View/Edit's height and vertical center.
+
+On wide screens, View/Edit stays at the reading column's right edge with or without a TOC, including Edit mode. A missing compact TOC lets the header span the reading column without changing the prose width limit.
+
 Sections containing rendered Git changes carry an orange disc when Git is enabled, while sections owning validation errors carry a red disc. Both remain visible together when both states apply.
 
 ## Adapts navigation to mobile screens
@@ -185,7 +189,13 @@ Below 64rem, files remain reachable through a sticky two-row header and a scroll
 
 The overlay exposes its expanded state, uses touch-sized file targets, locks document scrolling while open, and closes on navigation, Escape, or a return to desktop width. Content gutters narrow, code scrolls horizontally without browser text inflation, and the graph stacks above its inspector.
 
-When the desktop TOC rail no longer fits, a compact `On this page` control shares an aligned metadata row and expands its links in a bounded overlay without moving content. On mobile it becomes a full-width row below the app header, retains active and Git/error states, closes after selection or Escape, and offsets fragment targets.
+The Files and TOC icons, metadata, and reading text share a consistent left gutter across tablet and phone widths.
+
+Long unbroken text and inline code wrap within the reading column, while fenced code retains local horizontal scrolling. Map-loading error messages wrap inside their panel and keep Retry reachable without widening the page.
+
+When the desktop TOC rail no longer fits, a compact `On This Page` control shares an aligned metadata row and expands its links in a bounded overlay without moving content. On mobile it becomes a full-width row below the app header, retains active and Git/error states, closes after selection or Escape, and offsets fragment targets.
+
+Desktop header controls align vertically, including read-only documents without a presentation switch.
 
 ## Renders the graph workspace
 
@@ -193,13 +203,21 @@ Graph mode consumes a cached projection of documents, source targets, and code m
 
 The client renders a 50/50 graph and inspector. The logo and Graph toggle retain their normal desktop positions while floating over the graph with the semantic filter; Git and page Search are hidden. The right panel begins with the node preview and has no toolbar.
 
+Switching between graph and regular view preserves the logo and toolbar's vertical position at every breakpoint.
+
 The graph button persists a namespaced `localStorage` presentation setting without changing the current URL or browser history. Toggling it off immediately reveals the exact selected target in the normal file/source layout, and reload restores the stored mode.
 
 Plain document, section, source, and code-reference links navigate through their normal URLs without leaving Graph, so Back and Forward work without mode-specific history. Relative fragments resolve against the previewed document without refetching its content.
 
 Document and code radii grow only with incoming references. Every rendered label stays white over an 80%-opaque black plate with a text shadow in normal, selected, and hover states.
 
-The graph payload is prefetched after UI startup and a linear-time deterministic layout requires no force simulation, so toggling Graph paints immediately without a partial-page loading state, settling animation, or blocking pause.
+Local document counts sum direct backlinks to all headings, including nested sections and same-document links, with heading-badge paragraph deduplication. Visible edges retain occurrence weights and omit self-loops.
+
+Renderer-safe colors and premultiplied alpha keep edges visible and overlapping circles distinct without corrupting picking IDs. Selection stays emphasized while other nodes are hovered.
+
+Node positions remain fixed during pointer dragging; only the camera pans. Hover highlighting, click navigation, and zoom remain enabled.
+
+Graph uses a cached projection and a deterministic layout without force simulation or settling animation.
 
 Graph search debounces through the embedding-backed `/api/search` service used by `lat search`. Matching sections filter to their owning documents and adjacent code nodes without rendering a result popup. Their radii normalize by hit score; clearing search restores backlink sizing.
 
@@ -312,6 +330,10 @@ Focused source views place reference context before the highlighted definition, 
 ## Highlights source syntax safely
 
 Supported languages, including Dart and Java, become structured line trees without HTML serialization. HTML-like source remains inert text and multiline tokens retain their styling across every line.
+
+## Uses Geist syntax colors
+
+Code fences and source views share light/dark syntax roles. Keywords, strings, constants, and functions retain distinct colors; parameters, properties, punctuation, and string substitutions stay neutral.
 
 ## Builds a nested file tree
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "@codemirror/merge": "^6.12.2",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.9",
+    "@fontsource-variable/geist": "^5.3.0",
+    "@fontsource-variable/geist-mono": "^5.3.0",
     "@lezer/highlight": "^1.2.3",
     "@types/geojson": "^7946.0.16",
     "@types/express": "^5.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,12 @@ importers:
       '@codemirror/view':
         specifier: ^6.43.9
         version: 6.43.9
+      '@fontsource-variable/geist':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource-variable/geist-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
@@ -648,6 +654,12 @@ packages:
 
   '@folder/xdg@4.0.1':
     resolution: {integrity: sha512-mIBEyXvNK6sX341FOR6ZyGBmq84sSSkG2ocwTDmi4kJfAF6z8W//6aeMAi6vD/FuTcd4q0Px0HMVyP3ggOT/bg==}
+
+  '@fontsource-variable/geist-mono@5.3.0':
+    resolution: {integrity: sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw==}
+
+  '@fontsource-variable/geist@5.3.0':
+    resolution: {integrity: sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==}
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -3597,6 +3609,10 @@ snapshots:
       toml: 3.0.0
       write: 2.0.0
       yaml: 2.8.2
+
+  '@fontsource-variable/geist-mono@5.3.0': {}
+
+  '@fontsource-variable/geist@5.3.0': {}
 
   '@hono/node-server@1.19.11(hono@4.12.7)':
     dependencies:

--- a/src/view/graph.ts
+++ b/src/view/graph.ts
@@ -17,6 +17,7 @@ import { linkedSection } from './references.js';
 import type {
   ViewCodeReferenceFile,
   ViewParsedMarkdownFile,
+  ViewReferenceIndex,
 } from './references.js';
 import { viewSourceTarget } from './source-target.js';
 import type { ViewGitSnapshot } from './git.js';
@@ -66,6 +67,7 @@ export function buildViewGraph(
   diagnostics: ReadonlyMap<string, readonly ViewDocumentError[]>,
   git: ViewGitSnapshot,
   generation: number,
+  references: ViewReferenceIndex,
   external?: ExternalResolver,
 ): ViewGraph {
   const files = [...markdownFiles].sort((left, right) =>
@@ -131,7 +133,13 @@ export function buildViewGraph(
       breadcrumbs: pathBreadcrumbs(file.path),
       documentPath: file.path,
       sectionId: root?.id,
-      inDegree: 0,
+      inDegree: flat.reduce(
+        (count, section) =>
+          count +
+          (references.incomingBySection.get(section.id.toLowerCase())?.length ??
+            0),
+        0,
+      ),
       outDegree: 0,
       ...(git.files.get(file.path)?.status
         ? { gitStatus: git.files.get(file.path)?.status }
@@ -303,7 +311,9 @@ export function buildViewGraph(
     const source = nodes.get(edge.from);
     const target = nodes.get(edge.to);
     if (source) source.outDegree += edge.weight;
-    if (target) target.inDegree += edge.weight;
+    // Local documents use the sum of their headings' displayed backlink counts,
+    // not visual edge weights (which omit self-links and count repeat links).
+    if (target && !target.documentPath) target.inDegree += edge.weight;
   }
 
   return {

--- a/src/view/protocol.ts
+++ b/src/view/protocol.ts
@@ -97,6 +97,7 @@ export type ViewGraphNode = {
   label: string;
   url: string;
   breadcrumbs: string[];
+  /** Local documents sum direct backlink counts across every heading. Other nodes use incoming edge weights. */
   inDegree: number;
   outDegree: number;
   documentPath?: string;

--- a/src/view/store.ts
+++ b/src/view/store.ts
@@ -328,6 +328,7 @@ async function buildSnapshot(
       diagnostics,
       git,
       generation,
+      references,
       external,
     ),
     diagnostics,

--- a/tests/highlight.test.ts
+++ b/tests/highlight.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { toViewDocumentTree } from '../src/view/document-tree.js';
 import { highlightCode, highlightSource } from '../src/view/highlight.js';
 import type {
@@ -37,6 +38,62 @@ function treeTags(tree: ViewDocumentTree): string[] {
 }
 
 describe('source highlighting', () => {
+  // @lat: [[lat.md/view/specs#View Tests#Uses Geist syntax colors]]
+  it('shares Geist light and dark syntax roles across code and source views', () => {
+    const styles = readFileSync(
+      new URL('../view/src/styles.css', import.meta.url),
+      'utf8',
+    );
+    const palette = {
+      comment: ['oklch(0.42 0 0)', 'oklch(0.706 0 0)'],
+      keyword: ['oklch(53.5% 0.2058 2.84)', 'oklch(69.36% 0.2223 3.91)'],
+      number: ['oklch(53.18% 0.2399 256.99)', 'oklch(71.7% 0.1648 250.79)'],
+      string: ['oklch(51.75% 0.1453 147.65)', 'oklch(73.1% 0.2158 148.29)'],
+      title: ['oklch(47.18% 0.2579 304)', 'oklch(69.87% 0.2037 309.51)'],
+      markup: ['oklch(52.79% 0.1496 54.65)', 'oklch(77.21% 0.1991 64.28)'],
+    };
+    for (const [role, colors] of Object.entries(palette)) {
+      const declarations = Array.from(
+        styles.matchAll(new RegExp(`--syntax-${role}: ([^;]+);`, 'g')),
+        (match) => match[1],
+      );
+      expect(declarations).toEqual(colors);
+    }
+    const rules = new Map(
+      Array.from(
+        styles
+          .replace(/\/\*[\s\S]*?\*\//g, '')
+          .matchAll(/([^{}]+)\{([^{}]*)\}/g),
+      ).flatMap(([, selectors, declarations]) =>
+        selectors.split(',').map((selector) => [selector.trim(), declarations]),
+      ),
+    );
+    const roles = {
+      comment: 'syntax-comment',
+      keyword: 'syntax-keyword',
+      literal: 'syntax-number',
+      number: 'syntax-number',
+      string: 'syntax-string',
+      title: 'syntax-title',
+      built_in: 'syntax-title',
+      params: 'text',
+      attr: 'text',
+      attribute: 'text',
+      punctuation: 'text',
+      subst: 'text',
+    };
+    for (const scope of ['markdown', 'source-code']) {
+      for (const [token, role] of Object.entries(roles)) {
+        expect(rules.get(`.${scope} .hljs-${token}`)).toContain(
+          `color: var(--${role});`,
+        );
+      }
+    }
+    expect(rules.get('.markdown .language-json .hljs-keyword')).toContain(
+      'color: var(--syntax-number);',
+    );
+  });
+
   // @lat: [[lat.md/view/specs#View Tests#Highlights source syntax safely]]
   it('emits safe structured lines and preserves multiline tokens', () => {
     const lines = highlightSource(

--- a/tests/markdown-content.test.ts
+++ b/tests/markdown-content.test.ts
@@ -117,7 +117,7 @@ describe('MarkdownContent', () => {
       'Copied!',
     );
     await act(async () => vi.advanceTimersByTime(2500));
-    expect(buttons[0].getAttribute('aria-label')).toBe('Copy code');
+    expect(buttons[0].getAttribute('aria-label')).toBe('Copy Code');
     await act(async () => buttons[1].click());
     expect(writeText).toHaveBeenLastCalledWith('plain\ntext\n');
     expect(container.querySelector('pre')?.textContent).toBe(codeText);
@@ -132,7 +132,7 @@ describe('MarkdownContent', () => {
     const button =
       container.querySelector<HTMLButtonElement>('.code-block-copy')!;
     await act(async () => button.click());
-    expect(button.textContent).toBe('Retry copy');
+    expect(button.textContent).toBe('Retry Copy');
     expect(container.querySelector('[role="status"]')?.textContent).toBe(
       'Copy failed. Try again.',
     );
@@ -142,7 +142,7 @@ describe('MarkdownContent', () => {
       .mockResolvedValue(undefined);
     vi.stubGlobal('navigator', { clipboard: { writeText } });
     await act(async () => button.click());
-    expect(button.textContent).toBe('Retry copy');
+    expect(button.textContent).toBe('Retry Copy');
     await act(async () => button.click());
     expect(button.textContent).toBe('Copied!');
     expect(writeText).toHaveBeenLastCalledWith(codeText);

--- a/tests/markdown-editor.test.tsx
+++ b/tests/markdown-editor.test.tsx
@@ -96,8 +96,8 @@ describe('MarkdownEditor', () => {
       ),
     );
     expect(modeButtons.map((button) => button.textContent)).toEqual([
-      'view',
-      'edit',
+      'View',
+      'Edit',
     ]);
     expect(modeButtons[1].getAttribute('aria-pressed')).toBe('true');
     expect(modeButtons[0].querySelector('svg')).toBeNull();

--- a/tests/section-output-dialog.test.tsx
+++ b/tests/section-output-dialog.test.tsx
@@ -61,8 +61,8 @@ describe('SectionOutputDialog', () => {
       ),
     );
     expect(presentationButtons.map((button) => button.textContent)).toEqual([
-      'raw',
-      'formatted',
+      'Raw',
+      'Formatted',
     ]);
     expect(presentationButtons[1].getAttribute('aria-pressed')).toBe('true');
     expect(

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -57,6 +57,8 @@ import {
   validateDocumentRoutes,
   rewriteDocumentLink,
 } from '../src/view/document-route.js';
+import { buildViewGraph } from '../src/view/graph.js';
+import { buildViewReferenceIndex } from '../src/view/references.js';
 import { renderMarkdown as renderMarkdownTree } from '../src/view/markdown.js';
 import type {
   ViewDocument,
@@ -1155,7 +1157,7 @@ describe('lat ui', () => {
           );
           const links = [
             ...rendered.matchAll(
-              /<a class="section-back-reference-action" href="([^"]+)">View Markdown file<\/a>/g,
+              /<a class="section-back-reference-action" href="([^"]+)">View Markdown File<\/a>/g,
             ),
           ];
           expect(links).toHaveLength(1);
@@ -1242,6 +1244,79 @@ describe('lat ui', () => {
 
   // @lat: [[lat.md/view/specs#View Tests#Renders the graph workspace]]
   it('serves the cached graph projection and graph shell', async () => {
+    const graphClient = readFileSync(
+      join(import.meta.dirname, '..', 'view', 'src', 'GraphView.tsx'),
+      'utf8',
+    );
+    const graphStyles = readFileSync(
+      join(import.meta.dirname, '..', 'view', 'src', 'styles.css'),
+      'utf8',
+    );
+    for (const token of [
+      '--graph-edge',
+      '--graph-edge-muted',
+      '--graph-edge-active',
+      '--graph-node-muted',
+    ]) {
+      const colors = Array.from(
+        graphStyles.matchAll(new RegExp(`${token}: ([^;]+);`, 'g')),
+        (match) => match[1],
+      );
+      expect(colors).toHaveLength(2);
+      for (const color of colors) expect(color).toMatch(/^#[0-9a-f]{6}$/i);
+      expect(graphClient).toMatch(
+        new RegExp(`colorValue\\(\\s*styles,\\s*'${token}'`),
+      );
+    }
+    expect(graphClient).toContain('color: mutedEdgeColor');
+    expect(graphClient).toContain('color: activeEdgeColor');
+    expect(graphClient).toContain('color: mutedNodeColor');
+    expect(graphClient).not.toContain("sigma.on('downNode'");
+    expect(graphClient).not.toContain('graph.mergeNodeAttributes');
+    expect(graphClient).toContain("sigma.on('clickNode'");
+    expect(graphClient).toMatch(
+      /nodeProgramClasses:\s*\{\s*circle: GraphNodeProgram</,
+    );
+    const nodeProgram = readFileSync(
+      join(import.meta.dirname, '..', 'view', 'src', 'graph-node-program.ts'),
+      'utf8',
+    );
+    expect(nodeProgram).toContain('...super.getDefinition()');
+    expect(nodeProgram).toMatch(
+      /#ifdef PICKING_MODE\s*\/\/[^\n]*\n\s*gl_FragColor = v_color;/,
+    );
+    expect(nodeProgram).toContain('vec4(color * alpha, alpha)');
+    expect(nodeProgram).toContain('inset / (2.0 * u_correctionRatio)');
+    const fillOpacities = [...nodeProgram.matchAll(/return (0\.\d+);/g)].map(
+      (match) => Number(match[1]),
+    );
+    expect(fillOpacities).toEqual([0.8, 0.96]);
+    expect(fillOpacities[1] / fillOpacities[0]).toBeCloseTo(1.2);
+    expect(graphClient).toContain("type: isSelected ? 'selected' : 'circle'");
+    expect(graphClient).toContain('zIndex: isSelected ? 4 : 3');
+    expect(
+      graphClient.indexOf('if (isSelected || node === focus)'),
+    ).toBeLessThan(graphClient.indexOf('if (focus && node !== focus'));
+    expect(graphClient).not.toContain("colorValue(styles, '--panel-border'");
+    expect(graphStyles).toMatch(
+      /\.graph-kind-filters label span,\s*\.graph-fit \{[^}]*border: 0;/,
+    );
+    expect(graphStyles).toMatch(
+      /\.graph-topbar \{[^}]*height: calc\(56px \+ var\(--header-row-height\)\);/,
+    );
+    for (const height of [34, 42]) {
+      expect(graphStyles).toMatch(
+        new RegExp(
+          `\\.app-shell,\\s*\\.graph-shell \\{\\s*--header-row-height: ${height}px;`,
+        ),
+      );
+    }
+    expect(graphStyles).toMatch(
+      /\.graph-topbar-graph \{\s*min-height: 48px;\s*padding: 0 16px;/,
+    );
+    expect(graphStyles).toMatch(
+      /\.graph-topbar-graph \.graph-header \{\s*min-height: 48px;/,
+    );
     const shell = await fetch(new URL('/graph', view.url));
     expect(shell.status).toBe(200);
     expect(await shell.text()).toContain('lat ui shell');
@@ -1278,7 +1353,54 @@ describe('lat ui', () => {
     ).toMatchObject({ inDegree: 1, outDegree: 10 });
     expect(
       graph.nodes.find((node) => node.id === 'document:guide.md'),
-    ).toMatchObject({ inDegree: 8, outDegree: 2 });
+    ).toMatchObject({ inDegree: 7, outDegree: 2 });
+
+    const countFiles = [
+      analyzeMarkdownFile(
+        '/project/lat.md/target.md',
+        '# Target\n\nRoot overview.\n\n## Child\n\n[Deep](#deep).\n\n### Deep\n\nNested overview.\n',
+        '/project/lat.md',
+        '/project',
+      ),
+      analyzeMarkdownFile(
+        '/project/lat.md/from.md',
+        '# From\n\n[Root](target.md) [Child](target.md#child) [Deep](target.md#deep) [Repeated](target.md#deep).\n',
+        '/project/lat.md',
+        '/project',
+      ),
+    ];
+    const countSections = countFiles.flatMap((file) => file.sections);
+    const countReferences = buildViewReferenceIndex(
+      countFiles,
+      [],
+      countSections,
+    );
+    expect(
+      [...countReferences.incomingBySection.values()]
+        .map((refs) => refs.length)
+        .sort(),
+    ).toEqual([1, 1, 2]);
+    const countGraph = buildViewGraph(
+      countFiles,
+      [],
+      countSections,
+      new Map(),
+      { available: false, files: new Map() },
+      1,
+      countReferences,
+    );
+    expect(
+      countGraph.nodes.find((node) => node.id === 'document:target.md'),
+    ).toMatchObject({ inDegree: 4, outDegree: 0 });
+    expect(
+      countGraph.nodes.find((node) => node.id === 'document:from.md'),
+    ).toMatchObject({ inDegree: 0, outDegree: 4 });
+    expect(countGraph.edges).toHaveLength(1);
+    expect(countGraph.edges[0]).toMatchObject({
+      from: 'document:from.md',
+      to: 'document:target.md',
+      weight: 4,
+    });
 
     expect(graphUrl('document:guide.md')).toBe(
       '/graph?node=document%3Aguide.md',
@@ -1383,12 +1505,18 @@ describe('lat ui', () => {
     ).toBe(true);
     expect(validGraphPosition({ x: Number.NaN, y: 1 })).toBe(false);
     expect(graphNodeSize(0)).toBe(5);
-    expect(graphNodeSize(7)).toBeGreaterThan(graphNodeSize(1));
+    expect(graphNodeSize(1)).toBe(8);
+    expect(graphNodeSize(7)).toBe(14);
     expect(graphNodeSize(-1)).toBe(5);
     const positions = staticGraphPositions(graph);
     expect(positions.size).toBe(graph.nodes.length);
     expect([...positions.values()].every(validGraphPosition)).toBe(true);
     expect([...staticGraphPositions(graph)]).toEqual([...positions]);
+    const clusterCenter = positions.get('document:guide.md')!;
+    const satellite = positions.get('code-ref:src/app.ts:5')!;
+    expect(
+      Math.hypot(satellite.x - clusterCenter.x, satellite.y - clusterCenter.y),
+    ).toBeCloseTo(6.4);
     const searchScores = graphSearchNodeScores(
       graph,
       new Map([['guide.md', 0.82]]),
@@ -1799,6 +1927,11 @@ describe('lat ui', () => {
     );
     expect(styles).toContain('.external-link-icon');
     expect(styles).toContain('.external-source-link-unavailable');
+    expect(styles).toMatch(
+      /\.markdown ul > li::marker \{\s*color: var\(--gray-500\);\s*\}/,
+    );
+    expect(styles).toMatch(/\.markdown ul \{\s*padding-left: 1\.75em;/);
+    expect(styles).toMatch(/\.markdown ul > li \+ li \{\s*margin-top: 0\.5em;/);
     expect(styles).toContain('-webkit-mask:');
     expect(styles.match(/\.markdown a\s*\{([^}]*)\}/)?.[1]).toContain(
       'text-decoration-line: underline;',
@@ -1808,6 +1941,11 @@ describe('lat ui', () => {
     );
     expect(styles).toContain("input[type='checkbox']");
     expect(styles).toContain('.markdown details:not(.maplibregl-ctrl-attrib)');
+    const disclosureTitleStyles = styles.match(
+      /\.markdown details:not\(\.maplibregl-ctrl-attrib\) > summary \{([^}]*)\}/,
+    )?.[1];
+    expect(disclosureTitleStyles).toContain('-webkit-user-select: none;');
+    expect(disclosureTitleStyles).toContain('user-select: none;');
     expect(styles).toContain('.markdown .markdown-alert-caution');
     expect(styles).toContain('[data-footnotes]');
     expect(styles).toContain('img.markdown-emoji');
@@ -1838,6 +1976,20 @@ describe('lat ui', () => {
 
   // @lat: [[lat.md/view/specs#View Tests#Shows a local table of contents]]
   it('builds nested document navigation and tracks the active heading', async () => {
+    const styles = readFileSync(
+      join(import.meta.dirname, '..', 'view', 'src', 'styles.css'),
+      'utf8',
+    );
+    expect(styles).toMatch(
+      /\.document-toc-link \{[^}]*box-shadow: inset 1px 0 var\(--panel-border\);/,
+    );
+    expect(styles).toMatch(/\.document-toc-link::before \{[^}]*left: 0;/);
+    expect(styles).toMatch(
+      /\.document-toc-link:first-child::before \{\s*top: 0;[^}]*border-top-left-radius: 0;[^}]*border-top-right-radius: 0;/,
+    );
+    expect(styles).toMatch(
+      /\.document-toc-link:last-child::before \{\s*bottom: 0;[^}]*border-bottom-left-radius: 0;[^}]*border-bottom-right-radius: 0;/,
+    );
     const content =
       '# Guide\n\nOverview.\n\n## Features\n\nDetails.\n\n### `strict`\n\nMore details.';
     const analysis = analyzeMarkdownFile('guide.md', content, '.', '.');
@@ -1985,6 +2137,25 @@ describe('lat ui', () => {
     expect(app).toContain('aria-controls="mobile-file-navigation"');
     expect(app).toContain("body.classList.add('mobile-navigation-open')");
     expect(styles).toContain('@media (width < 64rem)');
+    expect(styles).toMatch(
+      /@media \(width < 64rem\)[\s\S]*?\.app-shell \{\s*--mobile-gutter: 18px;/,
+    );
+    expect(styles).toMatch(
+      /\.mobile-navigation-trigger \{[^}]*padding: 0 var\(--mobile-gutter\);/,
+    );
+    expect(styles).toMatch(
+      /\.main \{\s*padding: 28px var\(--mobile-gutter\) 80px;/,
+    );
+    expect(styles.match(/--mobile-gutter:/g)).toHaveLength(1);
+    expect(styles).toMatch(
+      /@media \(max-width: 1340px\) \{\s*\.document-layout:not\(:has\(> \.document-toc\)\) > \.document-column,/,
+    );
+    expect(styles).toMatch(
+      /\.document-layout:not\(:has\(> \.document-toc\)\) > \.document-column,\s*\.document-layout:not\(:has\(> \.document-toc\)\) \.document-header \{\s*grid-column: 1 \/ -1;/,
+    );
+    expect(styles).toMatch(
+      /\.document-layout:not\(:has\(> \.document-toc\)\) \.document-header \{\s*max-width: none;/,
+    );
     expect(styles).toContain(
       ".sidebar[data-mobile-navigation-open='true'] nav",
     );
@@ -2001,7 +2172,19 @@ describe('lat ui', () => {
       /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?grid-template-areas:[\s\S]*?'metadata toc'[\s\S]*?'document document'/,
     );
     expect(styles).toMatch(
-      /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?\.sidebar-header \{[\s\S]*?min-height: 42px;[\s\S]*?\.document-toc-toggle \{[\s\S]*?min-height: 42px;/,
+      /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?--header-row-height: 42px;/,
+    );
+    expect(styles).toMatch(
+      /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?\.document-layout \{[^}]*max-width: 760px;/,
+    );
+    expect(styles).toMatch(
+      /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?\.document-toc \{[^}]*align-self: center;/,
+    );
+    expect(styles).toMatch(
+      /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?\.app-shell \.document-toc-toggle \{\s*min-height: 34px;/,
+    );
+    expect(styles).toMatch(
+      /@media \(min-width: 64rem\) \{[\s\S]*?--header-row-height: 34px;[\s\S]*?\.app-shell \.sidebar-header,\s*\.app-shell \.document-header-line,\s*\.app-shell \.document-metadata,\s*\.app-shell \.document-toc-title \{\s*min-height: var\(--header-row-height\);/,
     );
     expect(styles).toMatch(
       /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?\.document-toc-list \{[\s\S]*?position: absolute;[\s\S]*?top: 100%;/,
@@ -2010,7 +2193,13 @@ describe('lat ui', () => {
       /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?\.document-toc \{[^}]*position: relative;[^}]*top: 0;/,
     );
     expect(styles).toMatch(
-      /@media \(min-width: 64rem\) and \(max-width: 1340px\)[\s\S]*?\.document-toc-states \{[^}]*padding-right: 14px;/,
+      /@media \(max-width: 1340px\)[\s\S]*?\.document-toc-list \{[^}]*padding: 8px 14px 8px 0;/,
+    );
+    expect(styles).toMatch(
+      /@media \(max-width: 1340px\)[\s\S]*?\.document-toc-link \{\s*box-shadow: none;/,
+    );
+    expect(styles).toMatch(
+      /@media \(max-width: 1340px\)[\s\S]*?\.document-toc-link::before \{\s*display: none;/,
     );
     expect(styles).toMatch(
       /@media \(width < 64rem\)[\s\S]*?\.document-toc-toggle \{[\s\S]*?border-top: 0;/,
@@ -2018,6 +2207,14 @@ describe('lat ui', () => {
     expect(styles).toMatch(
       /\.source-code \{[^}]*-webkit-text-size-adjust: 100%;[^}]*text-size-adjust: 100%;/,
     );
+    expect(styles).toMatch(
+      /\.markdown \.markdown-map-error \{[^}]*flex-wrap: wrap;/,
+    );
+    expect(styles).toMatch(
+      /\.markdown \.markdown-map-error > span \{[^}]*min-width: 0;[^}]*overflow-wrap: anywhere;/,
+    );
+    expect(styles).toMatch(/\.markdown \{[^}]*overflow-wrap: anywhere;/);
+    expect(styles).toMatch(/\.markdown pre code \{[^}]*overflow-wrap: normal;/);
   });
 
   // @lat: [[lat.md/view/specs#View Tests#Exposes code-mention frontmatter as metadata]]
@@ -2255,12 +2452,12 @@ describe('lat ui', () => {
     expect(rendered).not.toContain('<span>Refs</span>');
     expect(rendered).toContain('section-back-reference-count">5</span>');
     expect(rendered).toContain('id="section-back-references-1"');
-    expect(rendered).toContain('Copy link to the section');
-    expect(rendered).toContain('Copy section ID');
+    expect(rendered).toContain('Copy Link to the Section');
+    expect(rendered).toContain('Copy Section ID');
     expect(rendered).toContain('href="/guide.md"');
-    expect(rendered.match(/View Markdown file/g)).toHaveLength(1);
+    expect(rendered.match(/View Markdown File/g)).toHaveLength(1);
     const rawHref = rendered.match(
-      /<a class="section-back-reference-action" href="([^"]+)">View Markdown file<\/a>/,
+      /<a class="section-back-reference-action" href="([^"]+)">View Markdown File<\/a>/,
     )?.[1];
     expect(rawHref).toBe('/guide.md');
     const raw = await fetch(new URL(rawHref!, view.url));
@@ -2268,7 +2465,7 @@ describe('lat ui', () => {
     expect(await raw.text()).toBe(
       readFileSync(join(latDir, document.path), 'utf8'),
     );
-    expect(rendered).toContain('Show <code>lat section</code> output');
+    expect(rendered).toContain('Show <code>lat section</code> Output');
     expect(rendered).toContain('section-back-reference-breadcrumb');
     expect(rendered).toContain('section-back-reference-breadcrumb-label');
     expect(rendered).toContain('href="/code/src/app.ts?at=5"');
@@ -2300,7 +2497,13 @@ describe('lat ui', () => {
       /\.section-back-reference-action \{[\s\S]*?color: var\(--muted\);/,
     );
     expect(styles).toMatch(
-      /\.section-back-reference-action:hover \{\s*color: color-mix\(in srgb, var\(--muted\) 82%, white\);\s*\}/,
+      /\.section-back-reference-action:hover \{\s*color: var\(--text\);\s*\}/,
+    );
+    expect(styles).toMatch(
+      /\.section-back-reference-item \{\s*padding: 10px 13px;/,
+    );
+    expect(styles).toMatch(
+      /\.section-back-reference-item \.section-back-reference-paragraph p \{\s*margin: 5px 0 0;/,
     );
 
     const emptyResponse = await fetch(
@@ -2324,10 +2527,10 @@ describe('lat ui', () => {
     expect(emptyRendered).toContain('aria-label="Section menu"');
     expect(emptyRendered).toContain('No references to this section');
     expect(emptyRendered).not.toContain('section-back-reference-count');
-    expect(emptyRendered).toContain('Copy link to the section');
-    expect(emptyRendered).toContain('Copy section ID');
-    expect(emptyRendered).not.toContain('View Markdown file');
-    expect(emptyRendered).toContain('Show <code>lat section</code> output');
+    expect(emptyRendered).toContain('Copy Link to the Section');
+    expect(emptyRendered).toContain('Copy Section ID');
+    expect(emptyRendered).not.toContain('View Markdown File');
+    expect(emptyRendered).toContain('Show <code>lat section</code> Output');
 
     const staticRendered = renderToStaticMarkup(
       createElement(MarkdownContent, {
@@ -2336,8 +2539,8 @@ describe('lat ui', () => {
         tree: emptyDocument.tree,
       }),
     );
-    expect(staticRendered).toContain('Copy section ID');
-    expect(staticRendered).not.toContain('lat section</code> output');
+    expect(staticRendered).toContain('Copy Section ID');
+    expect(staticRendered).not.toContain('lat section</code> Output');
 
     const navigate = vi.fn();
     const clipboard = { writeText: vi.fn(async () => {}) };

--- a/view/src/CodeBlock.tsx
+++ b/view/src/CodeBlock.tsx
@@ -32,7 +32,7 @@ export function CodeBlock({
     ? currentResult.copied
       ? 'Copied!'
       : 'Copy failed. Try again.'
-    : 'Copy code';
+    : 'Copy Code';
   return (
     <div className="code-block">
       {children}
@@ -60,7 +60,7 @@ export function CodeBlock({
           {currentResult
             ? currentResult.copied
               ? 'Copied!'
-              : 'Retry copy'
+              : 'Retry Copy'
             : 'Copy'}
         </span>
       </button>

--- a/view/src/DocumentModeSwitch.tsx
+++ b/view/src/DocumentModeSwitch.tsx
@@ -26,7 +26,7 @@ export function DocumentModeSwitch({
               <path d="m8.5 3.3 1.4 1.4" />
             </svg>
           )}
-          <span>{value}</span>
+          <span>{value === 'view' ? 'View' : 'Edit'}</span>
         </button>
       ))}
     </div>

--- a/view/src/DocumentToc.tsx
+++ b/view/src/DocumentToc.tsx
@@ -121,7 +121,7 @@ export function DocumentToc({
     <aside className="document-toc" data-expanded={expanded || undefined}>
       <div className="document-toc-title document-toc-heading">
         <TocIcon />
-        <span>On this page</span>
+        <span>On This Page</span>
       </div>
       <button
         aria-controls="document-table-of-contents"
@@ -131,13 +131,13 @@ export function DocumentToc({
         type="button"
       >
         <TocIcon />
-        <span>On this page</span>
+        <span>On This Page</span>
         <span aria-hidden="true" className="document-toc-chevron">
           ›
         </span>
       </button>
       <nav
-        aria-label="On this page"
+        aria-label="On This Page"
         className="document-toc-list"
         id="document-table-of-contents"
         ref={navigationRef}

--- a/view/src/FileTree.tsx
+++ b/view/src/FileTree.tsx
@@ -213,7 +213,7 @@ export function FileTree({
             <circle cx="12" cy="12" r="8.5" />
             <path d="M3.5 12h17M12 3.5c2.2 2.3 3.4 5.1 3.4 8.5s-1.2 6.2-3.4 8.5M12 3.5C9.8 5.8 8.6 8.6 8.6 12s1.2 6.2 3.4 8.5" />
           </svg>
-          <span>External sources</span>
+          <span>External Sources</span>
         </div>
       )}
       {externalTree.map((node) => (

--- a/view/src/GraphView.tsx
+++ b/view/src/GraphView.tsx
@@ -10,6 +10,10 @@ import {
 } from 'react';
 import Sigma from 'sigma';
 import {
+  GraphNodeProgram,
+  GraphSelectedNodeProgram,
+} from './graph-node-program';
+import {
   createEdgeArrowProgram,
   type NodeLabelDrawingFunction,
 } from 'sigma/rendering';
@@ -81,10 +85,6 @@ function colorValue(
   fallback: string,
 ): string {
   return styles.getPropertyValue(name).trim() || fallback;
-}
-
-function withAlpha(color: string, alpha: string): string {
-  return /^#[\da-f]{6}$/i.test(color) ? `${color}${alpha}` : color;
 }
 
 const drawGraphNodeLabel: NodeLabelDrawingFunction<
@@ -197,9 +197,14 @@ function GraphCanvas({
       document: colorValue(styles, '--graph-document', '#ededed'),
       code: colorValue(styles, '--graph-code', '#737373'),
     };
-    const text = colorValue(styles, '--text', '#ededed');
-    const muted = colorValue(styles, '--muted', '#888888');
-    const edgeColor = colorValue(styles, '--panel-border', '#262626');
+    const mutedNodeColor = colorValue(styles, '--graph-node-muted', '#404040');
+    const activeEdgeColor = colorValue(
+      styles,
+      '--graph-edge-active',
+      '#686868',
+    );
+    const edgeColor = colorValue(styles, '--graph-edge', '#505050');
+    const mutedEdgeColor = colorValue(styles, '--graph-edge-muted', '#383838');
     const graph = new MultiDirectedGraph<
       GraphNodeAttributes,
       GraphEdgeAttributes
@@ -246,6 +251,13 @@ function GraphCanvas({
       {
         defaultEdgeColor: edgeColor,
         defaultEdgeType: 'arrow',
+        nodeProgramClasses: {
+          circle: GraphNodeProgram<GraphNodeAttributes, GraphEdgeAttributes>,
+          selected: GraphSelectedNodeProgram<
+            GraphNodeAttributes,
+            GraphEdgeAttributes
+          >,
+        },
         defaultDrawNodeHover: drawGraphNodeLabel,
         defaultDrawNodeLabel: drawGraphNodeLabel,
         edgeProgramClasses: {
@@ -257,8 +269,7 @@ function GraphCanvas({
         hideEdgesOnMove: true,
         labelColor: { color: '#fff' },
         labelDensity: 0.12,
-        labelFont:
-          'Geist, "Geist Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
+        labelFont: getComputedStyle(document.documentElement).fontFamily,
         labelRenderedSizeThreshold: 6,
         labelSize: 11,
         labelWeight: '600',
@@ -273,21 +284,23 @@ function GraphCanvas({
           const renderedData =
             searchSize === undefined ? data : { ...data, size: searchSize };
           const focus = hoveredNode || selected.current;
-          if (focus && node !== focus && !graph.areNeighbors(node, focus)) {
+          const isSelected = node === selected.current;
+          if (isSelected || node === focus) {
             return {
               ...renderedData,
-              color: withAlpha(muted, '48'),
-              label: null,
-              zIndex: 0,
-            };
-          }
-          if (node === focus) {
-            return {
-              ...renderedData,
+              type: isSelected ? 'selected' : 'circle',
               forceLabel: true,
               highlighted: true,
               size: renderedData.size + 2.5,
-              zIndex: 3,
+              zIndex: isSelected ? 4 : 3,
+            };
+          }
+          if (focus && node !== focus && !graph.areNeighbors(node, focus)) {
+            return {
+              ...renderedData,
+              color: mutedNodeColor,
+              label: null,
+              zIndex: 0,
             };
           }
           return {
@@ -305,14 +318,14 @@ function GraphCanvas({
           if (focus && from !== focus && to !== focus) {
             return {
               ...data,
-              color: withAlpha(edgeColor, '24'),
-              size: 0.35,
+              color: mutedEdgeColor,
+              size: 0.6,
             };
           }
           return focus
             ? {
                 ...data,
-                color: withAlpha(text, '70'),
+                color: activeEdgeColor,
                 size: data.size + 0.4,
               }
             : data;
@@ -331,29 +344,6 @@ function GraphCanvas({
       sigma.refresh();
     });
     sigma.on('clickNode', ({ node }) => onSelectRef.current(node));
-
-    let draggedNode = '';
-    let dragged = false;
-
-    sigma.on('downNode', ({ node, preventSigmaDefault }) => {
-      draggedNode = node;
-      dragged = false;
-      preventSigmaDefault();
-    });
-    const mouse = sigma.getMouseCaptor();
-    mouse.on('mousemovebody', (event) => {
-      if (!draggedNode) return;
-      dragged = true;
-      event.preventSigmaDefault();
-      const position = sigma.viewportToGraph(event);
-      graph.mergeNodeAttributes(draggedNode, position);
-    });
-    mouse.on('mouseup', () => {
-      if (!draggedNode) return;
-      positionCache.set(draggedNode, graph.getNodeAttributes(draggedNode));
-      draggedNode = '';
-      if (dragged) sigma.refresh();
-    });
 
     return () => {
       savePositions();

--- a/view/src/MarkdownContent.tsx
+++ b/view/src/MarkdownContent.tsx
@@ -241,7 +241,7 @@ function SectionMenu({
       >
         {count > 0 ? (
           <>
-            <div className="section-back-reference-header">Referenced from</div>
+            <div className="section-back-reference-header">Referenced From</div>
             <div className="section-back-reference-list">
               {section.references.map((reference, referenceIndex) =>
                 reference.kind === 'markdown' ? (
@@ -269,11 +269,11 @@ function SectionMenu({
             onClick={stop(() => onCopySectionLink?.(section.headingId))}
             type="button"
           >
-            Copy link to the section
+            Copy Link to the Section
           </button>
           {index === 0 && viewMarkdownUrl && (
             <a className="section-back-reference-action" href={viewMarkdownUrl}>
-              View Markdown file
+              View Markdown File
             </a>
           )}
           <button
@@ -283,7 +283,7 @@ function SectionMenu({
             )}
             type="button"
           >
-            Copy section ID
+            Copy Section ID
           </button>
           {sectionOutputEnabled && (
             <button
@@ -291,7 +291,7 @@ function SectionMenu({
               onClick={stop(() => onShowSectionOutput?.(section.sectionId))}
               type="button"
             >
-              Show <code>lat section</code> output
+              Show <code>lat section</code> Output
             </button>
           )}
         </div>

--- a/view/src/MarkdownEditor.tsx
+++ b/view/src/MarkdownEditor.tsx
@@ -28,16 +28,23 @@ type EditorStatus = {
 };
 
 const markdownHighlightStyle = HighlightStyle.define([
-  { tag: tags.heading, color: 'var(--syntax-title)', fontWeight: '700' },
-  { tag: [tags.link, tags.url], color: 'var(--link)' },
+  { tag: tags.heading, color: 'var(--syntax-markup)', fontWeight: '700' },
+  { tag: [tags.link, tags.url], color: 'var(--syntax-string)' },
   { tag: tags.emphasis, fontStyle: 'italic' },
   { tag: tags.strong, fontWeight: '700' },
   {
-    tag: [tags.keyword, tags.atom, tags.bool],
+    tag: tags.keyword,
     color: 'var(--syntax-keyword)',
   },
   { tag: [tags.string, tags.inserted], color: 'var(--syntax-string)' },
-  { tag: tags.number, color: 'var(--syntax-number)' },
+  { tag: [tags.number, tags.atom, tags.bool], color: 'var(--syntax-number)' },
+  { tag: tags.function(tags.variableName), color: 'var(--syntax-title)' },
+  { tag: tags.typeName, color: 'var(--syntax-title)' },
+  {
+    tag: [tags.variableName, tags.propertyName, tags.attributeName],
+    color: 'var(--text)',
+  },
+  { tag: tags.punctuation, color: 'var(--text)' },
   { tag: [tags.comment, tags.quote], color: 'var(--syntax-comment)' },
   { tag: [tags.monospace, tags.processingInstruction], color: 'var(--muted)' },
   { tag: tags.invalid, color: 'var(--danger)' },

--- a/view/src/SectionOutputDialog.tsx
+++ b/view/src/SectionOutputDialog.tsx
@@ -68,7 +68,7 @@ export function SectionOutputDialog({
           <div className="section-output-heading">
             <div className="section-output-title-line">
               <h2 id="section-output-title">
-                <code>lat section</code> output
+                <code>lat section</code> Output
               </h2>
               <div
                 aria-label="Section output presentation"
@@ -82,7 +82,7 @@ export function SectionOutputDialog({
                     onClick={() => setPresentation(value)}
                     type="button"
                   >
-                    {value}
+                    {value === 'raw' ? 'Raw' : 'Formatted'}
                   </button>
                 ))}
               </div>

--- a/view/src/graph-layout.ts
+++ b/view/src/graph-layout.ts
@@ -25,7 +25,7 @@ export function graphDisplayLabel(
 
 export function graphNodeSize(backlinks: number): number {
   const count = Number.isFinite(backlinks) ? Math.max(0, backlinks) : 0;
-  return 5 + Math.log2(count + 1) * 1.8;
+  return 5 + Math.log2(count + 1) * 3;
 }
 
 function polarPosition(angle: number, radius: number): GraphPosition {
@@ -94,7 +94,7 @@ export function staticGraphPositions(
     let ring = 0;
     while (offset < nodeIds.length) {
       const count = Math.min(12 + ring * 4, nodeIds.length - offset);
-      const radius = 4 + ring * 3.5;
+      const radius = 6.4 + ring * 5.6;
       for (let index = 0; index < count; index++) {
         const angle = baseAngle + ring * 0.31 + (index / count) * Math.PI * 2;
         const relative = polarPosition(angle, radius);

--- a/view/src/graph-node-program.ts
+++ b/view/src/graph-node-program.ts
@@ -1,0 +1,54 @@
+import { NodeCircleProgram } from 'sigma/rendering';
+
+/** Keep overlapping circles distinct without changing Sigma's geometry or picking. */
+export class GraphNodeProgram<
+  N extends Record<string, unknown>,
+  E extends Record<string, unknown>,
+> extends NodeCircleProgram<N, E> {
+  protected fillOpacity(): number {
+    return 0.8;
+  }
+
+  getDefinition() {
+    return {
+      ...super.getDefinition(),
+      FRAGMENT_SHADER_SOURCE: `
+precision highp float;
+
+varying vec4 v_color;
+varying vec2 v_diffVector;
+varying float v_radius;
+uniform float u_correctionRatio;
+
+void main(void) {
+  float inset = v_radius - length(v_diffVector);
+  if (inset < 0.0) discard;
+
+  #ifdef PICKING_MODE
+  // Picking IDs must remain opaque and unmodified, including at the border.
+  gl_FragColor = v_color;
+  #else
+  // Sigma's circle geometry uses two correction units per CSS pixel.
+  float pixels = inset / (2.0 * u_correctionRatio);
+  float coverage = smoothstep(0.0, 0.5, pixels);
+  float fill = smoothstep(1.0, 1.5, pixels);
+  vec3 color = mix(v_color.rgb * 0.45, v_color.rgb, fill);
+  float alpha = mix(0.95, ${this.fillOpacity()}, fill) * v_color.a * coverage;
+  // Sigma blends with ONE / ONE_MINUS_SRC_ALPHA: premultiply RGB as well.
+  gl_FragColor = vec4(color * alpha, alpha);
+  #endif
+}
+`,
+    };
+  }
+}
+
+/** Stronger fill preserves the selected node's hue in either theme. */
+export class GraphSelectedNodeProgram<
+  N extends Record<string, unknown>,
+  E extends Record<string, unknown>,
+> extends GraphNodeProgram<N, E> {
+  protected fillOpacity(): number {
+    return 0.96;
+  }
+}

--- a/view/src/main.tsx
+++ b/view/src/main.tsx
@@ -1,5 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import '@fontsource-variable/geist';
+import '@fontsource-variable/geist-mono';
 import 'katex/dist/katex.min.css';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { App } from './App';

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -1,27 +1,37 @@
 :root {
-  color: #171717;
-  background: #fff;
-  font-family:
-    Geist,
-    'Geist Sans',
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    sans-serif;
+  --font-sans:
+    'Geist Variable', ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono:
+    'Geist Mono Variable', ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, monospace;
+  font-family: var(--font-sans);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   color-scheme: light dark;
-  --background: #fff;
-  --panel: #fafafa;
-  --sidebar: #fafafa;
-  --sidebar-selection: #eaeaea;
-  --panel-border: #eaeaea;
-  --text: #171717;
-  --muted: #666;
-  --accent: #171717;
-  --accent-soft: #ededed;
+  /* Geist neutral scale: surfaces, interaction states, borders, then text. */
+  --background-100: #fff;
+  --background-200: #fafafa;
+  --gray-100: #f2f2f2;
+  --gray-200: #ebebeb;
+  --gray-300: #e6e6e6;
+  --gray-400: #ebebeb;
+  --gray-500: #c9c9c9;
+  --gray-600: #a8a8a8;
+  --gray-700: #8f8f8f;
+  --gray-800: #7d7d7d;
+  --gray-900: #666;
+  --gray-1000: #171717;
+  --gray-alpha-400: rgb(0 0 0 / 8%);
+  --background: var(--background-100);
+  --panel: var(--background-100);
+  --sidebar: var(--background-200);
+  --sidebar-selection: var(--gray-200);
+  --panel-border: var(--gray-alpha-400);
+  --text: var(--gray-1000);
+  --muted: var(--gray-900);
+  --accent: var(--gray-1000);
+  --accent-soft: var(--gray-100);
   --link: #0070f3;
   --danger: #e5484d;
   --danger-soft: #ffebe9;
@@ -31,11 +41,11 @@
   --success: #2e7d46;
   --success-soft: #e9f9ee;
   --git-notification: #e47f19;
-  --code: #f5f5f5;
-  --context-surface: #f7f7f7;
-  --inline-code: #ededed;
-  --reference-control: #e5e5e5;
-  --reference-control-hover: #ededed;
+  --code: var(--background-200);
+  --context-surface: var(--background-200);
+  --inline-code: var(--gray-100);
+  --reference-control: var(--gray-100);
+  --reference-control-hover: var(--gray-200);
   --section-menu-control: color-mix(
     in srgb,
     var(--reference-control) 70%,
@@ -48,28 +58,38 @@
   );
   --graph-document: #0070f3;
   --graph-code: #d97706;
+  /* Sigma needs renderer-safe colors, independent of translucent CSS borders. */
+  --graph-edge: #b8b8b8;
+  --graph-edge-muted: #d4d4d4;
+  --graph-edge-active: #999999;
+  --graph-node-muted: #c4c4c4;
   --map-control-filter: none;
-  --syntax-built-in: #9a3f75;
-  --syntax-comment: #737373;
-  --syntax-keyword: #6c4bc2;
-  --syntax-number: #a85414;
-  --syntax-string: #397348;
-  --syntax-title: #26649a;
+  --brand-filter: brightness(0);
+  /* Geistdocs Shiki roles, shared by Lowlight and the Markdown editor. */
+  --syntax-comment: oklch(0.42 0 0);
+  --syntax-keyword: oklch(53.5% 0.2058 2.84);
+  --syntax-number: oklch(53.18% 0.2399 256.99);
+  --syntax-string: oklch(51.75% 0.1453 147.65);
+  --syntax-title: oklch(47.18% 0.2579 304);
+  --syntax-markup: oklch(52.79% 0.1496 54.65);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    color: #ededed;
-    background: #000;
-    --background: #000;
-    --panel: #0a0a0a;
-    --sidebar: #000;
-    --sidebar-selection: #242424;
-    --panel-border: #262626;
-    --text: #ededed;
-    --muted: #888;
-    --accent: #fff;
-    --accent-soft: #1f1f1f;
+    --background-100: #000;
+    --background-200: #0a0a0a;
+    --sidebar: var(--background-100);
+    --gray-100: #1a1a1a;
+    --gray-200: #1f1f1f;
+    --gray-300: #292929;
+    --gray-400: #2e2e2e;
+    --gray-500: #454545;
+    --gray-600: #878787;
+    --gray-700: #8f8f8f;
+    --gray-800: #7d7d7d;
+    --gray-900: #a1a1a1;
+    --gray-1000: #ededed;
+    --gray-alpha-400: rgb(255 255 255 / 14%);
     --link: rgb(82, 168, 255);
     --danger: #ff6166;
     --danger-soft: #2a1314;
@@ -79,20 +99,20 @@
     --success: #62c073;
     --success-soft: #12261a;
     --git-notification: #f0a044;
-    --code: #111;
-    --context-surface: #111;
-    --inline-code: #1f1f1f;
-    --reference-control: #262626;
-    --reference-control-hover: #303030;
     --graph-document: rgb(82, 168, 255);
     --graph-code: #f5a623;
+    --graph-edge: #505050;
+    --graph-edge-muted: #383838;
+    --graph-edge-active: #686868;
+    --graph-node-muted: #404040;
     --map-control-filter: invert(1);
-    --syntax-built-in: #e6a2cc;
-    --syntax-comment: #888;
-    --syntax-keyword: #c2adff;
-    --syntax-number: #efb271;
-    --syntax-string: #9fd0a5;
-    --syntax-title: #8fc6ef;
+    --brand-filter: none;
+    --syntax-comment: oklch(0.706 0 0);
+    --syntax-keyword: oklch(69.36% 0.2223 3.91);
+    --syntax-number: oklch(71.7% 0.1648 250.79);
+    --syntax-string: oklch(73.1% 0.2158 148.29);
+    --syntax-title: oklch(69.87% 0.2037 309.51);
+    --syntax-markup: oklch(77.21% 0.1991 64.28);
   }
 }
 
@@ -116,6 +136,25 @@ body {
 
 a {
   color: var(--link);
+}
+
+:where(a, button, input, summary, [tabindex]):focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 3px;
+}
+
+.document-mode-switch button:focus-visible,
+.section-output-presentation button:focus-visible {
+  outline-offset: -3px;
+}
+
+.markdown table,
+.document-flag,
+.section-back-reference-count,
+.wiki-link-ref-count,
+.source-line-number,
+.graph-node-count {
+  font-variant-numeric: tabular-nums;
 }
 
 .app-shell {
@@ -177,7 +216,7 @@ a {
   align-items: center;
   overflow: hidden;
   color: var(--text);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 21px;
   font-weight: 750;
   letter-spacing: -0.04em;
@@ -191,6 +230,7 @@ a {
   width: auto;
   height: 21px;
   flex: none;
+  filter: var(--brand-filter);
 }
 
 .brand span {
@@ -302,8 +342,9 @@ a {
   align-items: center;
   gap: 7px;
   color: var(--muted);
-  font-size: 12px;
-  font-weight: 650;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
   cursor: pointer;
   list-style: none;
   border-radius: 7px;
@@ -366,8 +407,8 @@ a {
   gap: 8px;
   overflow: hidden;
   color: var(--muted);
-  font-size: 13px;
-  line-height: 1.35;
+  font-size: 14px;
+  line-height: 20px;
   text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -477,10 +518,12 @@ a {
   gap: 4px;
   color: var(--muted);
   font: inherit;
-  font-size: 11px;
-  line-height: 1.2;
+  min-height: 32px;
+  font-size: 13px;
+  line-height: 20px;
   cursor: pointer;
-  background: transparent;
+  background-color: transparent;
+  background-clip: padding-box;
   border: 0;
 }
 
@@ -495,18 +538,14 @@ a {
   stroke-width: 1.15;
 }
 
-.document-mode-switch button + button {
-  border-left: 1px solid var(--panel-border);
-}
-
 .document-mode-switch button:hover {
   color: var(--text);
-  background: var(--reference-control-hover);
+  background-color: var(--reference-control-hover);
 }
 
 .document-mode-switch button[aria-pressed='true'] {
   color: var(--text);
-  background: var(--reference-control);
+  background-color: var(--reference-control);
 }
 
 .document-layout {
@@ -539,10 +578,10 @@ a {
   padding: 0;
   align-items: center;
   gap: 9px;
-  color: var(--muted);
+  color: var(--text);
   font-family: inherit;
-  font-size: 13px;
-  font-weight: 650;
+  font-size: 14px;
+  font-weight: 500;
   text-align: left;
   background: transparent;
   border: 0;
@@ -568,7 +607,6 @@ a {
   margin-top: 14px;
   overflow-y: auto;
   overscroll-behavior: contain;
-  border-left: 1px solid var(--panel-border);
   scrollbar-width: none;
 }
 
@@ -579,16 +617,17 @@ a {
 .document-toc-link {
   position: relative;
   display: flex;
-  padding: 7px 0 7px calc(14px + var(--toc-depth) * 13px);
+  padding: 7px 0 7px calc(15px + var(--toc-depth) * 13px);
   align-items: center;
   gap: 7px;
   color: var(--muted);
-  font-size: 12.5px;
-  font-weight: 520;
-  line-height: 17px;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
   text-decoration: none;
   transition: color 140ms ease;
   overflow-wrap: anywhere;
+  box-shadow: inset 1px 0 var(--panel-border);
 }
 
 .document-toc-link-label {
@@ -625,11 +664,23 @@ a {
   position: absolute;
   top: 4px;
   bottom: 4px;
-  left: -1px;
+  left: 0;
   width: 2px;
   content: '';
   background: transparent;
   border-radius: 2px;
+}
+
+.document-toc-link:first-child::before {
+  top: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.document-toc-link:last-child::before {
+  bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .document-toc-link:hover {
@@ -660,14 +711,14 @@ a {
   min-width: 0;
   overflow-wrap: anywhere;
   color: var(--muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
 }
 
 .document-flag {
   padding: 3px 8px;
   color: var(--accent);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.025em;
@@ -681,7 +732,7 @@ a {
   padding: 3px 8px;
   align-items: center;
   color: var(--danger);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.025em;
@@ -699,15 +750,7 @@ a {
 .document-error-panel {
   margin-top: 12px;
   overflow: hidden;
-  font-family:
-    Geist,
-    'Geist Sans',
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    sans-serif;
+  font-family: var(--font-sans);
   background: color-mix(in srgb, var(--danger-soft) 55%, var(--background));
   border: 1px solid var(--danger-border);
   border-radius: 8px;
@@ -716,7 +759,7 @@ a {
 .document-error-header {
   padding: 9px 13px 7px;
   color: var(--danger);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 750;
   letter-spacing: 0.08em;
@@ -741,7 +784,7 @@ a {
 
 .document-error-location {
   color: var(--danger);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 700;
 }
@@ -769,7 +812,7 @@ a {
   min-height: 30px;
   padding: 8px 12px 7px;
   color: var(--muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   line-height: 14px;
   border-bottom: 1px solid var(--panel-border);
@@ -819,7 +862,7 @@ a {
 }
 
 .markdown-editor .cm-scroller {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: var(--editor-font-size);
   line-height: 1.6;
   overflow: auto;
@@ -947,15 +990,7 @@ a {
   max-width: 760px;
   margin: 12px 16px 12px 4.25rem;
   overflow: visible;
-  font-family:
-    Geist,
-    'Geist Sans',
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    sans-serif;
+  font-family: var(--font-sans);
   background: var(--context-surface);
   border: 1px solid var(--panel-border);
   border-radius: 8px;
@@ -972,7 +1007,7 @@ a {
   align-items: center;
   gap: 12px;
   color: var(--muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -1008,7 +1043,7 @@ a {
   align-items: center;
   gap: 6px;
   color: var(--accent);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 650;
   line-height: 1.3;
@@ -1049,7 +1084,7 @@ a {
   gap: 5px;
   overflow: hidden;
   color: var(--link);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 650;
   white-space: nowrap;
@@ -1107,7 +1142,7 @@ a {
   max-width: 100%;
   padding: 10px 0;
   overflow-x: auto;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 13px;
   line-height: 1.55;
   -webkit-text-size-adjust: 100%;
@@ -1200,63 +1235,76 @@ a {
 .markdown .hljs-comment,
 .markdown .hljs-quote {
   color: var(--syntax-comment);
-  font-style: italic;
 }
 
 .source-code .hljs-keyword,
-.source-code .hljs-literal,
-.source-code .hljs-selector-tag,
-.source-code .hljs-section,
-.markdown .hljs-keyword,
-.markdown .hljs-literal,
-.markdown .hljs-selector-tag,
-.markdown .hljs-section {
+.markdown .hljs-keyword {
   color: var(--syntax-keyword);
 }
 
 .source-code .hljs-string,
 .source-code .hljs-regexp,
 .source-code .hljs-addition,
-.source-code .hljs-attribute,
+.source-code .hljs-link,
 .markdown .hljs-string,
 .markdown .hljs-regexp,
 .markdown .hljs-addition,
-.markdown .hljs-attribute {
+.markdown .hljs-link {
   color: var(--syntax-string);
 }
 
 .source-code .hljs-number,
 .source-code .hljs-symbol,
-.source-code .hljs-bullet,
+.source-code .hljs-literal,
+.source-code .hljs-variable.language_,
 .markdown .hljs-number,
 .markdown .hljs-symbol,
-.markdown .hljs-bullet {
+.markdown .hljs-literal,
+.markdown .hljs-variable.language_ {
+  color: var(--syntax-number);
+}
+
+/* The JSON grammar classifies true, false, and null as keywords. */
+.markdown .language-json .hljs-keyword {
   color: var(--syntax-number);
 }
 
 .source-code .hljs-title,
-.source-code .hljs-function,
-.source-code .hljs-class,
 .source-code .hljs-type,
+.source-code .hljs-built_in,
+.source-code .hljs-name,
+.source-code .hljs-selector-tag,
 .markdown .hljs-title,
-.markdown .hljs-function,
-.markdown .hljs-class,
-.markdown .hljs-type {
+.markdown .hljs-type,
+.markdown .hljs-built_in,
+.markdown .hljs-name,
+.markdown .hljs-selector-tag {
   color: var(--syntax-title);
 }
 
-.source-code .hljs-built_in,
-.source-code .hljs-variable.language_,
-.source-code .hljs-meta,
-.markdown .hljs-built_in,
-.markdown .hljs-variable.language_,
-.markdown .hljs-meta {
-  color: var(--syntax-built-in);
+.source-code .hljs-bullet,
+.source-code .hljs-section,
+.markdown .hljs-bullet,
+.markdown .hljs-section {
+  color: var(--syntax-markup);
+}
+
+.source-code .hljs-params,
+.source-code .hljs-attr,
+.source-code .hljs-attribute,
+.source-code .hljs-punctuation,
+.source-code .hljs-subst,
+.markdown .hljs-params,
+.markdown .hljs-attr,
+.markdown .hljs-attribute,
+.markdown .hljs-punctuation,
+.markdown .hljs-subst {
+  color: var(--text);
 }
 
 .source-code .hljs-deletion,
 .markdown .hljs-deletion {
-  color: #bd3d3d;
+  color: var(--danger);
 }
 
 .source-code .hljs-emphasis,
@@ -1272,16 +1320,19 @@ a {
 .markdown {
   max-width: 760px;
   font-size: 16px;
-  line-height: 1.72;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 
 .markdown h1,
 .markdown h2,
 .markdown h3,
-.markdown h4 {
-  margin: 2em 0 0.65em;
-  line-height: 1.2;
-  letter-spacing: -0.025em;
+.markdown h4,
+.markdown h5,
+.markdown h6 {
+  margin: 40px 0 16px;
+  font-weight: 450;
+  letter-spacing: -0.02em;
   scroll-margin-top: 24px;
 }
 
@@ -1295,7 +1346,7 @@ a {
   justify-content: center;
   gap: 5px;
   color: var(--accent);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 650;
   line-height: 1.3;
@@ -1337,15 +1388,7 @@ a {
 .section-back-reference-panel {
   margin: -0.15em 0 1.5em;
   overflow: hidden;
-  font-family:
-    Geist,
-    'Geist Sans',
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    sans-serif;
+  font-family: var(--font-sans);
   background: var(--context-surface);
   border: 1px solid var(--panel-border);
   border-radius: 8px;
@@ -1358,11 +1401,8 @@ a {
 .section-back-reference-header {
   padding: 9px 13px 7px;
   color: var(--muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 13px;
+  font-weight: 500;
 }
 
 .section-back-reference-empty {
@@ -1374,18 +1414,18 @@ a {
 
 .section-back-reference-actions {
   display: grid;
-  gap: 7px;
+  gap: 4px;
   padding: 9px 13px;
   border-top: 1px solid var(--panel-border);
 }
 
 .section-back-reference-action {
   width: fit-content;
-  padding: 0;
+  padding: 4px 0;
   color: var(--muted);
   font: inherit;
-  font-size: 12px;
-  font-weight: 550;
+  font-size: 13px;
+  font-weight: 500;
   text-align: left;
   cursor: pointer;
   background: transparent;
@@ -1397,12 +1437,12 @@ a {
 }
 
 .section-back-reference-action:hover {
-  color: color-mix(in srgb, var(--muted) 82%, white);
+  color: var(--text);
 }
 
 .section-back-reference-action code {
   color: inherit;
-  font: inherit;
+  font-family: var(--font-mono);
 }
 
 .section-output-backdrop {
@@ -1465,7 +1505,8 @@ a {
   padding: 3px 8px;
   color: var(--muted);
   font: inherit;
-  font-size: 11px;
+  min-height: 32px;
+  font-size: 13px;
   line-height: 1.2;
   cursor: pointer;
   background: transparent;
@@ -1521,7 +1562,7 @@ a {
   overflow: auto;
   color: var(--text);
   background: var(--background);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.55;
   white-space: pre-wrap;
@@ -1566,7 +1607,7 @@ a {
 }
 
 .section-back-reference-item {
-  padding: 10px 13px 11px;
+  padding: 10px 13px;
 }
 
 .section-back-reference-item + .section-back-reference-item {
@@ -1581,7 +1622,7 @@ a {
   max-width: 100%;
   align-items: baseline;
   color: var(--link);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 650;
   line-height: 1.35;
@@ -1624,7 +1665,7 @@ a {
   overflow-wrap: anywhere;
 }
 
-.section-back-reference-paragraph p {
+.section-back-reference-item .section-back-reference-paragraph p {
   margin: 5px 0 0;
   color: var(--muted);
   font-size: 12px;
@@ -1655,15 +1696,36 @@ a {
 
 .markdown h1 {
   margin-top: 0;
-  font-size: clamp(32px, 5vw, 46px);
+  margin-bottom: 24px;
+  font-size: 40px;
+  line-height: 48px;
+  letter-spacing: -0.05em;
 }
 
 .markdown h2 {
-  font-size: 26px;
+  font-size: 24px;
+  line-height: 32px;
+  letter-spacing: -0.04em;
 }
 
 .markdown h3 {
   font-size: 20px;
+  line-height: 26px;
+}
+
+.markdown h4 {
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.markdown h5,
+.markdown h6 {
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.markdown strong {
+  font-weight: 600;
 }
 
 .markdown p,
@@ -1676,6 +1738,18 @@ a {
 
 .markdown li + li {
   margin-top: 0.35em;
+}
+
+.markdown ul {
+  padding-left: 1.75em;
+}
+
+.markdown ul > li + li {
+  margin-top: 0.5em;
+}
+
+.markdown ul > li::marker {
+  color: var(--gray-500);
 }
 
 .markdown .contains-task-list,
@@ -1714,12 +1788,13 @@ a {
 .markdown th,
 .markdown td {
   padding: 8px 12px;
-  border: 1px solid var(--panel-border);
+  border-bottom: 1px solid var(--panel-border);
+  vertical-align: baseline;
 }
 
 .markdown th {
-  font-weight: 650;
-  background: var(--panel);
+  font-weight: 500;
+  vertical-align: bottom;
 }
 
 .markdown th:not([align]) {
@@ -1737,6 +1812,8 @@ a {
 .markdown details:not(.maplibregl-ctrl-attrib) > summary {
   font-weight: 650;
   cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .markdown details:not(.maplibregl-ctrl-attrib)[open] > summary {
@@ -1962,7 +2039,7 @@ a.wiki-link-code:not(.wiki-link-segmented) .code-link-leading {
   align-items: center;
   justify-content: center;
   color: var(--background);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 0.62em;
   font-style: normal;
   font-weight: 800;
@@ -2081,7 +2158,7 @@ a.wiki-link-active {
 
 .markdown code {
   padding: 0.16em 0.36em;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 0.9em;
   background: var(--inline-code);
   border-radius: 5px;
@@ -2096,6 +2173,7 @@ a.wiki-link-active {
 }
 
 .markdown pre code {
+  overflow-wrap: normal;
   padding: 0;
   background: transparent;
 }
@@ -2324,9 +2402,16 @@ a.wiki-link-active {
 
 .markdown .markdown-map-error {
   display: flex;
+  flex-wrap: wrap;
   gap: 12px;
   align-items: center;
   justify-content: space-between;
+}
+
+.markdown .markdown-map-error > span {
+  min-width: 0;
+  flex: 1 1 200px;
+  overflow-wrap: anywhere;
 }
 
 .markdown .markdown-diagram-retry {
@@ -2465,7 +2550,7 @@ a.wiki-link-active {
   gap: 5px;
   overflow: hidden;
   color: var(--link);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 650;
   white-space: nowrap;
@@ -2541,7 +2626,7 @@ a.wiki-link-active {
   z-index: 8;
   inset: 0 auto auto 0;
   width: 50%;
-  height: 84px;
+  height: calc(56px + var(--header-row-height));
   pointer-events: none;
 }
 
@@ -2662,23 +2747,35 @@ a.wiki-link-active {
   pointer-events: none;
 }
 
-.graph-kind-filters label span {
-  padding: 4px 7px;
+.graph-kind-filters label span,
+.graph-fit {
+  display: inline-flex;
+  min-height: 28px;
+  padding: 4px 8px;
+  align-items: center;
   color: var(--muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 9px;
-  font-weight: 700;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  cursor: pointer;
+  background: var(--reference-control);
+  border: 0;
+  border-radius: 6px;
+}
+
+.graph-kind-filters label span {
   text-transform: capitalize;
-  background: color-mix(in srgb, var(--background) 82%, transparent);
-  border: 1px solid var(--panel-border);
-  border-radius: 999px;
-  backdrop-filter: blur(10px);
 }
 
 .graph-kind-filters input:checked + span {
   color: var(--accent);
   background: var(--accent-soft);
-  border-color: color-mix(in srgb, var(--accent) 30%, var(--panel-border));
+}
+
+.graph-kind-filters label:hover span,
+.graph-fit:hover {
+  background: var(--reference-control-hover);
 }
 
 .graph-kind-filters input:focus-visible + span {
@@ -2690,9 +2787,7 @@ a.wiki-link-active {
   flex: 0 0 auto;
   padding-right: 10px;
   color: var(--muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 9px;
-  font-weight: 650;
+  font-size: 12px;
   white-space: nowrap;
 }
 
@@ -2700,22 +2795,11 @@ a.wiki-link-active {
   position: absolute;
   z-index: 4;
   right: 18px;
-  bottom: 18px;
-  padding: 5px 8px;
-  color: var(--muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 9px;
-  font-weight: 700;
-  cursor: pointer;
-  background: color-mix(in srgb, var(--background) 84%, transparent);
-  border: 1px solid var(--panel-border);
-  border-radius: 6px;
-  backdrop-filter: blur(10px);
+  bottom: 20px;
 }
 
 .graph-fit:hover {
   color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 35%, var(--panel-border));
 }
 
 .graph-legend {
@@ -2839,6 +2923,15 @@ a.wiki-link-active {
 }
 
 @media (max-width: 1340px) {
+  .document-layout:not(:has(> .document-toc)) > .document-column,
+  .document-layout:not(:has(> .document-toc)) .document-header {
+    grid-column: 1 / -1;
+  }
+
+  .document-layout:not(:has(> .document-toc)) .document-header {
+    max-width: none;
+  }
+
   .document-layout {
     display: flex;
     flex-direction: column;
@@ -2891,7 +2984,7 @@ a.wiki-link-active {
   .document-toc-list {
     display: none;
     max-height: min(52vh, 420px);
-    padding: 8px 0;
+    padding: 8px 14px 8px 0;
     margin-top: 0;
     background: var(--panel);
     border: 1px solid var(--panel-border);
@@ -2906,20 +2999,48 @@ a.wiki-link-active {
   .document-toc[data-expanded='true'] .document-toc-list {
     display: block;
   }
+
+  .document-toc-link {
+    box-shadow: none;
+  }
+
+  .document-toc-link::before {
+    display: none;
+  }
+}
+
+@media (min-width: 64rem) {
+  .app-shell,
+  .graph-shell {
+    --header-row-height: 34px;
+  }
+
+  .app-shell .sidebar-header,
+  .app-shell .document-header-line,
+  .app-shell .document-metadata,
+  .app-shell .document-toc-title {
+    min-height: var(--header-row-height);
+  }
+
+  .app-shell .document-toc-list {
+    max-height: calc(100% - var(--header-row-height) - 14px);
+  }
 }
 
 @media (min-width: 64rem) and (max-width: 1340px) {
-  .sidebar-header {
-    min-height: 42px;
+  .app-shell,
+  .graph-shell {
+    --header-row-height: 42px;
   }
 
   .document-layout {
     display: grid;
+    max-width: 760px;
     grid-template-columns: minmax(0, 1fr) minmax(240px, 286px);
     grid-template-areas:
       'metadata toc'
       'document document';
-    column-gap: var(--document-toc-gutter);
+    column-gap: calc(var(--document-toc-gutter) * 0.375);
     row-gap: 34px;
     align-items: start;
   }
@@ -2934,13 +3055,9 @@ a.wiki-link-active {
     margin: 0;
   }
 
-  .document-metadata,
-  .document-toc-toggle {
-    min-height: 42px;
-  }
-
   .document-toc {
     grid-area: toc;
+    align-self: center;
     position: relative;
     z-index: 1;
     top: 0;
@@ -2948,15 +3065,16 @@ a.wiki-link-active {
     margin: 0;
   }
 
-  .document-toc-list {
+  .app-shell .document-toc-toggle {
+    min-height: 34px;
+  }
+
+  .app-shell .document-toc-list {
     position: absolute;
+    max-height: min(52vh, 420px);
     top: 100%;
     right: 0;
     left: 0;
-  }
-
-  .document-toc-states {
-    padding-right: 14px;
   }
 
   .markdown {
@@ -2977,6 +3095,8 @@ a.wiki-link-active {
   }
 
   .app-shell {
+    --mobile-gutter: 18px;
+
     display: block;
   }
 
@@ -3021,7 +3141,7 @@ a.wiki-link-active {
     display: flex;
     width: 100%;
     height: 56px;
-    padding: 0 18px;
+    padding: 0 var(--mobile-gutter);
     align-items: center;
     gap: 13px;
     overflow: hidden;
@@ -3070,8 +3190,7 @@ a.wiki-link-active {
     min-width: 0;
     overflow: hidden;
     color: var(--muted);
-    font-family:
-      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-family: var(--font-mono);
     text-overflow: ellipsis;
     white-space: nowrap;
   }
@@ -3105,9 +3224,7 @@ a.wiki-link-active {
   }
 
   .main {
-    --mobile-gutter: clamp(20px, 5vw, 48px);
-
-    padding: 28px clamp(20px, 5vw, 48px) 80px;
+    padding: 28px var(--mobile-gutter) 80px;
   }
 
   .document-header-line {
@@ -3141,12 +3258,11 @@ a.wiki-link-active {
   .document-toc-toggle {
     min-height: 56px;
     padding: 0 var(--mobile-gutter);
-    background: color-mix(in srgb, var(--background) 94%, transparent);
+    background: var(--background);
     border-top: 0;
     border-right: 0;
     border-left: 0;
     border-radius: 0;
-    backdrop-filter: blur(12px);
   }
 
   .document-toc[data-expanded='true'] .document-toc-toggle {
@@ -3190,19 +3306,19 @@ a.wiki-link-active {
     top: 0;
     width: 100%;
     height: auto;
-    background: color-mix(in srgb, var(--panel) 92%, transparent);
+    background: var(--background);
     border-bottom: 1px solid var(--panel-border);
-    backdrop-filter: blur(12px);
     pointer-events: auto;
   }
 
   .graph-topbar-graph {
-    min-height: 64px;
-    padding: 10px 16px;
+    min-height: 48px;
+    padding: 0 16px;
     border-right: 0;
   }
 
   .graph-topbar-graph .graph-header {
+    min-height: 48px;
     flex-basis: 190px;
   }
 
@@ -3242,7 +3358,8 @@ a.wiki-link-active {
     font-size: 16px;
   }
 
-  .graph-kind-filters label span {
+  .graph-kind-filters label span,
+  .graph-fit {
     min-height: 32px;
     padding: 7px 10px;
   }
@@ -3283,19 +3400,13 @@ a.wiki-link-active {
 }
 
 @media (max-width: 600px) {
-  .main {
-    --mobile-gutter: 18px;
-
-    padding-right: 18px;
-    padding-left: 18px;
-  }
-
   .markdown {
-    font-size: 15.5px;
+    font-size: 16px;
   }
 
   .markdown h1 {
     font-size: 32px;
+    line-height: 40px;
   }
 
   .markdown h2 {


### PR DESCRIPTION
## Summary

- Align typography, neutral colors, code highlighting, and code surfaces with Geist/Vercel docs.
- Fix responsive header alignment, View/Edit and TOC controls, mobile gutters, list spacing, and disclosure title selection.
- Improve graph contrast, outlines, transparency, selected-node emphasis, spacing, and controls; disable node dragging and size document nodes using references across all subsections.
- Keep architecture and test documentation focused on the resulting behavior.

This PR contains only the style and graph refinements. Root document routing is already on main via #146.

Rebased onto main including #143 and #146. The new copy button already inherits the shared design tokens and needs no layout or color changes; its Copy Code and Retry Copy labels now match the Title Case convention.

## Validation

- pnpm buildall
- pnpm test — 325 tests passed
- node dist/src/cli/index.js check
- Browser review: dark desktop and light touch layouts, keyboard visibility, 44px touch target, no horizontal page overflow