### PR TITLE
Make TOC section indicators 1px wide

### DIFF
--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -2044,7 +2044,7 @@ describe('lat ui', () => {
       /\.document-toc-link \{[^}]*box-shadow: inset 1px 0 var\(--panel-border\);/,
     );
     expect(styles).toMatch(
-      /\.document-toc-indicator \{[^}]*left: calc\(var\(--toc-depth\) \* 13px\);/,
+      /\.document-toc-indicator \{[^}]*left: calc\(var\(--toc-depth\) \* 13px\);\s*width: 1px;/,
     );
     expect(styles).toMatch(
       /\.document-toc-indicator \{[^}]*transition:[^}]*transform 200ms ease-out/,

--- a/view/src/styles.css
+++ b/view/src/styles.css
@@ -669,7 +669,7 @@ a {
   position: absolute;
   top: 0;
   left: calc(var(--toc-depth) * 13px);
-  width: 2px;
+  width: 1px;
   pointer-events: none;
   background: var(--link);
   border-radius: 2px;


### PR DESCRIPTION
## Summary

- Reduce the blue TOC indicator bars from 2px to 1px, preserving positioning and animation.
- Assert the thinner width in the existing TOC regression test.

## Validation

- pnpm buildall
- pnpm test — 330 tests passed
- node dist/src/cli/index.js check

This is a cosmetic adjustment; existing design documentation remains accurate.