### PR TITLE
Fix Mermaid rendering for multiline HTML labels

### DIFF
--- a/lat.md/markdown.md
+++ b/lat.md/markdown.md
@@ -50,6 +50,8 @@ GitHub-style inline dollar delimiters, display dollar blocks, and `math` fences 
 
 GitHub-style `mermaid` fences render as React-owned SVG trees in the browser through Mermaid's strict security mode, with the escaped source retained as a readable fallback when loading or rendering fails.
 
+The viewer parses Mermaid's SVG as inert HTML so multiline HTML labels retain their line breaks, then filters elements and properties before creating React nodes. [[tests/markdown-rich-fence.test.ts]] exercises rendering multiline labels.
+
 ## GeoJSON and TopoJSON Maps
 
 GitHub-style `geojson` and `topojson` fences render supplied geometry over an OpenStreetMap basemap from OpenFreeMap, with pan, zoom, and automatic data bounds.

--- a/tests/markdown-rich-fence.test.ts
+++ b/tests/markdown-rich-fence.test.ts
@@ -1,9 +1,64 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { parseMermaidSvg } from '../view/src/MarkdownRichFence.js';
+import { getMermaid } from '../view/src/markdown-rich-fences.js';
 
 describe('Markdown rich fences', () => {
+  it('preserves HTML line breaks in Mermaid SVG labels', () => {
+    const tree = parseMermaidSvg(`
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <foreignObject><div xmlns="http://www.w3.org/1999/xhtml">
+          <span>First<br>Second&nbsp;line</span>
+        </div></foreignObject>
+      </svg>
+    `);
+
+    expect(JSON.stringify(tree)).toContain('"tagName":"br"');
+    expect(JSON.stringify(tree)).toContain('Second\u00a0line');
+  });
+
+  it('rejects output without a single SVG root', () => {
+    for (const source of [
+      'error',
+      '<div>error</div>',
+      '<svg></svg><div></div>',
+    ]) {
+      expect(() => parseMermaidSvg(source)).toThrow(
+        'Mermaid did not return an SVG document',
+      );
+    }
+  });
+
+  it('renders multiline Mermaid labels into safe SVG trees', async () => {
+    // jsdom has no SVG layout; only geometry is stubbed, not Mermaid rendering.
+    const original = Object.getOwnPropertyDescriptor(
+      SVGElement.prototype,
+      'getBBox',
+    );
+    Object.defineProperty(SVGElement.prototype, 'getBBox', {
+      configurable: true,
+      value: vi.fn(() => ({ x: 0, y: 0, width: 100, height: 20 })),
+    });
+    try {
+      const mermaid = await getMermaid();
+      const diagrams = [
+        'flowchart TB\n query["Search query"] --> results["Ranked sections<br/>with source spans"]',
+        'flowchart LR\n cache{"Cached?"} -->|Yes| reuse["Reuse vector<br/>Skip embedding"]',
+      ];
+      for (const [index, source] of diagrams.entries()) {
+        const { svg } = await mermaid.render(`multiline-test-${index}`, source);
+        const tree = parseMermaidSvg(svg);
+        expect(tree).toMatchObject({ type: 'element', tagName: 'svg' });
+        expect(JSON.stringify(tree)).toContain('"tagName":"br"');
+      }
+    } finally {
+      if (original)
+        Object.defineProperty(SVGElement.prototype, 'getBBox', original);
+      else Reflect.deleteProperty(SVGElement.prototype, 'getBBox');
+    }
+  });
+
   it('reflects Mermaid SVG without executable nodes or properties', () => {
     const tree = parseMermaidSvg(`
       <svg xmlns="http://www.w3.org/2000/svg" onclick="alert(1)">

--- a/view/src/MarkdownRichFence.tsx
+++ b/view/src/MarkdownRichFence.tsx
@@ -45,6 +45,7 @@ type SvgNode =
 
 const SVG_ELEMENTS = new Set([
   'a',
+  'br',
   'circle',
   'clipPath',
   'defs',
@@ -152,10 +153,19 @@ function svgNode(node: Node): SvgNode | null {
 }
 
 export function parseMermaidSvg(source: string): SvgNode {
-  const parsed = new DOMParser().parseFromString(source, 'image/svg+xml');
-  const error = parsed.querySelector('parsererror');
-  if (error) throw new Error('Mermaid returned invalid SVG');
-  const root = svgNode(parsed.documentElement);
+  // Mermaid serializes HTML labels inside foreignObject with HTML void tags
+  // such as <br>. Parse as inert HTML, then apply our element/property filter.
+  const parsed = new DOMParser().parseFromString(source, 'text/html');
+  const element = parsed.body.firstElementChild;
+  if (
+    !element ||
+    element.localName !== 'svg' ||
+    element.namespaceURI !== 'http://www.w3.org/2000/svg' ||
+    parsed.body.children.length !== 1
+  ) {
+    throw new Error('Mermaid did not return an SVG document');
+  }
+  const root = svgNode(element);
   if (!root || root.type !== 'element' || root.tagName !== 'svg') {
     throw new Error('Mermaid did not return an SVG document');
   }
@@ -167,7 +177,7 @@ function renderSvgNode(node: SvgNode, key: string): ReactNode {
   return createElement(
     node.tagName,
     { ...node.properties, key },
-    node.children.map((child, index) =>
+    ...node.children.map((child, index) =>
       renderSvgNode(child, `${key}.${index}`),
     ),
   );


### PR DESCRIPTION
Mermaid flowcharts with `<br/>` in labels failed with “Mermaid returned invalid SVG”: Mermaid serializes those labels as HTML, which the viewer tried to parse as strict XML.

Parse the output as inert HTML, require an SVG root, and retain the existing element/property filtering before creating React nodes. Preserve line breaks and avoid supplying children to void elements.

Validation: four regression tests pass, including real Mermaid rendering of multiline labels; viewer typecheck, production UI build, and `lat check` pass.

Independent of the RAG PR stack; targets `main` and can merge first.
