### PR TITLE
Mount document routes at the UI root

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -28,7 +28,9 @@ The live server's default-self Content Security Policy permits OpenFreeMap tile 
 
 Read APIs accept only walked vault files or supported project source paths and reject traversal and escaping symlinks.
 
-Local Markdown documents use extensionless `/docs/...` browser routes. Appending `.md` addresses the exact Markdown source instead, with `text/markdown` from the live server and a physical `.md` file in static exports so agents can read the vault without the React protocol.
+Local Markdown routes mirror vault-relative paths without a fixed prefix: `guide.md` becomes `/guide`, and the entry document owns `/` in live and exported UIs. Raw Markdown remains at `/<file>.md`, with `text/markdown` from servers and physical files in exports.
+
+Document paths cannot shadow reserved UI namespaces (`api`, `assets`, `data`, `code`, `external`, `resources`, `graph`, and `search`) or generated HTML files. There is no special `docs/` namespace or compatibility alias.
 
 Relative links to non-Markdown files inside the vault become `/resources/...` routes. The live server reads only real files contained by the vault, while static and server builds copy only resources reached from rendered documents.
 
@@ -70,11 +72,11 @@ Each document route embeds the snapshot manifest and its own document response a
 
 The browser reads the snapshot manifest instead of `/api/*`, never opens an event stream, and hides Git, search, and runtime command controls. Documents contain no Git diff projection, while graph nodes contain no Git status.
 
-`--base /path/` prefixes routes, assets, and data and nests the physical payload under the same path, so deploying the output directory at a host's root serves the UI from that subpath. `/` is the default.
+`--base /path/` prefixes routes, assets, and data and nests the physical payload under the same path. `/` is the default; `--base docs/` normalizes to `/docs/`, without adding another document prefix.
 
 Vite emits lazy chunks, imported CSS, fonts, and renderer dependencies relative to their owning JavaScript or stylesheet. Generated route shells anchor only the entry assets at the configured base, so nested deployments do not leak requests to root `/assets/`.
 
-Relative Markdown links are rewritten against their source document and then to static UI routes, so export directories do not change their target or accidentally request raw Markdown. The entry document owns `/`; `index.html` is only its physical file, and the former `/docs/...` route redirects to the canonical root.
+Relative Markdown links are resolved against their source document before applying the deployment base, preserving nested links and fragments. The entry document owns the base root; `index.html` is only its physical file, and its filename route redirects home.
 
 Builds reject any existing destination, including an empty directory or prior export. `--force` allows intentional replacement; the builder stages the complete artifact beside the destination and moves it only after generation succeeds, retrying transient filesystem locks.
 
@@ -186,7 +188,7 @@ Every section heading exposes a burger-icon action menu, with a numeric badge on
 
 The topmost section menu in a local Markdown document links to the raw `.md` route. External documents and document previews outside their normal local route omit this action.
 
-Raw-file links preserve the deployment base and `/docs/` source path in live, static, and server builds. An exported homepage at `/` still links to its `/docs/<file>.md` source rather than appending `.md` to the homepage URL.
+Raw-file links preserve the deployment base in live, static, and server builds. A homepage at `/` links to its `/<file>.md` source rather than appending `.md` to the homepage URL.
 
 In live views, the menu can invoke [[src/cli/section.ts#sectionCommand|the shared `lat section` command path]] with plain styling. Its modal defaults to the React projection of the shared document tree and can switch to raw output; static exports omit only this execution action.
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -9,7 +9,9 @@ Functional specifications for the local browser, deployable builds, client navig
 
 ## Serves the document index and browser shell
 
-The loopback server exposes the visible Markdown index, redirects its root to the extensionless vault-index route, and serves the client shell for extensionless document routes.
+The loopback server exposes the visible Markdown index and renders its entry at `/`. Other documents use their extensionless vault-relative paths, without a fixed prefix; missing routes return 404.
+
+The live shell identifies its entry without enabling static mode. Reserved UI namespaces and generated-file collisions are rejected rather than silently shadowing documents.
 
 Requesting the same route with `.md` returns the exact known vault file as `text/markdown`; missing or escaping paths remain unavailable. `HEAD` returns the same source headers without a body.
 
@@ -27,7 +29,7 @@ The server anchors Vite's relative entry assets at `/assets/`, so every live doc
 
 Without an explicit output, it writes `.lat-build/static/`.
 
-Every local document also emits its exact source at the corresponding `.md` URL, while generated, relative, search, backlink, and graph navigation all target the extensionless React route.
+Documents use root-relative extensionless routes, with only the configured base as a prefix. Generated, relative, search, backlink, and graph links follow this mapping; each document also emits its exact source at the corresponding `.md` URL.
 
 The build copies each vault-local resource reached from a rendered document once, preserves its vault-relative path, and rewrites its URL under the configured deployment base.
 
@@ -43,11 +45,17 @@ Every source file stores its raw text and highlighted lines once. Request-specif
 
 `lat ui build static --logo-text <text>` persists the same plain-text override in the static manifest; without it, the exported client uses the bundled Lat wordmark.
 
-An absolute `--base` path nests the payload under that path as well as prefixing its URLs, so the output directory itself remains the deployment root.
+A `--base` path, with or without a leading slash, nests the payload under that path as well as prefixing its URLs. Root and nested builds keep document routes, raw Markdown, entry navigation, and assets consistent without an implicit `/docs/` segment.
 
 Entry assets use that base, while lazy JavaScript, CSS, fonts, and renderer chunks resolve relative to their owning production asset. Rich fences therefore work at both root and nested deployments.
 
 Any existing output path is rejected before snapshot work begins, including an empty directory or prior export. `--force` explicitly replaces it, but only after the complete successor has staged successfully. Transient busy-file errors during the final move are retried; destinations that could contain the project remain forbidden.
+
+## Mounts documents at the configured base
+
+Live, static, and server UIs render the entry at the mount root and other documents at extensionless vault-relative paths. Only an explicit build base adds a prefix; real `docs/` folders remain ordinary content.
+
+Root and nested builds preserve encoded filenames, relative links, fragments, raw Markdown, and assets. Reserved UI routes and file/directory collisions fail explicitly, with no legacy document aliases.
 
 ## Builds a portable server deployment
 
@@ -59,7 +67,7 @@ The generated package directly imports and constructs its pinned Express version
 
 The entrypoint passes literal module-relative manifest and index URLs as real runtime inputs and injects a search-engine factory made from ordinary embedding-engine and model imports. The runtime derives the sibling `public/` directory from the manifest instead of exposing it to file tracing; CDN-aware hosts publish that root directory without duplicating it inside the function. Package-owned code loads its own WASM and model assets, so file tracing follows the actual runtime graph without include globs or tracing-only expressions.
 
-Its static fallback preserves configured base paths, extensionless UI routes, and exact raw `.md` files on non-CDN hosts. `/` renders the configured entry document directly; `index.html` is only the physical file, and the former `/docs/...` route redirects to the root.
+Its static fallback preserves configured base paths, extensionless UI routes, and exact raw `.md` files on non-CDN hosts. `/` renders the configured entry document directly; `index.html` is only the physical file, and its filename route redirects home.
 
 The static client exposes Search only when the build advertises an endpoint. Editing, Git state, event streams, repository access, and the runtime section command remain disabled.
 
@@ -233,7 +241,7 @@ Every section exposes a burger-icon menu with a count only when references exist
 
 Muted actions stack below the references with “Copy link to the section” first. They can also copy the canonical ID accepted by `lat section`. The topmost local Markdown section links to the raw `.md` file, while external documents omit that action.
 
-Following the menu link returns the exact source from both the live UI and generated Node server. Exported homepages retain their `/docs/<file>.md` source route, and nested deployments preserve their base path.
+Following the menu link returns the exact source from both the live UI and generated Node server. Homepages retain their `/<file>.md` source route, and nested deployments preserve their base path.
 
 In live views, the output modal defaults to the shared React tree renderer and offers a raw-text toggle; static exports omit this runtime-only action.
 

--- a/src/view/document-route.ts
+++ b/src/view/document-route.ts
@@ -1,6 +1,17 @@
-const DOCUMENT_PREFIX = '/docs/';
+const DOCUMENT_PREFIX = '/';
 const RESOURCE_PREFIX = '/resources/';
 const MARKDOWN_EXTENSION = '.md';
+const RESERVED_ROUTES = new Set([
+  'api',
+  'assets',
+  'data',
+  'code',
+  'external',
+  'resources',
+  'graph',
+  'search',
+  'index.html',
+]);
 
 function encodePath(path: string): string {
   return path.split('/').map(encodeURIComponent).join('/');
@@ -9,14 +20,38 @@ function encodePath(path: string): string {
 function decodeDocumentPath(pathname: string): string | null {
   if (!pathname.startsWith(DOCUMENT_PREFIX)) return null;
   try {
-    const path = pathname
+    const segments = pathname
       .slice(DOCUMENT_PREFIX.length)
       .split('/')
-      .map(decodeURIComponent)
-      .join('/');
-    return path && !path.endsWith('/') ? path : null;
+      .map(decodeURIComponent);
+    if (
+      segments.some(
+        (part) => !part || part === '.' || part === '..' || /[/\\]/.test(part),
+      )
+    )
+      return null;
+    return segments.join('/');
   } catch {
     return null;
+  }
+}
+
+/** Fail explicitly when a document would shadow the UI or a generated file. */
+export function validateDocumentRoutes(paths: readonly string[]): void {
+  const files = new Set(paths);
+  for (const path of paths) {
+    if (documentPath(documentUrl(path)) !== path) {
+      throw new Error(
+        `Document path conflicts with a reserved UI route: ${path}`,
+      );
+    }
+    const parts = path.split('/');
+    if (
+      parts.some((part) => part === 'index.html.md') ||
+      parts.some((_, i) => i > 0 && files.has(parts.slice(0, i).join('/')))
+    ) {
+      throw new Error(`Document path conflicts with an exported file: ${path}`);
+    }
   }
 }
 
@@ -31,14 +66,24 @@ export function documentUrl(path: string, fragment = ''): string {
 /** Resolve an extensionless browser route back to its Markdown file path. */
 export function documentPath(pathname: string): string | null {
   const path = decodeDocumentPath(pathname);
-  if (!path || path.toLowerCase().endsWith(MARKDOWN_EXTENSION)) return null;
+  if (
+    !path ||
+    RESERVED_ROUTES.has(path.split('/')[0]!) ||
+    path.endsWith('/index.html') ||
+    path.toLowerCase().endsWith(MARKDOWN_EXTENSION)
+  )
+    return null;
   return `${path}${MARKDOWN_EXTENSION}`;
 }
 
 /** Resolve an explicit `.md` route to the raw Markdown file it requests. */
 export function rawDocumentPath(pathname: string): string | null {
   const path = decodeDocumentPath(pathname);
-  return path?.toLowerCase().endsWith(MARKDOWN_EXTENSION) ? path : null;
+  return path &&
+    !RESERVED_ROUTES.has(path.split('/')[0]!) &&
+    path.toLowerCase().endsWith(MARKDOWN_EXTENSION)
+    ? path
+    : null;
 }
 
 /** Build the browser route for a non-Markdown file stored in the vault. */

--- a/src/view/references.ts
+++ b/src/view/references.ts
@@ -115,14 +115,11 @@ export function linkedSection(
     .join('/');
   let destination: URL;
   try {
-    destination = new URL(url, `http://lat.local/docs/${encodedSourcePath}`);
+    destination = new URL(url, `http://lat.local/${encodedSourcePath}`);
   } catch {
     return null;
   }
-  if (
-    destination.origin !== 'http://lat.local' ||
-    !destination.pathname.startsWith('/docs/')
-  ) {
+  if (destination.origin !== 'http://lat.local') {
     return null;
   }
 
@@ -130,7 +127,7 @@ export function linkedSection(
   let fragment: string;
   try {
     path = destination.pathname
-      .slice('/docs/'.length)
+      .slice(1)
       .split('/')
       .map(decodeURIComponent)
       .join('/');

--- a/src/view/server.ts
+++ b/src/view/server.ts
@@ -33,8 +33,9 @@ import { createViewStore, type ViewStore } from './store.js';
 import { rewriteClientAssetUrls } from './client-shell.js';
 import {
   documentResourcePath,
-  documentUrl,
+  documentPath,
   rawDocumentPath,
+  validateDocumentRoutes,
 } from './document-route.js';
 
 const DEFAULT_HOST = '127.0.0.1';
@@ -179,9 +180,14 @@ async function sendClientShell(
   res: ServerResponse,
   path: string,
   headOnly: boolean,
+  entry: string,
 ): Promise<void> {
   try {
-    const body = rewriteClientAssetUrls(await readFile(path, 'utf8'), '/');
+    const html = rewriteClientAssetUrls(await readFile(path, 'utf8'), '/');
+    const config = `<meta name="lat-live-entry" content="${encodeURIComponent(entry)}">`;
+    const body = html.includes('</head>')
+      ? html.replace('</head>', `${config}</head>`)
+      : `${config}${html}`;
     res.setHeader('Cache-Control', 'no-cache');
     send(res, 200, 'text/html; charset=utf-8', body, headOnly);
   } catch (error) {
@@ -204,6 +210,12 @@ export async function createViewApp(
     watch: options.watch,
     externalCa: options.externalCa,
   });
+  try {
+    validateDocumentRoutes(store.getIndex().files);
+  } catch (error) {
+    await store.close();
+    throw error;
+  }
   const search =
     options.search ??
     createViewSearch(ctx.latDir, undefined, () => store.markdownGeneration);
@@ -243,8 +255,21 @@ export async function createViewApp(
           );
           return;
         }
-        res.statusCode = 302;
-        res.setHeader('Location', documentUrl(entry));
+        await sendClientShell(
+          res,
+          join(clientDir, 'index.html'),
+          headOnly,
+          entry,
+        );
+        return;
+      }
+
+      const index = store.getIndex();
+      const routePath = url.pathname.replace(/\/$/, '');
+      const markdownPath = documentPath(routePath);
+      if (markdownPath === index.entry) {
+        res.statusCode = 308;
+        res.setHeader('Location', `/${url.search}`);
         res.end();
         return;
       }
@@ -532,11 +557,16 @@ export async function createViewApp(
       if (
         url.pathname === '/search' ||
         url.pathname === '/graph' ||
-        url.pathname.startsWith('/docs/') ||
+        (markdownPath !== null && index.files.includes(markdownPath)) ||
         url.pathname.startsWith('/code/') ||
         url.pathname.startsWith('/external/')
       ) {
-        await sendClientShell(res, join(clientDir, 'index.html'), headOnly);
+        await sendClientShell(
+          res,
+          join(clientDir, 'index.html'),
+          headOnly,
+          index.entry,
+        );
         return;
       }
 

--- a/src/view/static-build.ts
+++ b/src/view/static-build.ts
@@ -41,6 +41,7 @@ import {
   documentPath,
   documentUrl,
   rawDocumentPath,
+  validateDocumentRoutes,
 } from './document-route.js';
 
 const defaultClientDir = fileURLToPath(new URL('./client/', import.meta.url));
@@ -69,12 +70,13 @@ function isInside(parent: string, child: string): boolean {
 }
 
 export function normalizeStaticViewBasePath(value: string): string {
-  const parsed = new URL(value || '/', 'http://lat.local');
+  const path = value.startsWith('/') ? value : `/${value}`;
+  const parsed = new URL(path, 'http://lat.local');
   if (
     parsed.origin !== 'http://lat.local' ||
     parsed.search ||
     parsed.hash ||
-    !value.startsWith('/')
+    value.includes('://')
   ) {
     throw new Error('Static UI base path must be an absolute URL path');
   }
@@ -113,7 +115,7 @@ export function staticViewUrl(
   basePath: string,
   entryPath?: string,
 ): string {
-  if (!value || value.startsWith('#')) return value;
+  if (!value || !value.startsWith('/') || value.startsWith('//')) return value;
   let url: URL;
   try {
     url = new URL(decodeHtmlUrlAttribute(value), 'http://lat.local');
@@ -122,10 +124,11 @@ export function staticViewUrl(
   }
   if (url.origin !== 'http://lat.local') return value;
 
-  if (url.pathname.startsWith('/docs/')) {
+  const markdownPath = documentPath(url.pathname.replace(/\/$/, ''));
+  if (markdownPath || rawDocumentPath(url.pathname)) {
     const route = url.pathname.slice(1).replace(/\/+$/, '');
     const suffix = `${url.search}${url.hash}`;
-    if (entryPath && documentPath(url.pathname) === entryPath) {
+    if (entryPath && markdownPath === entryPath) {
       return `${basePath}${suffix}`;
     }
     return `${basePath}${route}${suffix}`;
@@ -141,6 +144,9 @@ export function staticViewUrl(
   }
   if (url.pathname === '/graph') {
     return `${basePath}graph/${url.search}${url.hash}`;
+  }
+  if (url.pathname === '/' || url.pathname === '/search') {
+    return `${basePath}${url.pathname.slice(1)}${url.search}${url.hash}`;
   }
   return value;
 }
@@ -665,7 +671,7 @@ const REDIRECT_SCRIPT_PATH = 'data/redirect.js';
 const REDIRECT_SCRIPT = `const meta = document.querySelector('meta[name="lat-redirect"]');
 if (meta) {
   try {
-    window.location.replace(decodeURIComponent(meta.content) + window.location.hash);
+    window.location.replace(decodeURIComponent(meta.content) + window.location.search + window.location.hash);
   } catch {}
 }
 `;
@@ -733,6 +739,7 @@ export async function buildStaticView(
     await mkdir(payloadDir, { recursive: true });
     await cp(clientDir, payloadDir, { recursive: true });
     const index = { ...store.getIndex(), git: null, logoText };
+    validateDocumentRoutes(index.files);
     const shell = clientShell(
       clientHtml,
       basePath,
@@ -881,10 +888,10 @@ export async function buildStaticView(
         rewritten,
       );
       const source = await store.getDocumentSource(path);
-      const rawPath = join(payloadDir, 'docs', ...path.split('/'));
+      const rawPath = join(payloadDir, ...path.split('/'));
       await mkdir(dirname(rawPath), { recursive: true });
       await writeFile(rawPath, source.content);
-      const route = `docs/${path.slice(0, -'.md'.length)}`;
+      const route = path.slice(0, -'.md'.length);
       documentBootstraps.set(route, {
         request: viewStaticDocumentRequest(path),
         document: rewritten,
@@ -996,7 +1003,7 @@ export async function buildStaticView(
       );
     }
     await writeJson(join(payloadDir, 'data/manifest.json'), manifest);
-    const entryRoute = `docs/${index.entry.slice(0, -'.md'.length)}`;
+    const entryRoute = index.entry.slice(0, -'.md'.length);
     const entryBootstrap = documentBootstraps.get(entryRoute);
     if (!entryBootstrap) {
       throw new Error(`Static UI entry document is missing: ${index.entry}`);

--- a/tests/view-navigation.test.ts
+++ b/tests/view-navigation.test.ts
@@ -144,13 +144,13 @@ describe('directory index navigation', () => {
     expect(
       [...html.matchAll(/href="([^"]+)"/g)].map((match) => match[1]),
     ).toEqual([
-      '/docs/lat',
-      '/docs/zeta',
-      '/docs/docs/docs',
-      '/docs/docs/docs',
-      '/docs/docs/setup',
-      '/docs/docs/api',
-      '/docs/alpha',
+      '/lat',
+      '/zeta',
+      '/docs/docs',
+      '/docs/docs',
+      '/docs/setup',
+      '/docs/api',
+      '/alpha',
     ]);
     expect(await checkIndex(latDir)).toEqual([]);
 

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -53,6 +53,10 @@ import type {
   ViewStaticSourceView,
 } from '../src/view/static-protocol.js';
 import { buildGitDiffTree } from '../src/view/git-diff.js';
+import {
+  validateDocumentRoutes,
+  rewriteDocumentLink,
+} from '../src/view/document-route.js';
 import { renderMarkdown as renderMarkdownTree } from '../src/view/markdown.js';
 import type {
   ViewDocument,
@@ -247,10 +251,38 @@ describe('lat ui', () => {
     });
 
     const rootResponse = await fetch(view.url, { redirect: 'manual' });
-    expect(rootResponse.status).toBe(302);
-    expect(rootResponse.headers.get('location')).toBe('/docs/lat');
+    expect(rootResponse.status).toBe(200);
+    expect(rootResponse.headers.get('location')).toBeNull();
+    expect(await rootResponse.text()).toContain(
+      'name="lat-live-entry" content="lat.md"',
+    );
+    for (const [path, target] of [
+      ['/lat', '/'],
+      ['/lat?x=1', '/?x=1'],
+    ]) {
+      const redirect = await fetch(new URL(path!, view.url), {
+        redirect: 'manual',
+      });
+      expect(redirect.status).toBe(308);
+      expect(redirect.headers.get('location')).toBe(target);
+    }
+    expect((await fetch(new URL('/missing', view.url))).status).toBe(404);
+    expect((await fetch(new URL('/docs/guide', view.url))).status).toBe(404);
+    expect((await fetch(new URL('/docs/guide.md', view.url))).status).toBe(404);
+    vi.stubGlobal('document', {
+      querySelector: (selector: string) =>
+        selector.includes('lat-live-entry') ? { content: 'lat.md' } : null,
+    });
+    try {
+      expect(documentUrl('lat.md')).toBe('/');
+      expect(documentPath('/')).toBe('lat.md');
+      expect(rawDocumentUrl('lat.md')).toBe('/lat.md');
+      expect(staticViewBasePath()).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
 
-    const shellResponse = await fetch(new URL('/docs/guide', view.url));
+    const shellResponse = await fetch(new URL('/guide', view.url));
     expect(shellResponse.status).toBe(200);
     expect(shellResponse.headers.get('x-powered-by')).toBeNull();
     const shell = await shellResponse.text();
@@ -269,7 +301,7 @@ describe('lat ui', () => {
       "img-src 'self' data: https://github.com https://github.githubassets.com https://img.shields.io",
     );
 
-    const rawResponse = await fetch(new URL('/docs/guide.md', view.url));
+    const rawResponse = await fetch(new URL('/guide.md', view.url));
     expect(rawResponse.status).toBe(200);
     expect(rawResponse.headers.get('content-type')).toBe(
       'text/markdown; charset=utf-8',
@@ -278,7 +310,7 @@ describe('lat ui', () => {
       readFileSync(join(latDir, 'guide.md'), 'utf8'),
     );
 
-    const rawHeadResponse = await fetch(new URL('/docs/guide.md', view.url), {
+    const rawHeadResponse = await fetch(new URL('/guide.md', view.url), {
       method: 'HEAD',
     });
     expect(rawHeadResponse.status).toBe(200);
@@ -287,12 +319,10 @@ describe('lat ui', () => {
     );
     expect(await rawHeadResponse.text()).toBe('');
 
-    const missingRawResponse = await fetch(
-      new URL('/docs/missing.md', view.url),
-    );
+    const missingRawResponse = await fetch(new URL('/missing.md', view.url));
     expect(missingRawResponse.status).toBe(404);
     const escapingRawResponse = await fetch(
-      new URL('/docs/..%2F..%2FREADME.md', view.url),
+      new URL('/..%2F..%2FREADME.md', view.url),
     );
     expect(escapingRawResponse.status).toBe(404);
 
@@ -352,13 +382,10 @@ describe('lat ui', () => {
 
     expect(viewViteConfig).toMatchObject({ base: './' });
     expect(normalizeStaticViewBasePath('/project')).toBe('/project/');
-    expect(staticViewUrl('/docs/guide', '/project/')).toBe(
-      '/project/docs/guide',
-    );
-    expect(staticViewUrl('/docs/guide.md', '/project/')).toBe(
-      '/project/docs/guide.md',
-    );
-    expect(staticViewUrl('/docs/lat', '/project/', 'lat.md')).toBe('/project/');
+    expect(staticViewUrl('/guide', '/project/')).toBe('/project/guide');
+    expect(staticViewUrl('/guide/', '/project/')).toBe('/project/guide');
+    expect(staticViewUrl('/guide.md', '/project/')).toBe('/project/guide.md');
+    expect(staticViewUrl('/lat', '/project/', 'lat.md')).toBe('/project/');
     expect(staticViewUrl('/graph?node=document%3Alat.md', '/project/')).toBe(
       '/project/graph/?node=document%3Alat.md',
     );
@@ -385,19 +412,24 @@ describe('lat ui', () => {
     try {
       expect(staticViewBasePath()).toBe('/project/');
       expect(staticViewSearchApi()).toBe('/project/api/search');
-      expect(viewPathname('/project/index.html')).toBe('/docs/lat');
-      expect(viewPathname('/project/')).toBe('/docs/lat');
-      expect(staticViewRoute('docs/lat')).toBe('/project/');
-      expect(rawDocumentUrl('lat.md')).toBe('/project/docs/lat.md');
+      expect(viewPathname('/project/index.html')).toBe('/lat');
+      expect(viewPathname('/project/')).toBe('/lat');
+      expect(staticViewRoute('lat')).toBe('/project/');
+      expect(rawDocumentUrl('lat.md')).toBe('/project/lat.md');
       expect(rawDocumentUrl('nested/my guide.md')).toBe(
-        '/project/docs/nested/my%20guide.md',
+        '/project/nested/my%20guide.md',
       );
     } finally {
       vi.unstubAllGlobals();
     }
-    expect(() => normalizeStaticViewBasePath('project')).toThrow(
-      'absolute URL path',
-    );
+    expect(normalizeStaticViewBasePath('project')).toBe('/project/');
+    expect(normalizeStaticViewBasePath('docs/')).toBe('/docs/');
+    expect(staticViewUrl('/guide', '/docs/')).toBe('/docs/guide');
+    expect(staticViewUrl('/guide', '/')).toBe('/guide');
+    expect(staticViewUrl('/', '/project/')).toBe('/project/');
+    expect(staticViewUrl('../guide.md', '/project/')).toBe('../guide.md');
+    expect(() => normalizeStaticViewBasePath('//example.com')).toThrow();
+    expect(() => normalizeStaticViewBasePath('https://example.com')).toThrow();
 
     const buildRoot = mkdtempSync(join(tmpdir(), 'lat-ui-build-test-'));
     const staticProjectRoot = join(buildRoot, 'project');
@@ -475,7 +507,7 @@ describe('lat ui', () => {
       );
       expect(viewDocumentGitHtml(document)).toBeNull();
       expect(viewDocumentHtml(document)).toContain(
-        'href="/project/docs/guide#details"',
+        'href="/project/guide#details"',
       );
       expect(viewDocumentHtml(document)).toContain(
         'href="/project/code/src/app.ts/?from=',
@@ -493,10 +525,10 @@ describe('lat ui', () => {
       expect(graph.nodes.map((node) => node.url)).toContain('/project/');
       expect(graph.nodes.some((node) => node.kind === 'source')).toBe(true);
 
-      expect(existsSync(join(payloadDir, 'docs', 'lat', 'index.html'))).toBe(
-        true,
-      );
-      expect(readFileSync(join(payloadDir, 'docs', 'lat.md'), 'utf8')).toBe(
+      expect(existsSync(join(payloadDir, 'lat', 'index.html'))).toBe(true);
+      expect(existsSync(join(payloadDir, 'docs'))).toBe(false);
+      expect(existsSync(join(payloadDir, 'guide', 'index.html'))).toBe(true);
+      expect(readFileSync(join(payloadDir, 'lat.md'), 'utf8')).toBe(
         readFileSync(join(staticContext.latDir, 'lat.md'), 'utf8'),
       );
       expect(
@@ -545,7 +577,7 @@ describe('lat ui', () => {
         redirect,
       );
       expect(
-        readFileSync(join(payloadDir, 'docs', 'lat', 'index.html'), 'utf8'),
+        readFileSync(join(payloadDir, 'lat', 'index.html'), 'utf8'),
       ).toContain('/project/');
       expect(
         readFileSync(join(payloadDir, 'data', 'redirect.js'), 'utf8'),
@@ -598,6 +630,135 @@ describe('lat ui', () => {
       });
     } finally {
       rmSync(buildRoot, { recursive: true, force: true });
+    }
+  });
+
+  // @lat: [[lat.md/view/specs#View Tests#Mounts documents at the configured base]]
+  it('mounts documents at the root or explicit base without a hidden prefix', async () => {
+    expect(() =>
+      validateDocumentRoutes(['lat.md', 'docs/guide.md']),
+    ).not.toThrow();
+    for (const path of [
+      'api/help.md',
+      'assets/guide.md',
+      'data/page.md',
+      'graph.md',
+      'code.md',
+      'external/guide.md',
+      'resources/page.md',
+      'search.md',
+      'index.html.md',
+      'nested/index.html.md',
+    ]) {
+      expect(() => validateDocumentRoutes([path])).toThrow('conflicts');
+      expect(documentPath(`/${path.slice(0, -3)}`)).toBeNull();
+    }
+    expect(() => validateDocumentRoutes(['foo.md', 'foo.md/bar.md'])).toThrow(
+      'conflicts',
+    );
+    expect(documentPath('/nested%2Fguide')).toBeNull();
+    expect(documentPath('/%2e%2e/guide')).toBeNull();
+    expect(rewriteDocumentLink('assets/logo.svg', 'lat.md')).toBe(
+      '/resources/assets/logo.svg',
+    );
+    expect(rewriteDocumentLink('../guide.md#details', 'nested/page.md')).toBe(
+      '/guide#details',
+    );
+
+    const root = mkdtempSync(join(tmpdir(), 'lat-root-routing-'));
+    const project = join(root, 'project');
+    const vault = join(project, 'lat.md');
+    mkdirSync(join(vault, 'nested'), { recursive: true });
+    mkdirSync(join(vault, 'docs'));
+    writeFileSync(
+      join(vault, 'lat.md'),
+      '# Home\n\n[Guide](nested/my%20guide.md#details).\n',
+    );
+    writeFileSync(
+      join(vault, 'nested', 'my guide.md'),
+      '# Guide\n\n[Home](../lat.md).\n\n## Details\n\nDetails.\n',
+    );
+    writeFileSync(
+      join(vault, 'docs', 'real.md'),
+      '# Real Folder\n\nA real docs folder.\n',
+    );
+    const context = { ...testContext(), projectRoot: project, latDir: vault };
+    let live: ViewServer | undefined;
+    try {
+      live = await startViewServer(context, {
+        clientDir,
+        port: 0,
+        git: false,
+        watch: false,
+      });
+      expect(
+        (await fetch(new URL('/nested/my%20guide', live.url))).status,
+      ).toBe(200);
+      expect((await fetch(new URL('/docs/real', live.url))).status).toBe(200);
+      expect(
+        (await fetch(new URL('/docs/nested/my%20guide', live.url))).status,
+      ).toBe(404);
+      for (const [i, base] of ['/', 'docs/', '/project/'].entries()) {
+        const output = join(root, `site-${i}`);
+        const basePath = normalizeStaticViewBasePath(base);
+        await buildStaticView(context, output, {
+          clientDir,
+          ...(base === '/' ? {} : { basePath: base }),
+        });
+        const payload = join(output, basePath.slice(1));
+        expect(
+          existsSync(join(payload, 'nested', 'my guide', 'index.html')),
+        ).toBe(true);
+        expect(existsSync(join(payload, 'docs', 'real', 'index.html'))).toBe(
+          true,
+        );
+        expect(existsSync(join(payload, 'docs', 'lat', 'index.html'))).toBe(
+          false,
+        );
+        expect(
+          readFileSync(join(payload, 'nested', 'my guide.md'), 'utf8'),
+        ).toContain('# Guide');
+        const manifest = JSON.parse(
+          readFileSync(join(payload, 'data', 'manifest.json'), 'utf8'),
+        ) as ViewStaticManifest;
+        const home = JSON.parse(
+          readFileSync(join(payload, manifest.documents['lat.md']!), 'utf8'),
+        ) as ViewDocument;
+        const guide = JSON.parse(
+          readFileSync(
+            join(payload, manifest.documents['nested/my guide.md']!),
+            'utf8',
+          ),
+        ) as ViewDocument;
+        expect(viewDocumentHtml(home)).toContain(
+          `href="${basePath}nested/my%20guide#details"`,
+        );
+        expect(viewDocumentHtml(guide)).toContain(`href="${basePath}"`);
+        const shell = readFileSync(join(payload, 'index.html'), 'utf8');
+        expect(shell).toContain(`src="${basePath}assets/app.js"`);
+        const config = shell.match(
+          /name="lat-static-view" content="([^"]+)"/,
+        )![1];
+        vi.stubGlobal('document', {
+          querySelector: () => ({ content: config }),
+        });
+        try {
+          expect(documentPath(basePath)).toBe('lat.md');
+          expect(documentUrl('lat.md')).toBe(basePath);
+          expect(documentUrl('nested/my guide.md')).toBe(
+            `${basePath}nested/my%20guide`,
+          );
+          expect(documentPath(`${basePath}nested/my%20guide/`)).toBe(
+            'nested/my guide.md',
+          );
+          expect(rawDocumentUrl('lat.md')).toBe(`${basePath}lat.md`);
+        } finally {
+          vi.unstubAllGlobals();
+        }
+      }
+    } finally {
+      await live?.close();
+      rmSync(root, { recursive: true, force: true });
     }
   });
 
@@ -842,7 +1003,7 @@ describe('lat ui', () => {
         expect(document.headers.get('cache-control')).toBe('no-cache');
         expect(await document.text()).toContain('lat ui shell');
 
-        const oldDocumentRoute = await fetch(`${origin}/project/docs/lat`);
+        const oldDocumentRoute = await fetch(`${origin}/project/lat`);
         expect(oldDocumentRoute.status).toBe(200);
         expect(await oldDocumentRoute.text()).toContain(
           'meta name="lat-redirect"',
@@ -999,7 +1160,7 @@ describe('lat ui', () => {
           ];
           expect(links).toHaveLength(1);
           const href = links[0][1];
-          expect(href).toBe(`/project/docs/${path}`);
+          expect(href).toBe(`/project/${path}`);
           expect(documentPath(new URL(href, origin).pathname)).toBeNull();
           const raw = await fetch(new URL(href, origin));
           expect(raw.status).toBe(200);
@@ -1123,10 +1284,10 @@ describe('lat ui', () => {
       '/graph?node=document%3Aguide.md',
     );
     expect(graphNode('?node=document%3Aguide.md')).toBe('document:guide.md');
-    const sectionTarget = '/docs/guide#details';
+    const sectionTarget = '/guide#details';
     const targetedGraphUrl = graphUrl('document:guide.md', sectionTarget);
     expect(targetedGraphUrl).toBe(
-      '/graph?node=document%3Aguide.md&target=%2Fdocs%2Fguide%23details',
+      '/graph?node=document%3Aguide.md&target=%2Fguide%23details',
     );
     expect(graphTarget(new URL(targetedGraphUrl, view.url).search)).toBe(
       sectionTarget,
@@ -1173,12 +1334,12 @@ describe('lat ui', () => {
     expect(
       graphTargetForNode(graph, documentNode!, sectionTarget, view.url),
     ).toBe(sectionTarget);
-    expect(
-      graphTargetForNode(graph, documentNode!, '/docs/lat', view.url),
-    ).toBe(documentNode!.url);
+    expect(graphTargetForNode(graph, documentNode!, '/lat', view.url)).toBe(
+      documentNode!.url,
+    );
     const sameDocumentLink = graphInspectorLinkUrl(
       '#details',
-      '/docs/guide',
+      '/guide',
       view.url,
     );
     expect(`${sameDocumentLink?.pathname}${sameDocumentLink?.hash}`).toBe(
@@ -1266,13 +1427,13 @@ describe('lat ui', () => {
     expect(searchUrl('runner details')).toBe('/search?q=runner+details');
     expect(searchQuery('?q=runner+details')).toBe('runner details');
     expect(searchUrl('')).toBe('/search');
-    expect(searchReturnTo(searchHistoryState('/docs/guide#details'))).toBe(
-      '/docs/guide#details',
+    expect(searchReturnTo(searchHistoryState('/guide#details'))).toBe(
+      '/guide#details',
     );
     expect(searchReturnTo(null)).toBeNull();
     expect(searchEscapeAction('runner details')).toBe('clear');
     expect(searchEscapeAction('')).toBe('close');
-    expect(searchButtonAction('/docs/guide')).toBe('open');
+    expect(searchButtonAction('/guide')).toBe('open');
     expect(searchButtonAction('/search')).toBe('close');
 
     const emptyResponse = await fetch(new URL('/api/search?query=', view.url));
@@ -1295,7 +1456,7 @@ describe('lat ui', () => {
           path: 'guide.md',
           breadcrumbs: ['guide', 'Guide', 'Details'],
           description: 'Relative Markdown links preserve heading fragments.',
-          url: '/docs/guide#details',
+          url: '/guide#details',
           score: 0.82,
         },
       ],
@@ -1349,7 +1510,7 @@ describe('lat ui', () => {
     expect(viewDocumentHtml(document)).toContain(
       '<h1 id="view-project">View Project</h1>',
     );
-    expect(viewDocumentHtml(document)).toContain('href="/docs/guide#details"');
+    expect(viewDocumentHtml(document)).toContain('href="/guide#details"');
     expect(viewDocumentHtml(document)).not.toContain('require-code-mention');
 
     const links = await renderMarkdown(
@@ -1879,16 +2040,16 @@ describe('lat ui', () => {
     const document = (await response.json()) as ViewDocument;
 
     expect(viewDocumentHtml(document)).toContain(
-      '<a href="/docs/guide">wiki navigation<span class="wiki-link-ref-count" aria-label="2 references">2</span></a>',
+      '<a href="/guide">wiki navigation<span class="wiki-link-ref-count" aria-label="2 references">2</span></a>',
     );
     expect(viewDocumentHtml(document)).toContain(
-      '<a href="/docs/guide#details">wiki heading links<span class="wiki-link-ref-count" aria-label="5 references">5</span></a>',
+      '<a href="/guide#details">wiki heading links<span class="wiki-link-ref-count" aria-label="5 references">5</span></a>',
     );
     expect(viewDocumentHtml(document)).toContain(
-      '<a href="/docs/guide#details">the same heading again<span class="wiki-link-ref-count" aria-label="5 references">5</span></a>',
+      '<a href="/guide#details">the same heading again<span class="wiki-link-ref-count" aria-label="5 references">5</span></a>',
     );
     expect(viewDocumentHtml(document)).toContain(
-      '<a href="/docs/guide#details" class="wiki-link-segmented"><span class="wiki-link-context">guide#</span><span class="wiki-link-leaf">Details</span><span class="wiki-link-ref-count" aria-label="5 references">5</span></a>',
+      '<a href="/guide#details" class="wiki-link-segmented"><span class="wiki-link-context">guide#</span><span class="wiki-link-leaf">Details</span><span class="wiki-link-ref-count" aria-label="5 references">5</span></a>',
     );
     expect(viewDocumentHtml(document)).toContain(
       'href="/code/src/app.ts?from=lat.md%2Flat%23View+Project',
@@ -1959,11 +2120,9 @@ describe('lat ui', () => {
       const sparseReferences = await renderMarkdown(
         '[[orphan]]',
         'lat.md',
-        async () => ({ href: '/docs/orphan', referenceCount }),
+        async () => ({ href: '/orphan', referenceCount }),
       );
-      expect(sparseReferences.html).toBe(
-        '<p><a href="/docs/orphan">orphan</a></p>',
-      );
+      expect(sparseReferences.html).toBe('<p><a href="/orphan">orphan</a></p>');
     }
   });
 
@@ -2021,7 +2180,7 @@ describe('lat ui', () => {
       paragraph:
         'Source targets such as src/app.ts#run open their definitions; the guide explains them.',
       paragraphTree: expect.objectContaining({ version: 1, type: 'root' }),
-      url: '/docs/lat#view-project',
+      url: '/lat#view-project',
     });
     expect(source.otherReferences).toEqual([
       {
@@ -2029,7 +2188,7 @@ describe('lat ui', () => {
         breadcrumbs: ['guide', 'Guide', 'Details'],
         paragraph: 'The guide also references the same runner.',
         paragraphTree: expect.objectContaining({ version: 1, type: 'root' }),
-        url: '/docs/guide#details',
+        url: '/guide#details',
       },
     ]);
     expect(paragraphTreeHtml(source.context)).toContain(
@@ -2039,7 +2198,7 @@ describe('lat ui', () => {
       'code-link-language code-language-ts',
     );
     expect(paragraphTreeHtml(source.context)).toContain(
-      'href="/docs/guide#details"',
+      'href="/guide#details"',
     );
     expect(paragraphTreeHtml(source.otherReferences[0])).toContain(
       'wiki-link-code wiki-link-active',
@@ -2070,7 +2229,7 @@ describe('lat ui', () => {
       kind: 'markdown',
       sectionId: 'lat.md/lat#View Project',
       breadcrumbs: ['lat', 'View Project'],
-      url: '/docs/lat#view-project',
+      url: '/lat#view-project',
     });
     expect(details?.references[1]).toMatchObject({
       kind: 'markdown',
@@ -2098,12 +2257,12 @@ describe('lat ui', () => {
     expect(rendered).toContain('id="section-back-references-1"');
     expect(rendered).toContain('Copy link to the section');
     expect(rendered).toContain('Copy section ID');
-    expect(rendered).toContain('href="/docs/guide.md"');
+    expect(rendered).toContain('href="/guide.md"');
     expect(rendered.match(/View Markdown file/g)).toHaveLength(1);
     const rawHref = rendered.match(
       /<a class="section-back-reference-action" href="([^"]+)">View Markdown file<\/a>/,
     )?.[1];
-    expect(rawHref).toBe('/docs/guide.md');
+    expect(rawHref).toBe('/guide.md');
     const raw = await fetch(new URL(rawHref!, view.url));
     expect(raw.status).toBe(200);
     expect(await raw.text()).toBe(
@@ -2183,14 +2342,12 @@ describe('lat ui', () => {
     const navigate = vi.fn();
     const clipboard = { writeText: vi.fn(async () => {}) };
     const sectionUrl = navigateAndCopySectionLink(
-      new URL('/docs/lat#view-project', view.url).href,
+      new URL('/lat#view-project', view.url).href,
       'unreferenced',
       navigate,
       clipboard,
     );
-    expect(sectionUrl.href).toBe(
-      new URL('/docs/lat#unreferenced', view.url).href,
-    );
+    expect(sectionUrl.href).toBe(new URL('/lat#unreferenced', view.url).href);
     expect(navigate).toHaveBeenCalledWith(sectionUrl);
     expect(clipboard.writeText).toHaveBeenCalledWith(sectionUrl.href);
 
@@ -2218,7 +2375,7 @@ describe('lat ui', () => {
     expect(sectionOutput.output).toContain('> ## Unreferenced');
     expect(sectionOutput.output).toContain('`lat section "section#id"`');
     expect(documentTreeToHtml(sectionOutput.tree)).toContain(
-      'href="/docs/lat#unreferenced"',
+      'href="/lat#unreferenced"',
     );
     expect(documentTreeToHtml(sectionOutput.tree)).toContain('<blockquote>');
     expect(documentTreeToHtml(sectionOutput.tree)).toContain(
@@ -2444,28 +2601,26 @@ describe('lat ui', () => {
     expect(getElementById).not.toHaveBeenCalled();
     expect(scrollIntoView).not.toHaveBeenCalled();
 
-    expect(documentUrl('nested/my guide.md')).toBe('/docs/nested/my%20guide');
-    expect(rawDocumentUrl('nested/my guide.md')).toBe(
-      '/docs/nested/my%20guide.md',
-    );
-    expect(documentPath('/docs/nested/my%20guide')).toBe('nested/my guide.md');
-    expect(documentPath('/docs/nested/my%20guide.md')).toBeNull();
+    expect(documentUrl('nested/my guide.md')).toBe('/nested/my%20guide');
+    expect(rawDocumentUrl('nested/my guide.md')).toBe('/nested/my%20guide.md');
+    expect(documentPath('/nested/my%20guide')).toBe('nested/my guide.md');
+    expect(documentPath('/nested/my%20guide.md')).toBeNull();
 
-    expect(viewRouteIdentity('/docs/guide#features')).toBe('/docs/guide');
-    expect(viewRouteIdentity('/docs/guide#installation')).toBe('/docs/guide');
+    expect(viewRouteIdentity('/guide#features')).toBe('/guide');
+    expect(viewRouteIdentity('/guide#installation')).toBe('/guide');
     expect(viewRouteIdentity('/code/parser.ts#parse')).toBe(
       '/code/parser.ts#parse',
     );
     expect(
       isSameRenderedDocument(
-        new URL('http://lat.local/docs/guide#features'),
-        new URL('http://lat.local/docs/guide#installation'),
+        new URL('http://lat.local/guide#features'),
+        new URL('http://lat.local/guide#installation'),
       ),
     ).toBe(true);
     expect(
       isSameRenderedDocument(
-        new URL('http://lat.local/docs/guide'),
-        new URL('http://lat.local/docs/other'),
+        new URL('http://lat.local/guide'),
+        new URL('http://lat.local/other'),
       ),
     ).toBe(false);
     expect(
@@ -2478,12 +2633,12 @@ describe('lat ui', () => {
 
   // @lat: [[lat.md/view/specs#View Tests#Restores history scroll positions]]
   it('preserves scroll positions in navigation history state', () => {
-    const state = historyStateWithScroll(
-      searchHistoryState('/docs/guide#details'),
-      { left: 12, top: 480 },
-    );
+    const state = historyStateWithScroll(searchHistoryState('/guide#details'), {
+      left: 12,
+      top: 480,
+    });
 
-    expect(searchReturnTo(state)).toBe('/docs/guide#details');
+    expect(searchReturnTo(state)).toBe('/guide#details');
     expect(historyScrollPosition(state)).toEqual({ left: 12, top: 480 });
     expect(historyScrollPosition({ latScrollPosition: { top: '480' } })).toBe(
       null,

--- a/view/src/App.tsx
+++ b/view/src/App.tsx
@@ -698,6 +698,8 @@ export function App() {
   }
 
   function navigate(url: URL): void {
+    const path = documentPath(url.pathname);
+    if (path) url.pathname = documentUrl(path);
     const returnTo = currentLocation();
     const preservesDocument =
       page?.kind === 'markdown' &&

--- a/view/src/navigation.ts
+++ b/view/src/navigation.ts
@@ -1,6 +1,6 @@
 import type { ViewGraph, ViewGraphNode } from '../../src/view/protocol';
 import { isDocumentPath } from '../../src/document-formats';
-import { staticViewRoute, viewPathname } from './static-mode';
+import { staticViewRoute, viewPathname, viewEntryPath } from './static-mode';
 import {
   documentPath as routeDocumentPath,
   documentUrl as routeDocumentUrl,
@@ -18,7 +18,9 @@ type DocumentScroller = {
 
 export function documentUrl(path: string): string {
   const route = routeDocumentUrl(path);
-  return staticViewRoute(route.slice(1)) ?? route;
+  return (
+    staticViewRoute(route.slice(1)) ?? (path === viewEntryPath() ? '/' : route)
+  );
 }
 
 export function documentPath(pathname: string): string | null {

--- a/view/src/static-mode.ts
+++ b/view/src/static-mode.ts
@@ -46,6 +46,21 @@ export function isStaticView(): boolean {
   return staticViewBasePath() !== null;
 }
 
+/** Resolve the homepage in both a live shell and a portable snapshot. */
+export function viewEntryPath(): string | null {
+  const config = staticViewConfig();
+  if (config) return config.entry ?? null;
+  if (typeof document === 'undefined') return null;
+  const entry = document.querySelector<HTMLMetaElement>(
+    'meta[name="lat-live-entry"]',
+  )?.content;
+  try {
+    return entry ? decodeURIComponent(entry) : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Return the optional dynamic search endpoint attached to a static build. */
 export function staticViewSearchApi(): string | null {
   return staticViewConfig()?.searchApi ?? null;
@@ -65,11 +80,15 @@ export function staticViewAssetUrl(
 /** Strip the configured deployment prefix and static route trailing slash. */
 export function viewPathname(pathname: string): string {
   const config = staticViewConfig();
-  if (!config) return pathname;
+  if (!config) {
+    const entry = viewEntryPath();
+    if (pathname === '/' && entry) return documentUrl(entry);
+    return pathname.length > 1 ? pathname.replace(/\/$/, '') : pathname;
+  }
   const { basePath } = config;
   const prefix = basePath === '/' ? '' : basePath.slice(0, -1);
   const unprefixed =
-    prefix && pathname.startsWith(prefix)
+    prefix && (pathname === prefix || pathname.startsWith(`${prefix}/`))
       ? pathname.slice(prefix.length) || '/'
       : pathname;
   const route =

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -5,14 +5,9 @@ const nextConfig: NextConfig = {
     return [
       { source: '/lat.md', destination: '/lat.md/index.html' },
       {
-        source: '/lat.md/docs/:path*',
-        destination: '/lat.md/docs/:path*/index.html',
+        source: '/lat.md/:path*',
+        destination: '/lat.md/:path*/index.html',
       },
-      {
-        source: '/lat.md/code/:path*',
-        destination: '/lat.md/code/:path*/index.html',
-      },
-      { source: '/lat.md/graph', destination: '/lat.md/graph/index.html' },
     ];
   },
 };


### PR DESCRIPTION
## Summary

- Remove the implicit /docs/ prefix from live, static, and server document routes, with no compatibility aliases.
- Render the entry document at / and other documents at extensionless vault-relative paths; only --base adds a deployment prefix, including docs/ without a leading slash.
- Keep raw Markdown, relative links, fragments, navigation, assets, and website rewrites consistent with the mount path.
- Reject document names that collide with reserved UI routes or generated files; preserve real docs/ folders as ordinary content.
- Update the routing contract and add root/nested-base regression coverage.

Independent of the style PR: https://github.com/vercel-labs/lat.md/pull/145. Both target main.

## Validation

- pnpm buildall
- pnpm test — 322 tests passed on this standalone branch
- node dist/src/cli/index.js check
- Earlier browser checks verified live / to /cli navigation and static /docs/ to /docs/cli navigation with an explicit base, including raw Markdown