### PR TITLE
Refine graph with Tufte-inspired visual hierarchy

### DIFF
--- a/lat.md/view/graph.md
+++ b/lat.md/view/graph.md
@@ -17,7 +17,7 @@ Lat bundles `sigma` and `graphology` from development dependencies and loads the
 Graph mode replaces the document layout with a full-viewport graph workspace while preserving the selected document or source URL.
 
 - The graph uses the full left half; its logo, active Graph toggle, semantic filter, and node count float over the canvas instead of reserving a panel header. Git and page Search controls stay hidden in this mode. The right half begins directly with the node preview and has no inspector title bar.
-- The sidebar background covers the viewport, split equally between the graph and an independently scrollable inspector.
+- The graph draws across the desktop viewport behind the independently scrollable right-half inspector. Its translucent background softly blurs and desaturates the graph underneath without changing the sharpness or color of the content itself.
 - Enabling Graph on a document or represented source selects that node immediately. A section URL selects its owning document; with no represented node, the inspector explains how to choose one.
 - The browser URL always remains the exact document, section, source, or code-line target. Node and inspector navigation use ordinary history entries, so reload, copied URLs, Back, and Forward retain their normal meaning while Graph stays active.
 - The graph icon only toggles a namespaced `localStorage` presentation setting; it does not rewrite history. Disabling Graph reveals the same selected target in the file/source layout immediately, and the persisted setting restores Graph after reload.
@@ -45,7 +45,7 @@ Documents form the graph backbone, while code nodes appear when source definitio
 - `source:<project-path>#<symbol>` represents a source definition targeted by a wiki link. A file-only source target omits the symbol.
 - `code-ref:<project-path>:<line>` represents the cached code snippet containing an `@lat:` mention and links to its target document.
 
-Each node includes `id`, `kind`, `label`, canonical `url`, breadcrumbs, reference counts, and optional Git state, error count, source signature, or snippet. Node radius grows logarithmically with incoming references, so backlinks—not outgoing links—determine prominence.
+Each node includes `id`, `kind`, `label`, canonical `url`, breadcrumbs, reference counts, and optional Git state, error count, source signature, or snippet. Circle area grows linearly with incoming references above a minimum visible area, so backlinks—not outgoing links—determine prominence. Selection never inflates that quantitative size.
 
 A local document's incoming count sums the displayed direct backlink counts for its root and every nested section. Repeated links from one paragraph to the same section count once; links to different sections count separately. Same-document references and code mentions contribute too. Other nodes use incoming edge occurrence weights.
 
@@ -75,7 +75,9 @@ The graph canvas and inspector share route state but keep rendering responsibili
 
 The client caches the on-demand graph projection. A deterministic linear-time layout places documents on a ring and clusters code around its strongest document neighbor, without physics or animation.
 
-Sigma reducers dim unrelated nodes and edges on hover, emphasize immediate neighbors, render documents in Vercel blue and code in warm orange, and keep the selected node labeled. Every visible label uses white text and shadow on an 80%-opaque black plate; highly referenced nodes receive default labels.
+The graph uses restrained layers: neutral nodes and fine connections provide context, while selection and hover reveal document-blue and code-orange neighbors and directional arrows. Background edges stay visible during pan and zoom. Labels use theme-aware text with a narrow background halo rather than opaque cards; collision handling keeps ordinary labels from overlapping.
+
+Selected and hovered labels include exact incoming reference counts. A canvas note explains whether size represents reference area or semantic relevance. This follows [Tufte's layering and smallest effective difference principles](https://www.edwardtufte.com/notebook/analytical-design-and-human-factors/) without removing the underlying relationships.
 
 Outlined, translucent nodes remain distinguishable when overlapping. The circle shader premultiplies alpha for Sigma's blending mode but keeps picking IDs opaque. Edges and muted nodes use renderer-safe hex colors rather than CSS border tokens.
 
@@ -88,6 +90,8 @@ A node click navigates to its canonical document or source URL and renders the r
 Plain internal links inside the inspector keep Graph active and navigate to their normal exact routes. Same-document fragments resolve against the preview and scroll without refetching the document; modified clicks retain normal browser behavior.
 
 The graph pane remains fixed while the inspector scrolls from the top edge. The preview keeps current Git rendering, validation markers, backlinks, source context, and code expansion without wrapping them in another title toolbar.
+
+The left half remains the interaction and Fit area even though the canvas extends behind the inspector. Camera framing preserves its left-side center and relative zoom across resizing and mode changes. The inspector intercepts pointer input; narrow screens retain separate, opaque stacked panes.
 
 ## Initial scope
 

--- a/lat.md/view/specs.md
+++ b/lat.md/view/specs.md
@@ -209,13 +209,15 @@ Graph mode consumes a cached projection of documents, source targets, and code m
 
 The client renders a 50/50 graph and inspector. The logo and Graph toggle retain their normal desktop positions while floating over the graph with the semantic filter; Git and page Search are hidden. The right panel begins with the node preview and has no toolbar.
 
+On desktop the canvas extends behind the translucent inspector, whose backdrop filter blurs and desaturates only the underlying graph. Camera framing and Fit retain the left-half interaction area, and resizing preserves relative zoom and its center. The inspector keeps its own scrolling and pointer input; mobile panes stay stacked and opaque.
+
 Switching between graph and regular view preserves the logo and toolbar's vertical position at every breakpoint.
 
 The graph button persists a namespaced `localStorage` presentation setting without changing the current URL or browser history. Toggling it off immediately reveals the exact selected target in the normal file/source layout, and reload restores the stored mode.
 
 Plain document, section, source, and code-reference links navigate through their normal URLs without leaving Graph, so Back and Forward work without mode-specific history. Relative fragments resolve against the previewed document without refetching its content.
 
-Document and code radii grow only with incoming references. Every rendered label stays white over an 80%-opaque black plate with a text shadow in normal, selected, and hover states.
+Document and code areas grow linearly with incoming references above a visible baseline, without size inflation on selection. Focus labels report exact counts; theme-aware text halos replace opaque label plates. Background edges are fine lines, with arrows reserved for focused relationships.
 
 Local document counts sum direct backlinks to all headings, including nested sections and same-document links, with heading-badge paragraph deduplication. Visible edges retain occurrence weights and omit self-loops.
 

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -150,6 +150,11 @@ import {
   viewPathname,
 } from '../view/src/static-mode.js';
 import viewViteConfig from '../view/vite.config.js';
+import { matrixFromCamera, multiplyVec2 } from 'sigma/utils';
+import {
+  graphFitCamera,
+  graphViewportCamera,
+} from '../view/src/graph-camera.js';
 import {
   deterministicGraphPosition,
   graphDisplayLabel,
@@ -1246,6 +1251,38 @@ describe('lat ui', () => {
 
   // @lat: [[lat.md/view/specs#View Tests#Renders the graph workspace]]
   it('serves the cached graph projection and graph shell', async () => {
+    const desktop = { width: 1600, height: 1000, activeWidth: 800 };
+    const mobile = { width: 390, height: 520, activeWidth: 390 };
+    for (const dimensions of [
+      { width: 1, height: 1 },
+      { width: 3, height: 1 },
+      { width: 1, height: 3 },
+    ]) {
+      const fit = graphFitCamera(desktop, dimensions);
+      const projected = multiplyVec2(
+        matrixFromCamera(fit, desktop, dimensions, 40),
+        { x: 0.5, y: 0.5 },
+      );
+      expect(((projected.x + 1) * desktop.width) / 2).toBeCloseTo(400, 3);
+      expect(((1 - projected.y) * desktop.height) / 2).toBeCloseTo(500, 3);
+      const state = { x: 0.6, y: 0.3, ratio: 0.4, angle: 0.2 };
+      const resized = graphViewportCamera(state, mobile, desktop, dimensions);
+      const restored = graphViewportCamera(
+        resized,
+        desktop,
+        mobile,
+        dimensions,
+      );
+      for (const key of ['x', 'y', 'ratio', 'angle'] as const) {
+        expect(restored[key]).toBeCloseTo(state[key]);
+      }
+      expect(graphFitCamera(mobile, dimensions)).toEqual({
+        x: 0.5,
+        y: 0.5,
+        angle: 0,
+        ratio: 1,
+      });
+    }
     const graphClient = readFileSync(
       join(import.meta.dirname, '..', 'view', 'src', 'GraphView.tsx'),
       'utf8',
@@ -1254,6 +1291,13 @@ describe('lat ui', () => {
       join(import.meta.dirname, '..', 'view', 'src', 'styles.css'),
       'utf8',
     );
+    expect(graphStyles).toMatch(
+      /\.graph-canvas \{\s*right: auto;\s*width: 200%;/,
+    );
+    expect(graphStyles).toContain('backdrop-filter: blur(2px) grayscale(1)');
+    expect(graphStyles).toContain('var(--panel) 60%, transparent');
+    expect(graphClient).toContain("sigma.on('resize'");
+    expect(graphClient).toContain("sigma.setSetting('zoomToSizeRatioFunction'");
     for (const token of [
       '--graph-edge',
       '--graph-edge-muted',
@@ -1273,6 +1317,12 @@ describe('lat ui', () => {
     expect(graphClient).toContain('color: mutedEdgeColor');
     expect(graphClient).toContain('color: activeEdgeColor');
     expect(graphClient).toContain('color: mutedNodeColor');
+    expect(graphClient).toContain('hideEdgesOnMove: false');
+    expect(graphClient).toContain("type: 'line'");
+    expect(graphClient).toContain("type: 'arrow'");
+    expect(graphClient).toContain('context.strokeText(data.label');
+    expect(graphClient).not.toContain('renderedData.size +');
+    expect(graphClient).toContain('Area: incoming refs · includes subsections');
     expect(graphClient).not.toContain("sigma.on('downNode'");
     expect(graphClient).not.toContain('graph.mergeNodeAttributes');
     expect(graphClient).toContain("sigma.on('clickNode'");
@@ -1506,10 +1556,16 @@ describe('lat ui', () => {
       validGraphPosition(deterministicGraphPosition('code-ref:src/app.ts:5')),
     ).toBe(true);
     expect(validGraphPosition({ x: Number.NaN, y: 1 })).toBe(false);
-    expect(graphNodeSize(0)).toBe(5);
-    expect(graphNodeSize(1)).toBe(8);
-    expect(graphNodeSize(7)).toBe(14);
-    expect(graphNodeSize(-1)).toBe(5);
+    expect(graphNodeSize(0)).toBeCloseTo(3.6);
+    expect(graphNodeSize(1)).toBeCloseTo(1.2 * Math.sqrt(12.75));
+    expect(graphNodeSize(7)).toBeCloseTo(1.2 * Math.sqrt(35.25));
+    expect(graphNodeSize(-1)).toBeCloseTo(3.6);
+    expect(graphNodeSize(Infinity)).toBeCloseTo(3.6);
+    expect(graphNodeSize(Number.NaN)).toBeCloseTo(3.6);
+    // Equal reference increments produce equal area increments, not radius.
+    expect(graphNodeSize(20) ** 2 - graphNodeSize(10) ** 2).toBeCloseTo(
+      graphNodeSize(10) ** 2 - graphNodeSize(0) ** 2,
+    );
     const positions = staticGraphPositions(graph);
     expect(positions.size).toBe(graph.nodes.length);
     expect([...positions.values()].every(validGraphPosition)).toBe(true);
@@ -1538,11 +1594,13 @@ describe('lat ui', () => {
       ),
     ).toEqual(
       new Map([
-        ['weak', 5],
-        ['strong', 14],
+        ['weak', 6],
+        ['strong', 16.8],
       ]),
     );
-    expect(graphSearchNodeSizes(new Map([['only', 0.5]])).get('only')).toBe(14);
+    expect(graphSearchNodeSizes(new Map([['only', 0.5]])).get('only')).toBe(
+      16.8,
+    );
 
     const styles = readFileSync(
       join(import.meta.dirname, '..', 'view', 'src', 'styles.css'),

--- a/view/src/GraphView.tsx
+++ b/view/src/GraphView.tsx
@@ -10,11 +10,17 @@ import {
 } from 'react';
 import Sigma from 'sigma';
 import {
+  graphFitCamera,
+  graphViewportCamera,
+  type GraphViewport,
+} from './graph-camera';
+import {
   GraphNodeProgram,
   GraphSelectedNodeProgram,
 } from './graph-node-program';
 import {
   createEdgeArrowProgram,
+  EdgeLineProgram,
   type NodeLabelDrawingFunction,
 } from 'sigma/rendering';
 import type {
@@ -56,6 +62,8 @@ type GraphNodeAttributes = {
   color: string;
   label: string;
   backlinks: number;
+  category: GraphCategory;
+  labelColor?: string;
 };
 
 type GraphEdgeAttributes = {
@@ -70,6 +78,7 @@ type GraphCategory = 'document' | 'code';
 const positionCache = new Map<string, { x: number; y: number }>();
 let cameraCache: { x: number; y: number; angle: number; ratio: number } | null =
   null;
+let cameraViewportCache: GraphViewport | null = null;
 let cachedViewGraph: ViewGraph | null = null;
 let viewGraphRequest: Promise<ViewGraph> | null = null;
 let viewGraphInstanceId = '';
@@ -95,54 +104,16 @@ const drawGraphNodeLabel: NodeLabelDrawingFunction<
   const fontSize = settings.labelSize;
   const labelX = data.x + data.size + 4;
   const baselineY = data.y + fontSize / 3;
-  const horizontalPadding = 5;
-  const verticalPadding = 3;
-
   context.save();
   context.font = `${settings.labelWeight} ${fontSize}px ${settings.labelFont}`;
-  const metrics = context.measureText(data.label);
-  const ascent = metrics.actualBoundingBoxAscent || fontSize * 0.8;
-  const descent = metrics.actualBoundingBoxDescent || fontSize * 0.2;
-  const plateX = labelX - horizontalPadding;
-  const plateY = baselineY - ascent - verticalPadding;
-  const plateWidth = metrics.width + horizontalPadding * 2;
-  const plateHeight = ascent + descent + verticalPadding * 2;
-  const radius = 3;
-
-  context.fillStyle = 'rgba(0, 0, 0, 0.8)';
-  context.beginPath();
-  context.moveTo(plateX + radius, plateY);
-  context.lineTo(plateX + plateWidth - radius, plateY);
-  context.quadraticCurveTo(
-    plateX + plateWidth,
-    plateY,
-    plateX + plateWidth,
-    plateY + radius,
-  );
-  context.lineTo(plateX + plateWidth, plateY + plateHeight - radius);
-  context.quadraticCurveTo(
-    plateX + plateWidth,
-    plateY + plateHeight,
-    plateX + plateWidth - radius,
-    plateY + plateHeight,
-  );
-  context.lineTo(plateX + radius, plateY + plateHeight);
-  context.quadraticCurveTo(
-    plateX,
-    plateY + plateHeight,
-    plateX,
-    plateY + plateHeight - radius,
-  );
-  context.lineTo(plateX, plateY + radius);
-  context.quadraticCurveTo(plateX, plateY, plateX + radius, plateY);
-  context.closePath();
-  context.fill();
-
-  context.fillStyle = '#fff';
-  context.shadowColor = 'rgba(0, 0, 0, 0.95)';
-  context.shadowBlur = 5;
-  context.shadowOffsetX = 0;
-  context.shadowOffsetY = 1;
+  // A narrow, theme-aware halo separates text from edges without label cards.
+  const styles = getComputedStyle(document.documentElement);
+  context.strokeStyle = colorValue(styles, '--sidebar', '#000');
+  context.lineWidth = 3;
+  context.lineJoin = 'round';
+  context.strokeText(data.label, labelX, baselineY);
+  context.fillStyle =
+    data.labelColor || colorValue(styles, '--text', '#ededed');
   context.fillText(data.label, labelX, baselineY);
   context.restore();
 };
@@ -169,6 +140,7 @@ function GraphCanvas({
   const searchSizes = useRef(searchNodeSizes);
   const visible = useRef(visibleNodes);
   const onSelectRef = useRef(onSelect);
+  const fitCamera = useRef<() => void>(() => {});
 
   useLayoutEffect(() => {
     selected.current = selectedNodeId;
@@ -198,6 +170,13 @@ function GraphCanvas({
       code: colorValue(styles, '--graph-code', '#737373'),
     };
     const mutedNodeColor = colorValue(styles, '--graph-node-muted', '#404040');
+    const documentColor = colorValue(
+      styles,
+      '--graph-document-rest',
+      '#999999',
+    );
+    const codeColor = colorValue(styles, '--graph-code-rest', '#737373');
+    const mutedLabelColor = colorValue(styles, '--muted', '#a1a1a1');
     const activeEdgeColor = colorValue(
       styles,
       '--graph-edge-active',
@@ -221,6 +200,7 @@ function GraphCanvas({
         ...position,
         label: graphDisplayLabel(node),
         backlinks,
+        category: nodeCategory(node.kind),
         size: graphNodeSize(backlinks),
         color: colors[nodeCategory(node.kind)],
       });
@@ -229,8 +209,8 @@ function GraphCanvas({
       if (!graph.hasNode(edge.from) || !graph.hasNode(edge.to)) continue;
       graph.addDirectedEdgeWithKey(edge.id, edge.from, edge.to, {
         color: edgeColor,
-        size: 0.6 + Math.log2(edge.weight + 1) * 0.45,
-        type: 'arrow',
+        size: 0.4 + Math.log2(edge.weight + 1) * 0.15,
+        type: 'line',
         weight: edge.weight,
       });
     }
@@ -261,18 +241,19 @@ function GraphCanvas({
         defaultDrawNodeHover: drawGraphNodeLabel,
         defaultDrawNodeLabel: drawGraphNodeLabel,
         edgeProgramClasses: {
+          line: EdgeLineProgram<GraphNodeAttributes, GraphEdgeAttributes>,
           arrow: createEdgeArrowProgram<
             GraphNodeAttributes,
             GraphEdgeAttributes
           >(),
         },
-        hideEdgesOnMove: true,
+        hideEdgesOnMove: false,
         labelColor: { color: '#fff' },
-        labelDensity: 0.12,
+        labelDensity: 0.3,
         labelFont: getComputedStyle(document.documentElement).fontFamily,
-        labelRenderedSizeThreshold: 6,
-        labelSize: 11,
-        labelWeight: '600',
+        labelRenderedSizeThreshold: 3,
+        labelSize: 12,
+        labelWeight: '400',
         minCameraRatio: 0.08,
         maxCameraRatio: 8,
         renderEdgeLabels: false,
@@ -291,7 +272,7 @@ function GraphCanvas({
               type: isSelected ? 'selected' : 'circle',
               forceLabel: true,
               highlighted: true,
-              size: renderedData.size + 2.5,
+              label: `${data.label} · ${data.backlinks} ${data.backlinks === 1 ? 'ref' : 'refs'}`,
               zIndex: isSelected ? 4 : 3,
             };
           }
@@ -299,13 +280,20 @@ function GraphCanvas({
             return {
               ...renderedData,
               color: mutedNodeColor,
-              label: null,
+              label: data.category === 'document' ? data.label : null,
+              labelColor: mutedLabelColor,
               zIndex: 0,
             };
           }
           return {
             ...renderedData,
-            forceLabel: data.backlinks >= 4,
+            color: focus
+              ? data.color
+              : data.color === colors.document
+                ? documentColor
+                : codeColor,
+            // Let Sigma resolve collisions; only the focus forces a label.
+            forceLabel: false,
             zIndex: data.backlinks >= 4 ? 2 : 1,
           };
         },
@@ -319,21 +307,65 @@ function GraphCanvas({
             return {
               ...data,
               color: mutedEdgeColor,
-              size: 0.6,
+              size: 0.4,
             };
           }
           return focus
             ? {
                 ...data,
                 color: activeEdgeColor,
-                size: data.size + 0.4,
+                type: 'arrow',
+                size: data.size + 0.2,
               }
             : data;
         },
       },
     );
     renderer.current = sigma;
-    if (cameraCache) sigma.getCamera().setState(cameraCache);
+    const viewport = (): GraphViewport => ({
+      ...sigma.getDimensions(),
+      activeWidth: target.parentElement?.clientWidth ?? target.clientWidth,
+    });
+    let previousViewport = viewport();
+    sigma.setSetting('zoomToSizeRatioFunction', (ratio) =>
+      Math.sqrt(
+        ratio / graphFitCamera(viewport(), sigma.getGraphDimensions()).ratio,
+      ),
+    );
+    sigma
+      .getCamera()
+      .setState(
+        cameraCache && cameraViewportCache
+          ? graphViewportCamera(
+              cameraCache,
+              cameraViewportCache,
+              previousViewport,
+              sigma.getGraphDimensions(),
+            )
+          : graphFitCamera(previousViewport, sigma.getGraphDimensions()),
+      );
+    sigma.on('resize', () => {
+      const nextViewport = viewport();
+      sigma
+        .getCamera()
+        .setState(
+          graphViewportCamera(
+            sigma.getCamera().getState(),
+            previousViewport,
+            nextViewport,
+            sigma.getGraphDimensions(),
+          ),
+        );
+      previousViewport = nextViewport;
+    });
+    fitCamera.current = () => {
+      const state = graphFitCamera(viewport(), sigma.getGraphDimensions());
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        sigma.getCamera().setState(state);
+      } else {
+        void sigma.getCamera().animate(state);
+      }
+    };
 
     sigma.on('enterNode', ({ node }) => {
       hoveredNode = node;
@@ -348,6 +380,8 @@ function GraphCanvas({
     return () => {
       savePositions();
       cameraCache = sigma.getCamera().getState();
+      cameraViewportCache = previousViewport;
+      fitCamera.current = () => {};
       sigma.kill();
       renderer.current = null;
     };
@@ -362,7 +396,7 @@ function GraphCanvas({
       />
       <button
         className="graph-fit"
-        onClick={() => void renderer.current?.getCamera().animatedReset()}
+        onClick={() => fitCamera.current()}
         title="Fit graph"
         type="button"
       >
@@ -833,6 +867,11 @@ export default function GraphView({
                   <span>{category}</span>
                 </label>
               ))}
+            </div>
+            <div className="graph-encoding-note">
+              {searchNodeSizes
+                ? 'Size: relevance'
+                : 'Area: incoming refs · includes subsections'}
             </div>
             {searchError ? (
               <div className="graph-no-results">{searchError}</div>

--- a/view/src/graph-camera.ts
+++ b/view/src/graph-camera.ts
@@ -1,0 +1,51 @@
+import { getCorrectionRatio } from 'sigma/utils';
+
+export type GraphViewport = {
+  width: number;
+  height: number;
+  activeWidth: number;
+};
+
+type CameraState = { x: number; y: number; angle: number; ratio: number };
+
+/** Preserve the view in the interaction pane when the drawing surface changes. */
+export function graphViewportCamera(
+  state: CameraState,
+  from: GraphViewport,
+  to: GraphViewport,
+  graphDimensions: { width: number; height: number },
+): CameraState {
+  const scale = (width: number, height: number) =>
+    Math.max(1, Math.min(width, height) - 80) *
+    getCorrectionRatio({ width, height }, graphDimensions);
+  const framing = (viewport: GraphViewport) => {
+    const fullScale = scale(viewport.width, viewport.height);
+    const activeScale = scale(viewport.activeWidth, viewport.height);
+    return {
+      ratio: fullScale / activeScale,
+      offset: (viewport.width - viewport.activeWidth) / (2 * activeScale),
+    };
+  };
+  const before = framing(from);
+  const after = framing(to);
+  const zoom = state.ratio / before.ratio;
+  const offset = (after.offset - before.offset) * zoom;
+  return {
+    ...state,
+    x: state.x + offset * Math.cos(state.angle),
+    y: state.y + offset * Math.sin(state.angle),
+    ratio: after.ratio * zoom,
+  };
+}
+
+export function graphFitCamera(
+  viewport: GraphViewport,
+  graphDimensions: { width: number; height: number },
+): CameraState {
+  return graphViewportCamera(
+    { x: 0.5, y: 0.5, angle: 0, ratio: 1 },
+    { ...viewport, width: viewport.activeWidth },
+    viewport,
+    graphDimensions,
+  );
+}

--- a/view/src/graph-layout.ts
+++ b/view/src/graph-layout.ts
@@ -25,7 +25,8 @@ export function graphDisplayLabel(
 
 export function graphNodeSize(backlinks: number): number {
   const count = Number.isFinite(backlinks) ? Math.max(0, backlinks) : 0;
-  return 5 + Math.log2(count + 1) * 3;
+  // Circle area, rather than radius, encodes references above a visible baseline.
+  return 1.2 * Math.sqrt(9 + count * 3.75);
 }
 
 function polarPosition(angle: number, radius: number): GraphPosition {
@@ -160,8 +161,8 @@ export function graphSearchNodeSizes(
   if (values.length === 0) return new Map();
   const minimum = Math.min(...values);
   const maximum = Math.max(...values);
-  const sizeMinimum = 5;
-  const sizeMaximum = 14;
+  const sizeMinimum = 6;
+  const sizeMaximum = 16.8;
   const spread = maximum - minimum;
 
   return new Map(

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -59,9 +59,11 @@
   --graph-document: #0070f3;
   --graph-code: #d97706;
   /* Sigma needs renderer-safe colors, independent of translucent CSS borders. */
-  --graph-edge: #b8b8b8;
-  --graph-edge-muted: #d4d4d4;
-  --graph-edge-active: #999999;
+  --graph-document-rest: #666666;
+  --graph-code-rest: #999999;
+  --graph-edge: #cccccc;
+  --graph-edge-muted: #dddddd;
+  --graph-edge-active: #888888;
   --graph-node-muted: #c4c4c4;
   --map-control-filter: none;
   --brand-filter: brightness(0);
@@ -101,9 +103,11 @@
     --git-notification: #f0a044;
     --graph-document: rgb(82, 168, 255);
     --graph-code: #f5a623;
-    --graph-edge: #505050;
-    --graph-edge-muted: #383838;
-    --graph-edge-active: #686868;
+    --graph-document-rest: #999999;
+    --graph-code-rest: #737373;
+    --graph-edge: #383838;
+    --graph-edge-muted: #242424;
+    --graph-edge-active: #626262;
     --graph-node-muted: #404040;
     --map-control-filter: invert(1);
     --brand-filter: none;
@@ -2660,8 +2664,7 @@ a.wiki-link-active {
 }
 
 .graph-pane {
-  overflow: hidden;
-  border-right: 1px solid var(--panel-border);
+  overflow: visible;
 }
 
 .graph-canvas-shell,
@@ -2841,6 +2844,17 @@ a.wiki-link-active {
   opacity: 0.42;
 }
 
+.graph-encoding-note {
+  position: absolute;
+  bottom: 58px;
+  left: 18px;
+  right: 18px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 16px;
+  pointer-events: none;
+}
+
 .graph-no-results {
   position: absolute;
   z-index: 3;
@@ -2855,6 +2869,20 @@ a.wiki-link-active {
 
 .graph-inspector {
   background: var(--panel);
+}
+
+@media (min-width: 64rem) {
+  .graph-canvas {
+    right: auto;
+    width: 200%;
+  }
+
+  .graph-inspector {
+    z-index: 1;
+    background: color-mix(in srgb, var(--panel) 60%, transparent);
+    -webkit-backdrop-filter: blur(2px) grayscale(1);
+    backdrop-filter: blur(2px) grayscale(1);
+  }
 }
 
 .graph-inspector-scroll {
@@ -3340,6 +3368,7 @@ a.wiki-link-active {
     height: min(58vh, 520px);
     height: min(58svh, 520px);
     min-height: 320px;
+    overflow: hidden;
     border-right: 0;
     border-bottom: 1px solid var(--panel-border);
   }


### PR DESCRIPTION
## Summary

- Use fine background connections and neutral context nodes, reserving color and directional arrows for focused relationships.
- Replace opaque label cards with theme-aware text halos; retain muted document labels and show exact reference counts on selected or hovered nodes.
- Size node area linearly by incoming references above a visible baseline, without selection-based size inflation. Include the final larger-circle and stronger backlink-growth tuning.
- Extend the desktop canvas across the viewport behind the inspector while preserving left-half framing, Fit, circle sizes, and relative zoom across resizing.
- Give the inspector a 60%-opaque background with 2px backdrop blur and grayscale; content stays sharp and colored, with independent scrolling and pointer input. Mobile retains opaque stacked panes.
- Explain reference versus search-relevance sizing and keep connections visible during pan and zoom.
- Update graph design documentation and regression coverage, including camera projection and resize tests.

## Validation

- pnpm buildall
- pnpm test — 330 tests passed
- node dist/src/cli/index.js check
- Browser inspection in dark and light themes and at mobile width; verified full-width canvas, left-half Fit, zoom underneath the inspector, independent content scrolling, and mobile fallback during implementation.