### PR TITLE
Highlight TOC section groups and animate active indicators

### DIFF
--- a/lat.md/view/architecture.md
+++ b/lat.md/view/architecture.md
@@ -176,6 +176,8 @@ Rendered link text is always underlined. A [[src/view/document-tree.ts#decorateE
 
 Document responses project every parsed heading and canonical GitHub slug into a local TOC. Its H1 entry stays bold at the base indentation, while subsection indentation remains relative to the first subsection level.
 
+The current section and its entire subtree stay subtly emphasized while readers move through its subsections. Desktop indicators mark the active heading and its section ancestors at their own indentation; the document H1 does not emphasize the whole page.
+
 TOC entries show an orange disc when their section contains a rendered Git change and a red disc when it owns validation errors. Git discs follow the Git visibility toggle; error discs remain visible.
 
 Same-document fragment navigation updates history and scroll position without clearing, refetching, or remounting the rendered Markdown. The H1 TOC fragment positions the viewport at document scroll-top zero; source fragments remain part of route identity because they select code symbols.

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -179,6 +179,12 @@ The fixed-width desktop rail fills the available viewport height without program
 
 The active indicator stays within the desktop rail; dropdowns omit it. The compact dropdown and expanded list align with the reading column's right edge, and its trigger matches View/Edit's height and vertical center.
 
+The active section's complete subtree remains subtly highlighted across subsection transitions and clears when entering a sibling section. Active ancestors retain their own indented bars, including skipped heading levels; only the current heading has `aria-current`.
+
+Desktop bars glide between headings at each indentation level and resize for wrapped titles. Layout changes update their positions; reduced-motion preferences disable both bar transitions and smooth TOC scrolling. Dropdowns remain bar-free.
+
+TOC auto-scrolling continuously eases toward the active heading without restarting when the target changes. Motion is frame-rate independent, stops for direct wheel, touch, pointer, or keyboard interaction, and snaps immediately with reduced motion.
+
 On wide screens, View/Edit stays at the reading column's right edge with or without a TOC, including Edit mode. A missing compact TOC lets the header span the reading column without changing the prose width limit.
 
 Sections containing rendered Git changes carry an orange disc when Git is enabled, while sections owning validation errors carry a red disc. Both remain visible together when both states apply.

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -82,6 +82,8 @@ import {
   centeredDocumentTocScrollTop,
   documentTocActivationLine,
   documentTocIndentationDepth,
+  documentTocActiveGroup,
+  nextDocumentTocScrollTop,
 } from '../view/src/document-toc.js';
 import {
   buildExternalFileTree,
@@ -1983,12 +1985,14 @@ describe('lat ui', () => {
     expect(styles).toMatch(
       /\.document-toc-link \{[^}]*box-shadow: inset 1px 0 var\(--panel-border\);/,
     );
-    expect(styles).toMatch(/\.document-toc-link::before \{[^}]*left: 0;/);
     expect(styles).toMatch(
-      /\.document-toc-link:first-child::before \{\s*top: 0;[^}]*border-top-left-radius: 0;[^}]*border-top-right-radius: 0;/,
+      /\.document-toc-indicator \{[^}]*left: calc\(var\(--toc-depth\) \* 13px\);/,
     );
     expect(styles).toMatch(
-      /\.document-toc-link:last-child::before \{\s*bottom: 0;[^}]*border-bottom-left-radius: 0;[^}]*border-bottom-right-radius: 0;/,
+      /\.document-toc-indicator \{[^}]*transition:[^}]*transform 200ms ease-out/,
+    );
+    expect(styles).toMatch(
+      /@media \(prefers-reduced-motion: reduce\) \{\s*\.document-toc-indicator,[^}]*transition: none;/,
     );
     const content =
       '# Guide\n\nOverview.\n\n## Features\n\nDetails.\n\n### `strict`\n\nMore details.';
@@ -2036,6 +2040,37 @@ describe('lat ui', () => {
     expect(
       [1, 2, 3].map((depth) => documentTocIndentationDepth(depth, 2)),
     ).toEqual([0, 0, 1]);
+    const nestedToc = [
+      { id: 'title', depth: 1 },
+      { id: 'intro', depth: 2 },
+      { id: 'features', depth: 2 },
+      { id: 'first', depth: 3 },
+      { id: 'deep', depth: 5 },
+      { id: 'second', depth: 3 },
+      { id: 'next', depth: 2 },
+    ];
+    for (const id of ['features', 'first', 'deep', 'second']) {
+      expect([...documentTocActiveGroup(nestedToc, id).groupIds]).toEqual([
+        'features',
+        'first',
+        'deep',
+        'second',
+      ]);
+    }
+    expect([...documentTocActiveGroup(nestedToc, 'deep').ancestorIds]).toEqual([
+      'features',
+      'first',
+    ]);
+    expect([
+      ...documentTocActiveGroup(nestedToc, 'second').ancestorIds,
+    ]).toEqual(['features']);
+    expect([...documentTocActiveGroup(nestedToc, 'next').groupIds]).toEqual([
+      'next',
+    ]);
+    expect([...documentTocActiveGroup(nestedToc, 'title').groupIds]).toEqual([
+      'title',
+    ]);
+    expect(documentTocActiveGroup([], 'missing').groupIds.size).toBe(0);
     expect(
       activeDocumentTocId(
         ['features', 'strict'],
@@ -2092,6 +2127,20 @@ describe('lat ui', () => {
         itemTop: 300,
       }),
     ).toBe(210);
+    const firstFrame = nextDocumentTocScrollTop(0, 300, 16);
+    expect(firstFrame).toBeGreaterThan(0);
+    expect(firstFrame).toBeLessThan(300);
+    const retargeted = nextDocumentTocScrollTop(firstFrame, 500, 16);
+    expect(retargeted).toBeGreaterThan(firstFrame);
+    expect(retargeted).toBeLessThan(500);
+    expect(nextDocumentTocScrollTop(retargeted, 0, 16)).toBeLessThan(
+      retargeted,
+    );
+    expect(nextDocumentTocScrollTop(firstFrame, 300, 16)).toBeCloseTo(
+      nextDocumentTocScrollTop(0, 300, 32),
+    );
+    expect(nextDocumentTocScrollTop(299.8, 300, 16)).toBe(300);
+    expect(nextDocumentTocScrollTop(0, 300, 0)).toBe(0);
     expect(
       centeredDocumentTocScrollTop({
         containerHeight: 200,
@@ -2199,7 +2248,7 @@ describe('lat ui', () => {
       /@media \(max-width: 1340px\)[\s\S]*?\.document-toc-link \{\s*box-shadow: none;/,
     );
     expect(styles).toMatch(
-      /@media \(max-width: 1340px\)[\s\S]*?\.document-toc-link::before \{\s*display: none;/,
+      /@media \(max-width: 1340px\)[\s\S]*?\.document-toc-indicator \{\s*display: none;/,
     );
     expect(styles).toMatch(
       /@media \(width < 64rem\)[\s\S]*?\.document-toc-toggle \{[\s\S]*?border-top: 0;/,

--- a/view/src/DocumentToc.tsx
+++ b/view/src/DocumentToc.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -12,9 +13,17 @@ import {
   centeredDocumentTocScrollTop,
   documentTocActivationLine,
   documentTocIndentationDepth,
+  documentTocActiveGroup,
+  nextDocumentTocScrollTop,
 } from './document-toc';
 
 type TocLinkStyle = CSSProperties & { '--toc-depth': number };
+type TocIndicator = {
+  depth: number;
+  top: number;
+  height: number;
+  visible: boolean;
+};
 
 function TocIcon() {
   return (
@@ -46,8 +55,78 @@ export function DocumentToc({
   const minimumSubsectionDepth =
     subsectionDepths.length > 0 ? Math.min(...subsectionDepths) : 2;
   const [activeId, setActiveId] = useState(ids[0] ?? '');
+  const { groupIds, ancestorIds } = useMemo(
+    () => documentTocActiveGroup(items, activeId),
+    [items, activeId],
+  );
   const [expanded, setExpanded] = useState(false);
   const navigationRef = useRef<HTMLElement>(null);
+  const scrollAnimation = useRef({ frame: 0, target: 0, position: 0, time: 0 });
+
+  useEffect(() => {
+    const navigation = navigationRef.current;
+    const animation = scrollAnimation.current;
+    const stop = () => {
+      window.cancelAnimationFrame(animation.frame);
+      animation.frame = 0;
+    };
+    navigation?.addEventListener('wheel', stop, { passive: true });
+    navigation?.addEventListener('touchstart', stop, { passive: true });
+    navigation?.addEventListener('pointerdown', stop);
+    navigation?.addEventListener('keydown', stop);
+    return () => {
+      stop();
+      navigation?.removeEventListener('wheel', stop);
+      navigation?.removeEventListener('touchstart', stop);
+      navigation?.removeEventListener('pointerdown', stop);
+      navigation?.removeEventListener('keydown', stop);
+    };
+  }, []);
+  const [indicators, setIndicators] = useState<TocIndicator[]>([]);
+  const indicatorIds = useRef(ids);
+
+  useLayoutEffect(() => {
+    const navigation = navigationRef.current;
+    if (!navigation) return;
+    const links = [
+      ...navigation.querySelectorAll<HTMLElement>('.document-toc-link'),
+    ];
+    const measure = () => {
+      if (!navigation.clientHeight) return;
+      const next = links.flatMap((link, index): TocIndicator[] => {
+        if (
+          !link.hasAttribute('aria-current') &&
+          !link.hasAttribute('data-active-ancestor')
+        )
+          return [];
+        const insetTop = index === 0 ? 0 : 4;
+        const insetBottom = index === links.length - 1 ? 0 : 4;
+        return [
+          {
+            depth: Number(link.style.getPropertyValue('--toc-depth')),
+            top: link.offsetTop + insetTop,
+            height: Math.max(0, link.offsetHeight - insetTop - insetBottom),
+            visible: true,
+          },
+        ];
+      });
+      const sameDocument = indicatorIds.current === ids;
+      indicatorIds.current = ids;
+      setIndicators((previous) => [
+        ...next,
+        ...(sameDocument
+          ? previous
+              .filter((bar) => !next.some((item) => item.depth === bar.depth))
+              .map((bar) => ({ ...bar, visible: false }))
+          : []),
+      ]);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(navigation);
+    links.forEach((link) => observer.observe(link));
+    return () => observer.disconnect();
+  }, [activeId, ancestorIds, ids, expanded]);
 
   useEffect(() => {
     setExpanded(false);
@@ -110,9 +189,43 @@ export function DocumentToc({
       itemHeight: activeRect.height,
       itemTop: navigation.scrollTop + activeRect.top - navigationRect.top,
     });
-    if (Math.abs(navigation.scrollTop - top) < 1) return;
+    const animation = scrollAnimation.current;
+    animation.target = top;
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    if (reducedMotion.matches) {
+      window.cancelAnimationFrame(animation.frame);
+      animation.frame = 0;
+      navigation.scrollTo({ behavior: 'instant', top });
+      return;
+    }
+    if (animation.frame || Math.abs(navigation.scrollTop - top) < 1) return;
 
-    navigation.scrollTo({ behavior: 'smooth', top });
+    animation.position = navigation.scrollTop;
+    animation.time = performance.now();
+    const tick = (time: number) => {
+      animation.frame = 0;
+      if (!navigation.clientHeight) return;
+      animation.target = Math.max(
+        0,
+        Math.min(
+          animation.target,
+          navigation.scrollHeight - navigation.clientHeight,
+        ),
+      );
+      animation.position = reducedMotion.matches
+        ? animation.target
+        : nextDocumentTocScrollTop(
+            animation.position,
+            animation.target,
+            time - animation.time,
+          );
+      animation.time = time;
+      navigation.scrollTo({ behavior: 'instant', top: animation.position });
+      if (animation.position !== animation.target) {
+        animation.frame = window.requestAnimationFrame(tick);
+      }
+    };
+    animation.frame = window.requestAnimationFrame(tick);
   }, [activeId, expanded]);
 
   if (items.length === 0) return null;
@@ -149,6 +262,8 @@ export function DocumentToc({
               aria-current={activeId === item.id ? 'location' : undefined}
               className="document-toc-link"
               data-depth={item.depth}
+              data-active-group={groupIds.has(item.id) || undefined}
+              data-active-ancestor={ancestorIds.has(item.id) || undefined}
               href={`#${encodeURIComponent(item.id)}`}
               key={item.id}
               onClick={(event) => {
@@ -192,6 +307,21 @@ export function DocumentToc({
             </a>
           );
         })}
+        {indicators.map((bar) => (
+          <span
+            aria-hidden="true"
+            className="document-toc-indicator"
+            key={bar.depth}
+            style={
+              {
+                '--toc-depth': bar.depth,
+                transform: `translateY(${bar.top}px)`,
+                height: bar.height,
+                opacity: bar.visible ? 1 : 0,
+              } as TocLinkStyle
+            }
+          />
+        ))}
       </nav>
     </aside>
   );

--- a/view/src/document-toc.ts
+++ b/view/src/document-toc.ts
@@ -1,3 +1,39 @@
+/** Keep the current section's entire subtree emphasized while its children scroll. */
+export function documentTocActiveGroup(
+  items: readonly { id: string; depth: number }[],
+  activeId: string,
+): { groupIds: Set<string>; ancestorIds: Set<string> } {
+  const activeIndex = items.findIndex((item) => item.id === activeId);
+  const groupIds = new Set<string>();
+  const ancestorIds = new Set<string>();
+  if (activeIndex === -1) return { groupIds, ancestorIds };
+
+  const trail: number[] = [];
+  for (let i = 0; i <= activeIndex; i++) {
+    while (
+      trail.length &&
+      items[trail[trail.length - 1]!]!.depth >= items[i]!.depth
+    )
+      trail.pop();
+    trail.push(i);
+  }
+  const sectionTrail = trail.filter((i) => items[i]!.depth > 1);
+  const start = sectionTrail[0] ?? activeIndex;
+  groupIds.add(items[start]!.id);
+  if (items[start]!.depth > 1) {
+    for (
+      let i = start + 1;
+      i < items.length && items[i]!.depth > items[start]!.depth;
+      i++
+    )
+      groupIds.add(items[i]!.id);
+  }
+  for (const i of sectionTrail) {
+    if (i !== activeIndex) ancestorIds.add(items[i]!.id);
+  }
+  return { groupIds, ancestorIds };
+}
+
 export function activeDocumentTocId(
   ids: readonly string[],
   tops: ReadonlyMap<string, number>,
@@ -41,6 +77,18 @@ export function documentTocActivationLine({
   // Near the end of the document, move the activation line down through the
   // viewport so every short final section can cross it before scrolling stops.
   return offset + Math.max(0, bottomTravel - remainingScroll);
+}
+
+/** Frame-rate-independent easing that can follow a changing destination. */
+export function nextDocumentTocScrollTop(
+  current: number,
+  target: number,
+  elapsedMs: number,
+): number {
+  if (Math.abs(target - current) < 0.5) return target;
+  return (
+    current + (target - current) * (1 - Math.exp(-Math.max(0, elapsedMs) / 90))
+  );
 }
 
 export function centeredDocumentTocScrollTop({

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -602,6 +602,7 @@ a {
 }
 
 .document-toc-list {
+  position: relative;
   display: block;
   max-height: calc(100% - 38px);
   margin-top: 14px;
@@ -660,29 +661,25 @@ a {
   background: currentColor;
 }
 
-.document-toc-link::before {
+.document-toc-indicator {
   position: absolute;
-  top: 4px;
-  bottom: 4px;
-  left: 0;
-  width: 2px;
-  content: '';
-  background: transparent;
-  border-radius: 2px;
-}
-
-.document-toc-link:first-child::before {
   top: 0;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
+  left: calc(var(--toc-depth) * 13px);
+  width: 2px;
+  pointer-events: none;
+  background: var(--link);
+  border-radius: 2px;
+  transition:
+    transform 200ms ease-out,
+    height 200ms ease-out,
+    opacity 140ms ease;
 }
 
-.document-toc-link:last-child::before {
-  bottom: 0;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
+.document-toc-link[data-active-group='true'] {
+  color: color-mix(in srgb, var(--muted) 65%, var(--text));
 }
 
+.document-toc-link[data-active-ancestor='true'],
 .document-toc-link:hover {
   color: var(--text);
 }
@@ -693,10 +690,6 @@ a {
 
 .document-toc-link[aria-current='location'] {
   color: var(--link);
-}
-
-.document-toc-link[aria-current='location']::before {
-  background: var(--link);
 }
 
 .document-metadata {
@@ -2905,6 +2898,7 @@ a.wiki-link-active {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .document-toc-indicator,
   .document-toc-link,
   .document-toc-chevron {
     transition: none;
@@ -3004,7 +2998,7 @@ a.wiki-link-active {
     box-shadow: none;
   }
 
-  .document-toc-link::before {
+  .document-toc-indicator {
     display: none;
   }
 }


### PR DESCRIPTION
## Summary

- Subtly emphasize the active section and its complete subtree while moving between subsections.
- Keep separate, indented indicators for the active heading and its section ancestors.
- Glide persistent indicators between headings over 200ms, resize for wrapped titles, and track layout changes.
- Keep dropdowns bar-free and disable indicator transitions and smooth TOC scrolling for reduced-motion preferences.
- Update the TOC behavior documentation and regression coverage.

## Validation

- pnpm buildall
- pnpm test — 325 tests passed on the full rerun
- node dist/src/cli/index.js check
- Browser checks verified independent parent/subsection bars, intermediate animation positions, bar-free dropdowns, and zero-duration transitions with reduced motion.

The initial full run hit an intermittent semantic-search startup assertion; its isolated rerun and the subsequent full suite both passed without changes.